### PR TITLE
feat: replace matchStyle with two match variables

### DIFF
--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -84,24 +84,11 @@ concept pkg_descriptor_typename = std::derived_from<T, PkgDescriptorBase>;
  */
 struct PkgQueryArgs : public PkgDescriptorBase {
 
-  enum match_style {
-    QMS_NONE = 0  /**< Indicates unset/unspecified. */
-  /**
-   * Match exact or partial `pname`/`pkgAttrName`, and partial `descriptions`.
-   */
-  , QMS_SEARCH  = 1
-  , QMS_RESOLVE = 2  /**< Match exact `pname` or `pkgAttrName`. */
-  };  /* End enum `match_style' */
-  /**
-   * Indicates how `match` ( if any ) should be interpreted by the
-   * query builder.
-   *
-   * @see match_style
-   */
-  match_style matchStyle = QMS_NONE;
+  /** Filter results by partial match on pname, pkgAttrName, or description */
+  std::optional<std::string> partialMatch;
 
-  /** Filter results by partial match according to `matchStyle` rules. */
-  std::optional<std::string> match;
+  /** Filter results by an exact match on either `pname` or `pkgAttrName`. To match just `pname` see @a flox::pkgdb::PkgDescriptorBase. */
+  std::optional<std::string> pnameOrPkgAttrName;
 
   /** Filter results to those explicitly marked with the given licenses. */
   std::optional<std::vector<std::string>> licenses;

--- a/include/flox/resolver/params.hh
+++ b/include/flox/resolver/params.hh
@@ -54,6 +54,9 @@ struct PkgDescriptorRaw : public pkgdb::PkgDescriptorBase {
    *   std::optional<std::string> semver;
    */
 
+  /** Filter results by an exact match on either `pname` or `pkgAttrName`. To match just `pname` see @a flox::pkgdb::PkgDescriptorBase. */
+  std::optional<std::string> pnameOrPkgAttrName;
+
   /** Restricts resolution to the named registry input. */
   std::optional<std::string> input;
 

--- a/include/flox/resolver/params.hh
+++ b/include/flox/resolver/params.hh
@@ -54,7 +54,10 @@ struct PkgDescriptorRaw : public pkgdb::PkgDescriptorBase {
    *   std::optional<std::string> semver;
    */
 
-  /** Filter results by an exact match on either `pname` or `pkgAttrName`. To match just `pname` see @a flox::pkgdb::PkgDescriptorBase. */
+  /** 
+   * Filter results by an exact match on either `pname` or `pkgAttrName`.
+   * To match just `pname` see @a flox::pkgdb::PkgDescriptorBase.
+   */
   std::optional<std::string> pnameOrPkgAttrName;
 
   /** Restricts resolution to the named registry input. */

--- a/include/flox/resolver/state.hh
+++ b/include/flox/resolver/state.hh
@@ -109,7 +109,6 @@ class ResolverState : protected pkgdb::PkgDbRegistryMixin {
       pkgdb::PkgQueryArgs args;
       this->preferences.fillPkgQueryArgs( args );
       this->registry->at( name )->fillPkgQueryArgs( args );
-      args.matchStyle = pkgdb::PkgQueryArgs::QMS_RESOLVE;
       return args;
     }
 

--- a/include/flox/search/params.hh
+++ b/include/flox/search/params.hh
@@ -47,9 +47,8 @@ struct SearchQuery : public pkgdb::PkgDescriptorBase {
    *   std::optional<std::string> semver;
    */
 
-  /** Filter results by partial name/description match. */
-  std::optional<std::string> match;
-
+  /** Filter results by partial match on pname, pkgAttrName, or description */
+  std::optional<std::string> partialMatch;
 
   /** @brief Reset to default state. */
   virtual void clear() override;
@@ -122,7 +121,7 @@ void to_json( nlohmann::json & jto, const SearchQuery & qry );
  * , "systems": ["x86_64-linux"]
  * , "allow":   { "unfree": true, "broken": false, "licenses": ["MIT"] }
  * , "semver":  { "preferPreReleases": false }
- * , "query":   { "match": "hello" }
+ * , "query":   { "partialMatch": "hello" }
  * }
  * ```
  */

--- a/src/pkgdb/pkg-query.cc
+++ b/src/pkgdb/pkg-query.cc
@@ -415,7 +415,6 @@ PkgQuery::initOrderBy()
   this->addOrderBy( R"SQL(
     exactPname              DESC
   , exactPkgAttrName        DESC
-
   , matchExactPname         DESC
   , matchExactPkgAttrName   DESC
   , matchPartialPname       DESC

--- a/src/resolver/params.cc
+++ b/src/resolver/params.cc
@@ -38,6 +38,8 @@ PkgDescriptorRaw::clear()
 from_json( const nlohmann::json & jfrom, PkgDescriptorRaw & desc )
 {
   pkgdb::from_json( jfrom, dynamic_cast<pkgdb::PkgDescriptorBase &>( desc ) );
+  try { jfrom.at( "pnameOrPkgAttrName" ).get_to( desc.pnameOrPkgAttrName ); }
+  catch( const nlohmann::json::out_of_range & ) {}
   try { jfrom.at( "preferPreReleases" ).get_to( desc.preferPreReleases ); }
   catch( const nlohmann::json::out_of_range & ) {}
   try { jfrom.at( "path" ).get_to( desc.path ); }
@@ -49,6 +51,7 @@ from_json( const nlohmann::json & jfrom, PkgDescriptorRaw & desc )
 to_json( nlohmann::json & jto, const PkgDescriptorRaw & desc )
 {
   pkgdb::to_json( jto, dynamic_cast<const pkgdb::PkgDescriptorBase &>( desc ) );
+  jto["pnameOrPkgAttrName"] = desc.pnameOrPkgAttrName;
   jto["preferPreReleases"] = desc.preferPreReleases;
   jto["path"] = desc.path;
 }

--- a/src/search/params.cc
+++ b/src/search/params.cc
@@ -21,7 +21,7 @@ namespace flox::search {
 SearchQuery::clear()
 {
   this->pkgdb::PkgDescriptorBase::clear();
-  this->match = std::nullopt;
+  this->partialMatch = std::nullopt;
 }
 
 
@@ -31,7 +31,7 @@ SearchQuery::clear()
 from_json( const nlohmann::json & jfrom, SearchQuery & qry )
 {
   pkgdb::from_json( jfrom, dynamic_cast<pkgdb::PkgDescriptorBase &>( qry ) );
-  try { jfrom.at( "match" ).get_to( qry.match ); }
+  try { jfrom.at( "partialMatch" ).get_to( qry.partialMatch ); }
   catch( const nlohmann::json::out_of_range & ) {}
 }
 
@@ -39,7 +39,7 @@ from_json( const nlohmann::json & jfrom, SearchQuery & qry )
 to_json( nlohmann::json & jto, const SearchQuery & qry )
 {
   pkgdb::to_json( jto, dynamic_cast<const pkgdb::PkgDescriptorBase &>( qry ) );
-  jto["match"] = qry.match;
+  jto["partialMatch"] = qry.partialMatch;
 }
 
 
@@ -49,12 +49,11 @@ to_json( nlohmann::json & jto, const SearchQuery & qry )
 SearchQuery::fillPkgQueryArgs( pkgdb::PkgQueryArgs & pqa ) const
 {
   /* XXX: DOES NOT CLEAR FIRST! We are called after global preferences. */
-  pqa.name       = this->name;
-  pqa.pname      = this->pname;
-  pqa.version    = this->version;
-  pqa.semver     = this->semver;
-  pqa.match      = this->match;
-  pqa.matchStyle = pkgdb::PkgQueryArgs::QMS_SEARCH;
+  pqa.name               = this->name;
+  pqa.pname              = this->pname;
+  pqa.version            = this->version;
+  pqa.semver             = this->semver;
+  pqa.partialMatch       = this->partialMatch;
   return pqa;
 }
 

--- a/tests/data/search/defaults.json
+++ b/tests/data/search/defaults.json
@@ -37,5 +37,5 @@
   , "priority": ["nixpkgs", "nixpkgs-flox", "floco", "floxpkgs"]
   }
 , "systems": ["x86_64-linux"]
-, "query": { "match": "hello" }
+, "query": { "partialMatch": "hello" }
 }

--- a/tests/data/search/doc-params.json
+++ b/tests/data/search/doc-params.json
@@ -62,6 +62,6 @@
   , "pname": null
   , "version": null
   , "semver": "2"
-  , "match": "hello"
+  , "partialMatch": "hello"
   }
 }

--- a/tests/data/search/params0.json
+++ b/tests/data/search/params0.json
@@ -22,7 +22,7 @@
     "preferPreReleases": false
   }
 , "query": {
-    "match": "hello"
+    "partialMatch": "hello"
   , "name": null
   , "pname": null
   , "version": null

--- a/tests/data/search/params1.json
+++ b/tests/data/search/params1.json
@@ -41,7 +41,7 @@
     "preferPreReleases": false
   }
 , "query": {
-    "match": "hello"
+    "partialMatch": "hello"
   , "name": null
   , "pname": null
   , "version": null

--- a/tests/pkgdb.cc
+++ b/tests/pkgdb.cc
@@ -473,7 +473,7 @@ test_PkgQuery1( flox::pkgdb::PkgDb & db )
 
 /* -------------------------------------------------------------------------- */
 
-/* Tests `match' filtering. */
+/* Tests `partialMatch' and `pnameOrPkgAttrName' filtering. */
   bool
 test_PkgQuery2( flox::pkgdb::PkgDb & db )
 {
@@ -516,17 +516,16 @@ test_PkgQuery2( flox::pkgdb::PkgDb & db )
   flox::pkgdb::PkgQueryArgs qargs;
   qargs.systems = std::vector<std::string> { "x86_64-linux" };
 
-  /* Run `match = "hello"' query */
+  /* Run `partialMatch = "hello"' query */
   {
-    qargs.match      = "hello";
-    qargs.matchStyle = flox::pkgdb::PkgQueryArgs::QMS_SEARCH;
+    qargs.partialMatch      = "hello";
     flox::pkgdb::PkgQuery qry( qargs
                              , std::vector<std::string> {
                                  "matchExactPname"
                                , "matchPartialDescription"
                                }
                              );
-    qargs.match = std::nullopt;
+    qargs.partialMatch = std::nullopt;
     size_t count = 0;
     auto   bound = qry.bind( db.db );
     for ( const auto & row : * bound )
@@ -546,16 +545,15 @@ test_PkgQuery2( flox::pkgdb::PkgDb & db )
     EXPECT_EQ( count, std::size_t( 2 ) );
   }
 
-  /* Run `match = "farewell"' query */
+  /* Run `partialMatch = "farewell"' query */
   {
-    qargs.match      = "farewell";
-    qargs.matchStyle = flox::pkgdb::PkgQueryArgs::QMS_SEARCH;
+    qargs.partialMatch      = "farewell";
     flox::pkgdb::PkgQuery qry( qargs
                              , std::vector<std::string> {
                                  "matchPartialDescription"
                                }
                              );
-    qargs.match = std::nullopt;
+    qargs.partialMatch = std::nullopt;
     size_t count = 0;
     auto   bound = qry.bind( db.db );
     for ( const auto & row : * bound )
@@ -566,17 +564,16 @@ test_PkgQuery2( flox::pkgdb::PkgDb & db )
     EXPECT_EQ( count, std::size_t( 2 ) );
   }
 
-  /* Run `match = "hel"' query */
+  /* Run `partialMatch = "hel"' query */
   {
-    qargs.match      = "hel";
-    qargs.matchStyle = flox::pkgdb::PkgQueryArgs::QMS_SEARCH;
+    qargs.partialMatch = "hel";
     flox::pkgdb::PkgQuery qry( qargs
                              , std::vector<std::string> {
                                  "matchPartialPname"
                                , "matchPartialDescription"
                                }
                              );
-    qargs.match = std::nullopt;
+    qargs.partialMatch = std::nullopt;
     size_t count = 0;
     auto   bound = qry.bind( db.db );
     for ( const auto & row : * bound )
@@ -596,12 +593,11 @@ test_PkgQuery2( flox::pkgdb::PkgDb & db )
     EXPECT_EQ( count, std::size_t( 2 ) );
   }
 
-  /* Run `match = "xxxxx"' query */
+  /* Run `pnameOrPkgAttrName = "xxxxx"' query */
   {
-    qargs.match      = "xxxxx";
-    qargs.matchStyle = flox::pkgdb::PkgQueryArgs::QMS_RESOLVE;
+    qargs.pnameOrPkgAttrName = "xxxxx";
     flox::pkgdb::PkgQuery qry( qargs );
-    qargs.match = std::nullopt;
+    qargs.pnameOrPkgAttrName = std::nullopt;
     EXPECT( qry.execute( db.db ).empty() );
   }
 

--- a/tests/pkgdb.cc
+++ b/tests/pkgdb.cc
@@ -593,12 +593,58 @@ test_PkgQuery2( flox::pkgdb::PkgDb & db )
     EXPECT_EQ( count, std::size_t( 2 ) );
   }
 
-  /* Run `pnameOrPkgAttrName = "xxxxx"' query */
+  /* Run `pnameOrPkgAttrName = "hello"' query, which matches pname */
   {
-    qargs.pnameOrPkgAttrName = "xxxxx";
+    qargs.pnameOrPkgAttrName = "hello";
+    flox::pkgdb::PkgQuery qry( qargs
+                             , std::vector<std::string> {
+                                 "exactPname"
+                               , "exactPkgAttrName"
+                               }
+                             );
+    qargs.pnameOrPkgAttrName = std::nullopt;
+    size_t count = 0;
+    auto   bound = qry.bind( db.db );
+    for ( const auto & row : * bound )
+      {
+        ++count;
+        // exactPname is true
+        EXPECT( row.get<bool>( 0 ) );
+        // exactPkgAttrName is false
+        EXPECT( ! row.get<bool>( 1 ) );
+      }
+    EXPECT_EQ( count, std::size_t( 1 ) );
+  }
+
+  /* Run `pnameOrPkgAttrName = "hel"' query */
+  {
+    qargs.pnameOrPkgAttrName = "hel";
     flox::pkgdb::PkgQuery qry( qargs );
     qargs.pnameOrPkgAttrName = std::nullopt;
     EXPECT( qry.execute( db.db ).empty() );
+  }
+
+  /* Run `pnameOrPkgAttrName = "pkg0"' query, which matches attrName */
+  {
+    qargs.pnameOrPkgAttrName = "pkg0";
+    flox::pkgdb::PkgQuery qry( qargs
+                             , std::vector<std::string> {
+                                 "exactPname"
+                               , "exactPkgAttrName"
+                               }
+                             );
+    qargs.pnameOrPkgAttrName = std::nullopt;
+    size_t count = 0;
+    auto   bound = qry.bind( db.db );
+    for ( const auto & row : * bound )
+      {
+        ++count;
+        // exactPname is false
+        EXPECT( ! row.get<bool>( 0 ) );
+        // exactPkgAttrName is true
+        EXPECT( row.get<bool>( 1 ) );
+      }
+    EXPECT_EQ( count, std::size_t( 1 ) );
   }
 
   return true;

--- a/tests/pkgdb.cc
+++ b/tests/pkgdb.cc
@@ -518,7 +518,7 @@ test_PkgQuery2( flox::pkgdb::PkgDb & db )
 
   /* Run `partialMatch = "hello"' query */
   {
-    qargs.partialMatch      = "hello";
+    qargs.partialMatch = "hello";
     flox::pkgdb::PkgQuery qry( qargs
                              , std::vector<std::string> {
                                  "matchExactPname"

--- a/tests/search-params.cc
+++ b/tests/search-params.cc
@@ -86,7 +86,7 @@ main( int argc, char * argv[] )
       , "systems": ["x86_64-linux"]
       , "allow":   { "unfree": true, "broken": false, "licenses": ["MIT"] }
       , "semver":  { "preferPreReleases": false }
-      , "query":   { "match": "hello" }
+      , "query":   { "partialMatch": "hello" }
       } )" ).get_to( params );
     }
   else

--- a/tests/search.bats
+++ b/tests/search.bats
@@ -24,11 +24,11 @@ setup_file() {
 
 # Dump parameters for a query on `nixpkgs'.
 genParams() {
-  jq -r '.query.match|=null' "$TDATA/params0.json"|jq "${1?}";
+  jq -r '.query.partialMatch|=null' "$TDATA/params0.json"|jq "${1?}";
 }
 
 genParamsNixpkgsFlox() {
-  jq -r '.query.match|=null
+  jq -r '.query.partialMatch|=null
         |.registry.inputs|=( del( .nixpkgs )|del( .floco ) )'  \
      "$TDATA/params1.json"|jq "${1?}";
 }
@@ -36,7 +36,7 @@ genParamsNixpkgsFlox() {
 
 # ---------------------------------------------------------------------------- #
 
-# bats test_tags=search:match
+# bats test_tags=search:partialMatch
 
 # Searches `nixpkgs#legacyPackages.x86_64-linux' for a fuzzy match on "hello"
 @test "'pkgdb search' params0.json" {
@@ -62,7 +62,7 @@ genParamsNixpkgsFlox() {
 
 # bats test_tags=search:match
 #
-@test "'pkgdb search' 'match=hello'" {
+@test "'pkgdb search' 'partialMatch=hello'" {
   run sh -c "$PKGDB search '$TDATA/params0.json'|wc -l;";
   assert_success;
   assert_output 11;


### PR DESCRIPTION
Instead of using matchStyle to determine the meaning of match, split the two possible use cases into partialMatch and pnameOrPkgAttrName.