### PR TITLE
tests: additional semver filtering tests

### DIFF
--- a/tests/data/search/params-semver.json
+++ b/tests/data/search/params-semver.json
@@ -1,0 +1,51 @@
+{
+  "registry": {
+    "inputs": {
+      "nixpkgs": {
+        "from": {
+          "type": "github"
+        , "owner": "NixOS"
+        , "repo": "nixpkgs"
+        , "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+        }
+      , "subtrees": ["legacyPackages"]
+      }
+    , "nixpkgs-flox": {
+        "from": {
+          "type": "github"
+        , "owner": "flox"
+        , "repo": "nixpkgs-flox"
+        , "rev": "feb593b6844a96dd4e17497edaabac009be05709"
+        }
+      , "subtrees": ["catalog"]
+      , "stabilities": ["stable"]
+      }
+    , "floco": {
+        "from": {
+          "type": "github"
+        , "owner": "aakropotkin"
+        , "repo": "floco"
+        , "rev": "1e84b4b16bba5746e1195fa3a4d8addaaf2d9ef4"
+        }
+      , "subtrees": ["packages"]
+      }
+    }
+    , "priority": ["nixpkgs", "floco", "nixpkgs-flox"]
+  }
+, "systems": ["x86_64-linux"]
+, "allow": {
+    "unfree": true
+  , "broken": false
+  , "licenses": null
+  }
+, "semver": {
+    "preferPreReleases": false
+  }
+, "query": {
+    "match": "charasay"
+  , "name": null
+  , "pname": null
+  , "version": null
+  , "semver": "^2"
+  }
+}

--- a/tests/pkgdb.cc
+++ b/tests/pkgdb.cc
@@ -1072,11 +1072,10 @@ test_getPackages_semver0( flox::pkgdb::PkgDb & db )
   {
     auto semvers = getSemvers( "*" );
     EXPECT_EQ( semvers.size(), std::size_t( 5 ) );
-    EXPECT( std::ranges::all_of(
-              semvers
-            , []( const auto & maybeSemver ) { return maybeSemver.has_value(); }
-            )
-          );
+    for ( const auto & maybeSemver : semvers )
+      { 
+        EXPECT( maybeSemver.has_value() );
+      }
   }
 
   return true;

--- a/tests/pkgdb.cc
+++ b/tests/pkgdb.cc
@@ -973,7 +973,10 @@ test_getPackages_semver0( flox::pkgdb::PkgDb & db )
       ( :parentId, 'hello0', 'hello-2.12', 'hello', '2.12', '2.12.0'
       , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
       )
-    , ( :parentId, 'hello1', 'hello-2.12.1', 'hello', '2.12.1', '2.12.1'
+    , ( :parentId, 'hello1', 'hello-2.13.1', 'hello', '2.13.1', '2.13.1'
+      , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
+      )
+    , ( :parentId, 'hello1', 'hello-2.14.1', 'hello', '2.14.1', '2.14.1'
       , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
       )
     , ( :parentId, 'hello2', 'hello-3', 'hello', '3', '3.0.0'
@@ -1024,6 +1027,30 @@ test_getPackages_semver0( flox::pkgdb::PkgDb & db )
   /* ^2 : 2.0.0 <= VERSION < 3.0.0 */
   {
     auto semvers = getSemvers( "^2" );
+    EXPECT_EQ( semvers.size(), std::size_t( 3 ) );
+    size_t idx = 0;
+    for ( const std::optional<std::string> & maybeSemver : semvers )
+      {
+        EXPECT( maybeSemver.has_value() );
+        if ( idx == 0 )
+          {
+            EXPECT_EQ( * maybeSemver, "2.14.1" );
+          }
+        else if ( idx == 1 )
+          {
+            EXPECT_EQ( * maybeSemver, "2.13.1" );
+          }
+        else if ( idx == 2 )
+          {
+            EXPECT_EQ( * maybeSemver, "2.12.0" );
+          }
+        ++idx;
+      }
+  }
+
+  /* ^2.13.1 : 2.13.1 <= VERSION < 3.0.0 */
+  {
+    auto semvers = getSemvers( "^2.13.1" );
     EXPECT_EQ( semvers.size(), std::size_t( 2 ) );
     size_t idx = 0;
     for ( const std::optional<std::string> & maybeSemver : semvers )
@@ -1031,15 +1058,16 @@ test_getPackages_semver0( flox::pkgdb::PkgDb & db )
         EXPECT( maybeSemver.has_value() );
         if ( idx == 0 )
           {
-            EXPECT_EQ( * maybeSemver, "2.12.1" );
+            EXPECT_EQ( * maybeSemver, "2.14.1" );
           }
         else if ( idx == 1 )
           {
-            EXPECT_EQ( * maybeSemver, "2.12.0" );
+            EXPECT_EQ( * maybeSemver, "2.13.1" );
           }
         ++idx;
       }
   }
+
 
   return true;
 }

--- a/tests/pkgdb.cc
+++ b/tests/pkgdb.cc
@@ -976,16 +976,16 @@ test_getPackages_semver0( flox::pkgdb::PkgDb & db )
     , ( :parentId, 'hello1', 'hello-2.13.1', 'hello', '2.13.1', '2.13.1'
       , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
       )
-    , ( :parentId, 'hello1', 'hello-2.14.1', 'hello', '2.14.1', '2.14.1'
+    , ( :parentId, 'hello2', 'hello-2.14.1', 'hello', '2.14.1', '2.14.1'
       , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
       )
-    , ( :parentId, 'hello2', 'hello-3', 'hello', '3', '3.0.0'
+    , ( :parentId, 'hello3', 'hello-3', 'hello', '3', '3.0.0'
       , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
       )
-    , ( :parentId, 'hello3', 'hello-4.2.0', 'hello', '4.2', '4.2.0'
+    , ( :parentId, 'hello4', 'hello-4.2.0', 'hello', '4.2', '4.2.0'
       , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
       )
-    , ( :parentId, 'hello4', 'hello-no-version', 'hello', NULL, NULL
+    , ( :parentId, 'hello5', 'hello-no-version', 'hello', NULL, NULL
       , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
       )
   )SQL" );
@@ -1068,6 +1068,16 @@ test_getPackages_semver0( flox::pkgdb::PkgDb & db )
       }
   }
 
+  /* '*' : Any semantic version, should omit `hello-no-version' */
+  {
+    auto semvers = getSemvers( "*" );
+    EXPECT_EQ( semvers.size(), std::size_t( 5 ) );
+    EXPECT( std::ranges::all_of(
+              semvers
+            , []( const auto & maybeSemver ) { return maybeSemver.has_value(); }
+            )
+          );
+  }
 
   return true;
 }

--- a/tests/pkgdb.cc
+++ b/tests/pkgdb.cc
@@ -928,6 +928,7 @@ test_DbPackage0( flox::pkgdb::PkgDb & db )
                    static_cast<flox::pkgdb::PkgDbReadOnly &>( db )
                  , pkgId
                  );
+
   EXPECT( pkg.getPathStrs() ==
           ( flox::AttrPath { "legacyPackages", "x86_64-linux", "hello" } )
         );
@@ -948,6 +949,98 @@ test_DbPackage0( flox::pkgdb::PkgDb & db )
   EXPECT_EQ( nix::parseFlakeRef( nixpkgsRef ).to_string()
            , pkg.getLockedFlakeRef().to_string()
            );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+  bool
+test_getPackages_semver0( flox::pkgdb::PkgDb & db )
+{
+  clearTables( db );
+
+  /* Make packages */
+  row_id linux =
+    db.addOrGetAttrSetId( flox::AttrPath { "legacyPackages", "x86_64-linux" } );
+  row_id desc =
+    db.addOrGetDescriptionId( "A program with a friendly greeting/farewell" );
+  sqlite3pp::command cmd( db.db, R"SQL(
+    INSERT INTO Packages (
+      parentId, attrName, name, pname, version, semver, license, outputs
+    , outputsToInstall, broken, unfree, descriptionId
+    ) VALUES
+      ( :parentId, 'hello0', 'hello-2.12', 'hello', '2.12', '2.12.0'
+      , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
+      )
+    , ( :parentId, 'hello1', 'hello-2.12.1', 'hello', '2.12.1', '2.12.1'
+      , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
+      )
+    , ( :parentId, 'hello2', 'hello-3', 'hello', '3', '3.0.0'
+      , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
+      )
+    , ( :parentId, 'hello3', 'hello-4.2.0', 'hello', '4.2', '4.2.0'
+      , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
+      )
+    , ( :parentId, 'hello4', 'hello-no-version', 'hello', NULL, NULL
+      , 'GPL-3.0-or-later', '["out"]', '["out"]', false, false, :descriptionId
+      )
+  )SQL" );
+  cmd.bind( ":parentId",      static_cast<long long>( linux ) );
+  cmd.bind( ":descriptionId", static_cast<long long>( desc )  );
+  if ( flox::pkgdb::sql_rc rc = cmd.execute(); flox::pkgdb::isSQLError( rc ) )
+    {
+      throw flox::pkgdb::PkgDbException(
+        db.dbPath
+      , nix::fmt( "Failed to write Packages:(%d) %s"
+                , rc
+                , db.db.error_msg()
+                )
+      );
+    }
+
+  flox::pkgdb::PkgQueryArgs qargs;
+  qargs.subtrees = std::vector<flox::Subtree> { flox::ST_LEGACY };
+  qargs.systems  = std::vector<std::string> { "x86_64-linux" };
+  qargs.pname    = "hello";
+
+  auto getSemvers =
+    [&]( const std::string & semver ) -> std::vector<std::optional<std::string>>
+    {
+      std::vector<std::optional<std::string>> rsl;
+      qargs.semver = { semver };
+      for( flox::pkgdb::row_id rowId : db.getPackages( qargs ) )
+        {
+          rsl.emplace_back(
+            flox::pkgdb::DbPackage(
+              static_cast<flox::pkgdb::PkgDbReadOnly &>( db )
+            , rowId
+            ).getSemver()
+          );
+        }
+      return rsl;
+    };
+
+  /* ^2 : 2.0.0 <= VERSION < 3.0.0 */
+  {
+    auto semvers = getSemvers( "^2" );
+    EXPECT_EQ( semvers.size(), std::size_t( 2 ) );
+    size_t idx = 0;
+    for ( const std::optional<std::string> & maybeSemver : semvers )
+      {
+        EXPECT( maybeSemver.has_value() );
+        if ( idx == 0 )
+          {
+            EXPECT_EQ( * maybeSemver, "2.12.1" );
+          }
+        else if ( idx == 1 )
+          {
+            EXPECT_EQ( * maybeSemver, "2.12.0" );
+          }
+        ++idx;
+      }
+  }
+
   return true;
 }
 
@@ -1013,6 +1106,8 @@ main( int argc, char * argv[] )
     RUN_TEST( getPackages2, db );
 
     RUN_TEST( DbPackage0, db );
+
+    RUN_TEST( getPackages_semver0, db );
 
   }
 


### PR DESCRIPTION
I ran into some unexpected `semver` results using `flox::resolver::*` interfaces which are in development in a separate PR.

To sanity check the results I saw there I created a few new `semver` filtering tests for the `flox::pkgdb::PkgDbReadOnly::getPackage()` routine.

While filtering behaves _as specified_, I found that when searching/resolving across multiple inputs, the resulting order being _grouped by input_ may not be what is expected.