### PR TITLE
fix: revert renaming of query param 'match' -> 'partialMatch'

### DIFF
--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -175,25 +175,6 @@ struct PkgQueryArgs : public PkgDescriptorBase {
 };  /* End struct `PkgQueryArgs' */
 
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-  PkgQueryArgs
-, name
-, pname
-, version
-, semver
-, partialMatch
-, pnameOrPkgAttrName
-, licenses
-, allowBroken
-, allowUnfree
-, preferPreReleases
-, subtrees
-, systems
-, stabilities
-, relPath
-)
-
-
 /* -------------------------------------------------------------------------- */
 
 /**

--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -175,6 +175,25 @@ struct PkgQueryArgs : public PkgDescriptorBase {
 };  /* End struct `PkgQueryArgs' */
 
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+  PkgQueryArgs
+, name
+, pname
+, version
+, semver
+, partialMatch
+, pnameOrPkgAttrName
+, licenses
+, allowBroken
+, allowUnfree
+, preferPreReleases
+, subtrees
+, systems
+, stabilities
+, relPath
+)
+
+
 /* -------------------------------------------------------------------------- */
 
 /**

--- a/src/pkgdb/pkg-query.cc
+++ b/src/pkgdb/pkg-query.cc
@@ -228,7 +228,10 @@ addIn( std::stringstream & oss, const std::vector<std::string> & elems )
   void
 PkgQuery::initMatch()
 {
-  if ( this->pnameOrPkgAttrName.has_value() && ( ! this->pnameOrPkgAttrName->empty() ) )
+  /* Filter by exact matches on `pname' or `pkgAttrName'. */
+  if ( this->pnameOrPkgAttrName.has_value() &&
+       ( ! this->pnameOrPkgAttrName->empty() )
+     )
     {
       this->addSelection(
         "( :pnameOrPkgAttrName = pname ) AS exactPname"
@@ -242,9 +245,11 @@ PkgQuery::initMatch()
   else
     {
       /* Add bogus `match*` values so that later `ORDER BY` works. */
-      this->addSelection( "NULL AS exactPname" );
-      this->addSelection( "NULL AS exactPkgAttrName" );
+      this->addSelection( "0 AS exactPname" );
+      this->addSelection( "0 AS exactPkgAttrName" );
     }
+
+  /* Filter by partial matches on `pname', `pkgAttrName', or `description'. */
   if ( this->partialMatch.has_value() && ( ! this->partialMatch->empty() ) )
     {
       /* We have to add '%' around `:match' because they were added for
@@ -276,11 +281,11 @@ PkgQuery::initMatch()
   else
     {
       /* Add bogus `match*` values so that later `ORDER BY` works. */
-      this->addSelection( "NULL AS matchExactPname" );
-      this->addSelection( "NULL AS matchExactPkgAttrName" );
-      this->addSelection( "NULL AS matchPartialPname" );
-      this->addSelection( "NULL AS matchPartialPkgAttrName" );
-      this->addSelection( "NULL AS matchPartialDescription" );
+      this->addSelection( "0 AS matchExactPname" );
+      this->addSelection( "0 AS matchExactPkgAttrName" );
+      this->addSelection( "0 AS matchPartialPname" );
+      this->addSelection( "0 AS matchPartialPkgAttrName" );
+      this->addSelection( "0 AS matchPartialDescription" );
     }
 }
 

--- a/src/pkgdb/pkg-query.cc
+++ b/src/pkgdb/pkg-query.cc
@@ -245,8 +245,8 @@ PkgQuery::initMatch()
   else
     {
       /* Add bogus `match*` values so that later `ORDER BY` works. */
-      this->addSelection( "0 AS exactPname" );
-      this->addSelection( "0 AS exactPkgAttrName" );
+      this->addSelection( "NULL AS exactPname" );
+      this->addSelection( "NULL AS exactPkgAttrName" );
     }
 
   /* Filter by partial matches on `pname', `pkgAttrName', or `description'. */
@@ -281,11 +281,11 @@ PkgQuery::initMatch()
   else
     {
       /* Add bogus `match*` values so that later `ORDER BY` works. */
-      this->addSelection( "0 AS matchExactPname" );
-      this->addSelection( "0 AS matchExactPkgAttrName" );
-      this->addSelection( "0 AS matchPartialPname" );
-      this->addSelection( "0 AS matchPartialPkgAttrName" );
-      this->addSelection( "0 AS matchPartialDescription" );
+      this->addSelection( "NULL AS matchExactPname" );
+      this->addSelection( "NULL AS matchExactPkgAttrName" );
+      this->addSelection( "NULL AS matchPartialPname" );
+      this->addSelection( "NULL AS matchPartialPkgAttrName" );
+      this->addSelection( "NULL AS matchPartialDescription" );
     }
 }
 

--- a/tests/data/search/defaults.json
+++ b/tests/data/search/defaults.json
@@ -37,5 +37,5 @@
   , "priority": ["nixpkgs", "nixpkgs-flox", "floco", "floxpkgs"]
   }
 , "systems": ["x86_64-linux"]
-, "query": { "partialMatch": "hello" }
+, "query": { "match": "hello" }
 }

--- a/tests/data/search/doc-params.json
+++ b/tests/data/search/doc-params.json
@@ -62,6 +62,6 @@
   , "pname": null
   , "version": null
   , "semver": "2"
-  , "partialMatch": "hello"
+  , "match": "hello"
   }
 }

--- a/tests/data/search/params0.json
+++ b/tests/data/search/params0.json
@@ -22,7 +22,7 @@
     "preferPreReleases": false
   }
 , "query": {
-    "partialMatch": "hello"
+    "match": "hello"
   , "name": null
   , "pname": null
   , "version": null

--- a/tests/data/search/params1.json
+++ b/tests/data/search/params1.json
@@ -41,7 +41,7 @@
     "preferPreReleases": false
   }
 , "query": {
-    "partialMatch": "hello"
+    "match": "hello"
   , "name": null
   , "pname": null
   , "version": null

--- a/tests/search.bats
+++ b/tests/search.bats
@@ -24,11 +24,11 @@ setup_file() {
 
 # Dump parameters for a query on `nixpkgs'.
 genParams() {
-  jq -r '.query.partialMatch|=null' "$TDATA/params0.json"|jq "${1?}";
+  jq -r '.query.match|=null' "$TDATA/params0.json"|jq "${1?}";
 }
 
 genParamsNixpkgsFlox() {
-  jq -r '.query.partialMatch|=null
+  jq -r '.query.match|=null
         |.registry.inputs|=( del( .nixpkgs )|del( .floco ) )'  \
      "$TDATA/params1.json"|jq "${1?}";
 }
@@ -36,7 +36,7 @@ genParamsNixpkgsFlox() {
 
 # ---------------------------------------------------------------------------- #
 
-# bats test_tags=search:partialMatch
+# bats test_tags=search:match
 
 # Searches `nixpkgs#legacyPackages.x86_64-linux' for a fuzzy match on "hello"
 @test "'pkgdb search' params0.json" {
@@ -62,7 +62,7 @@ genParamsNixpkgsFlox() {
 
 # bats test_tags=search:match
 #
-@test "'pkgdb search' 'partialMatch=hello'" {
+@test "'pkgdb search' 'match=hello'" {
   run sh -c "$PKGDB search '$TDATA/params0.json'|wc -l;";
   assert_success;
   assert_output 11;


### PR DESCRIPTION
## Overview
Restore `pkgdb search` parameter _name_ `query.match`.


## Context
When adding separate internal arguments for `partialMatch` and `pnameOrPkgAttrName` from the existing `match` argument, the _public interface_ was also renamed from `match` to `partialMatch`.

The _public interface_ change was unintended, and caused breakage in existing usage.
