### PR TITLE
use prerelease version of argparse-cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ src/pkgdb.o: $(SQL_HH_FILES)
 
 ignores: tests/.gitignore
 tests/.gitignore: FORCE
-	printf '%s\n' $(patsubst tests/%,%,$(TESTS)) > $@
+	printf '%s\n' $(patsubst tests/%,%,$(test_SRCS:.cc=)) > $@
 
 
 # ---------------------------------------------------------------------------- #

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@
 { nixpkgs         ? builtins.getFlake "nixpkgs"
 , floco           ? builtins.getFlake "github:aakropotkin/floco"
 , sqlite3pp-flake ? builtins.getFlake "github:aakropotkin/sqlite3pp"
+, argparse-flake  ? builtins.getFlake "github:aakropotkin/argparse"
 , sql-builder-src ? builtins.fetchTree {
                     type = "github"; owner = "six-ddc"; repo = "sql-builder";
                   }
@@ -18,7 +19,7 @@
 , nlohmann_json ? pkgsFor.nlohmann_json
 , nix           ? pkgsFor.nix
 , boost         ? pkgsFor.boost
-, argparse      ? pkgsFor.argparse
+, argparse      ? argparse-flake.packages.${system}.argparse
 , semver        ? floco.packages.${system}.semver
 , sqlite3pp     ? sqlite3pp-flake.packages.${system}.sqlite3pp
 , sql-builder   ? pkgsFor.runCommandNoCC "sql-builder" {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "argparse": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1691774076,
+        "narHash": "sha256-J4Cdw5xc1sKfSqT1NfxY58ETj6fAV9aFbFummJqNKss=",
+        "owner": "aakropotkin",
+        "repo": "argparse",
+        "rev": "e3223ebfd8ab893ea041fc1d5ad72533f58b7279",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aakropotkin",
+        "repo": "argparse",
+        "type": "github"
+      }
+    },
     "floco": {
       "inputs": {
         "nixpkgs": [
@@ -37,6 +57,7 @@
     },
     "root": {
       "inputs": {
+        "argparse": "argparse",
         "floco": "floco",
         "nixpkgs": "nixpkgs",
         "sql-builder": "sql-builder",

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,8 @@
   inputs.nixpkgs.url                      = "github:NixOS/nixpkgs";
   inputs.floco.url                        = "github:aakropotkin/floco";
   inputs.floco.inputs.nixpkgs.follows     = "/nixpkgs";
+  inputs.argparse.url                     = "github:aakropotkin/argparse";
+  inputs.argparse.inputs.nixpkgs.follows  = "/nixpkgs";
   inputs.sqlite3pp.url                    = "github:aakropotkin/sqlite3pp";
   inputs.sqlite3pp.inputs.nixpkgs.follows = "/nixpkgs";
   inputs.sql-builder                      = {
@@ -21,7 +23,7 @@
 
 # ---------------------------------------------------------------------------- #
 
-  outputs = { nixpkgs, floco, sql-builder, sqlite3pp, ... }: let
+  outputs = { nixpkgs, floco, argparse, sql-builder, sqlite3pp, ... }: let
 
 # ---------------------------------------------------------------------------- #
 
@@ -36,8 +38,11 @@
 
 # ---------------------------------------------------------------------------- #
 
-    overlays.deps = nixpkgs.lib.composeExtensions floco.overlays.default
-                                                  sqlite3pp.overlays.default;
+    overlays.deps = nixpkgs.lib.composeManyExtensions [
+      floco.overlays.default
+      sqlite3pp.overlays.default
+      argparse.overlays.default
+    ];
     overlays.flox-pkgdb = final: prev: {
       flox-pkgdb = final.callPackage ./pkg-fun.nix {};
       sql-builder  = final.runCommandNoCC "sql-builder" {


### PR DESCRIPTION
Uses the pre-release version of `argparse` ( C++ lib ) to get `parser.at<argparse::ArgumentParser>( "subcommand" );` "getter".