### PR TITLE
feat: JSON ADL serializers for std::variant

### DIFF
--- a/include/flox/core/util.hh
+++ b/include/flox/core/util.hh
@@ -42,13 +42,22 @@ template<class... Ts> overloaded( Ts... ) -> overloaded<Ts...>;
 
 /* -------------------------------------------------------------------------- */
 
-/* Extension to the `nlohmann::json' serializer to support addition STLs. */
+/**
+ * @brief Extension to the `nlohmann::json' serializer to support additional
+ *        _Argument Dependent Lookup_ (ADL) types.
+ */
 namespace nlohmann {
 
-  /** Serializers for `std::optional` */
+/* -------------------------------------------------------------------------- */
+
+  /** @brief Optional types to/from JSON. */
     template <typename T>
   struct adl_serializer<std::optional<T>> {
 
+    /**
+     *  @brief Convert an optional type to a JSON type  treating `std::nullopt`
+     *         as `null`.
+     */
       static void
     to_json( json & jto, const std::optional<T> & opt )
     {
@@ -56,6 +65,10 @@ namespace nlohmann {
       else                   { jto = nullptr; }
     }
 
+    /**
+     * @brief Convert a JSON type to an `optional<T>` treating
+     *        `null` as `std::nullopt`.
+     */
       static void
     from_json( const json & jfrom, std::optional<T> & opt )
     {
@@ -66,51 +79,135 @@ namespace nlohmann {
   };  /* End struct `adl_serializer<std::optional<T>>' */
 
 
-    template <typename T>
-  struct adl_serializer<std::vector<std::optional<T>>> {
+/* -------------------------------------------------------------------------- */
 
+  /** @brief Variants ( Eithers ) of two elements to/from JSON. */
+    template<typename A, typename B>
+  struct adl_serializer<std::variant<A, B>> {
+
+    /** @brief Convert a @a std::variant<A, B> to a JSON type. */
       static void
-    to_json( json & jto, const std::vector<std::optional<T>> & vec )
+    to_json( json & jto, const std::variant<A, B> & var )
     {
-      jto = json::array();
-      for ( const auto & opt : vec )
+      if ( std::holds_alternative<A>( var ) )
         {
-          if ( opt.has_value() ) { jto.push_back( * opt ); }
-          else                   { jto.push_back( nullptr ); }
+          jto = std::get<A>( var );
+        }
+      else
+        {
+          jto = std::get<B>( var );
         }
     }
 
+    /** @brief Convert a JSON type to a @a std::variant<A, B>. */
       static void
-    from_json( const json & jfrom, std::vector<std::optional<T>> & vec )
+    from_json( const json & jfrom, std::variant<A, B> & var )
     {
-      vec.clear();
-      for ( const auto & value : jfrom )
+      try
         {
-          if ( value.is_null() )
-            {
-              vec.push_back( std::nullopt );
-            }
-          else
-            {
-              vec.push_back( std::make_optional( value.template get<T>() ) );
-            }
+          var = jfrom.template get<A>();
+        }
+      catch( ... )
+        {
+          var = jfrom.template get<B>();
         }
     }
 
-  };  /* End struct `adl_serializer<std::vector<std::optional<T>>>' */
+  };  /* End struct `adl_serializer<std::variant<A, B>>' */
 
 
-  /* Flake Refs */
+/* -------------------------------------------------------------------------- */
+
+  /**
+   * @brief Variants ( Eithers ) of any number of elements to/from JSON.
+   *
+   * The order of your types effects priority.
+   * Any valid parse or coercion from a type named _early_ in the variant list
+   * will succeed before attempting to parse alternatives.
+   *
+   * For example, always attempt `bool` first, then `int`, then `float`, and
+   * alway attempt `std::string` LAST.
+   *
+   * It's important to note that you must never nest multiple `std::optional`
+   * types in a variant, instead make `std::optional<std::variant<...>>`.
+   */
+    template<typename A, typename... Types>
+  struct adl_serializer<std::variant<A, Types...>> {
+
+    /** @brief Convert a @a std::variant<A, Types...> to a JSON type. */
+      static void
+    to_json( json & jto, const std::variant<A, Types...> & var )
+    {
+      /* This _unwraps_ the inner type and calls the proper `to_json'.
+       * The compiler does the heavy lifting for us here <3. */
+      std::visit( [&]( auto unwrapped ) -> void { jto = unwrapped; }, var );
+    }
+
+    /** @brief Convert a JSON type to a @a std::variant<Types...>. */
+      static void
+    from_json( const json & jfrom, std::variant<A, Types...> & var )
+    {
+      /* Try getting typename `A', or recur. */
+      try
+        {
+          var = jfrom.template get<A>();
+        }
+      catch( ... )
+        {
+          /* Strip typename `A' from variant, and call recursively. */
+          using next_variant = std::variant<Types...>;
+
+          /* Coerce to `next_variant' type. */
+          next_variant next = jfrom.template get<next_variant>();
+          std::visit( [&]( auto unwrapped ) -> void { var = unwrapped; }
+                    , next
+                    );
+        }
+    }
+
+  };  /* End struct `adl_serializer<std::variant<A, Types...>>' */
+
+
+/* -------------------------------------------------------------------------- */
+
+  /** @brief @a nix::fetchers::Attrs to/from JSON */
+    template<>
+  struct adl_serializer<nix::fetchers::Attrs> {
+
+    /** @brief Convert a @a nix::fetchers::Attrs to a JSON object. */
+      static void
+    to_json( json & jto, const nix::fetchers::Attrs & attrs )
+    {
+      /* That was easy. */
+      jto = nix::fetchers::attrsToJSON( attrs );
+    }
+
+    /** @brief Convert a JSON object to a @a nix::fetchers::Attrs. */
+      static void
+    from_json( const json & jfrom, nix::fetchers::Attrs & attrs )
+    {
+      /* That was easy. */
+      attrs = nix::fetchers::jsonToAttrs( jfrom );
+    }
+
+  };  /* End struct `adl_serializer<nix::fetchers::Attrs>' */
+
+
+/* -------------------------------------------------------------------------- */
+
+  /** @brief @a nix::FlakeRef to/from JSON. */
     template<>
   struct adl_serializer<nix::FlakeRef> {
 
+    /** @brief Convert a @a nix::FlakeRef to a JSON object. */
       static void
     to_json( json & jto, const nix::FlakeRef & ref )
     {
+      /* That was easy. */
       jto = nix::fetchers::attrsToJSON( ref.toAttrs() );
     }
 
-    /** _Move-only_ constructor for flake-ref from JSON. */
+    /** @brief _Move-only_ conversion of a JSON object to a @a nix::FlakeRef. */
       static nix::FlakeRef
     from_json( const json & jfrom )
     {
@@ -128,61 +225,13 @@ namespace nlohmann {
 
   };  /* End struct `adl_serializer<nix::FlakeRef>' */
 
-  /* Eithers */
-    template<typename A, typename B>
-  struct adl_serializer<std::variant<A, B>> {
 
-      static void
-    to_json( json & jto, const std::variant<A, B> & var )
-    {
-      if ( std::holds_alternative<A>( var ) )
-        {
-          jto = std::get<A>( var );
-        }
-      else
-        {
-          jto = std::get<B>( var );
-        }
-    }
-
-      static void
-    from_json( const json & jfrom, std::variant<A, B> & var )
-    {
-      try
-        {
-          var = jfrom.template get<A>();
-        }
-      catch( ... )
-        {
-          var = jfrom.template get<B>();
-        }
-    }
-
-  };  /* End struct `adl_serializer<std::variant<A, B>>' */
-
-
-  /* nix::fetchers::Attrs */
-    template<>
-  struct adl_serializer<nix::fetchers::Attrs> {
-
-      static void
-    to_json( json & jto, const nix::fetchers::Attrs & attrs )
-    {
-      jto = nix::fetchers::attrsToJSON( attrs );
-    }
-
-      static void
-    from_json( const json & jfrom, nix::fetchers::Attrs & attrs )
-    {
-      attrs = nix::fetchers::jsonToAttrs( jfrom );
-    }
-
-  };  /* End struct `adl_serializer<std::variant<A, B>>' */
+/* -------------------------------------------------------------------------- */
 
 }  /* End namespace `nlohmann' */
 
 
-/* ========================================================================== */
+/* -------------------------------------------------------------------------- */
 
 namespace flox {
 

--- a/tests/util.cc
+++ b/tests/util.cc
@@ -101,13 +101,125 @@ test_splitAttrPath6()
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief Test conversion of variants with 2 options. */
+  bool
+test_variantJSON0()
+{
+  using Trivial = std::variant<bool, std::string>;
+
+  Trivial tbool      = true;
+  Trivial tstr       = "Howdy";
+  nlohmann::json jto = tbool;
+
+  EXPECT_EQ( jto, true );
+
+  jto = tstr;
+  EXPECT_EQ( jto, "Howdy" );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test conversion of variants with 3 options. */
+  bool
+test_variantJSON1()
+{
+  using Trivial = std::variant<int, bool, std::string>;
+
+  Trivial tint       = 420;
+  Trivial tbool      = true;
+  Trivial tstr       = "Howdy";
+  nlohmann::json jto = tint;
+
+  EXPECT_EQ( jto, 420 );
+
+  jto = tbool;
+  EXPECT_EQ( jto, true );
+
+  jto = tstr;
+  EXPECT_EQ( jto, "Howdy" );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test conversion of variants with 2 options in a vector. */
+  bool
+test_variantJSON2()
+{
+  using Trivial = std::variant<bool, std::string>;
+
+  std::vector<Trivial> tvec = { true, "Howdy" };
+
+  nlohmann::json jto = tvec;
+
+  EXPECT( jto.is_array() );
+  EXPECT_EQ( jto.at( 0 ), true );
+  EXPECT_EQ( jto.at( 1 ), "Howdy" );
+
+  std::vector<Trivial> back = jto;
+  EXPECT_EQ( back.size(), std::size_t( 2 ) );
+
+  EXPECT( std::holds_alternative<bool>( back.at( 0 ) ) );
+  EXPECT_EQ( std::get<bool>( back.at( 0 ) ), std::get<bool>( tvec.at( 0 ) ) );
+
+  EXPECT( std::holds_alternative<std::string>( back.at( 1 ) ) );
+  EXPECT_EQ( std::get<std::string>( back.at( 1 ) )
+           , std::get<std::string>( tvec.at( 1 ) )
+           );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test conversion of variants with 3 options in a vector. */
+  bool
+test_variantJSON3()
+{
+  /* NOTE: `bool` MUST come before `int` to avoid coercion!
+   * `std::string` always has to go last. */
+  using Trivial = std::variant<bool, int, std::string>;
+
+  std::vector<Trivial> tvec = { true, "Howdy", 420 };
+
+  nlohmann::json jto = tvec;
+
+  EXPECT( jto.is_array() );
+  EXPECT_EQ( jto.at( 0 ), true );
+  EXPECT_EQ( jto.at( 1 ), "Howdy" );
+  EXPECT_EQ( jto.at( 2 ), 420 );
+
+  std::vector<Trivial> back = jto;
+  EXPECT_EQ( back.size(), std::size_t( 3 ) );
+
+  EXPECT( std::holds_alternative<bool>( back.at( 0 ) ) );
+  EXPECT_EQ( std::get<bool>( back.at( 0 ) ), std::get<bool>( tvec.at( 0 ) ) );
+
+  EXPECT( std::holds_alternative<std::string>( back.at( 1 ) ) );
+  EXPECT_EQ( std::get<std::string>( back.at( 1 ) )
+           , std::get<std::string>( tvec.at( 1 ) )
+           );
+
+  EXPECT( std::holds_alternative<int>( back.at( 2 ) ) );
+  EXPECT_EQ( std::get<int>( back.at( 2 ) ), std::get<int>( tvec.at( 2 ) ) );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
   int
 main()
 {
   int ec = EXIT_SUCCESS;
 # define RUN_TEST( ... )  _RUN_TEST( ec, __VA_ARGS__ )
-
-/* -------------------------------------------------------------------------- */
 
   RUN_TEST( splitAttrPath0 );
   RUN_TEST( splitAttrPath1 );
@@ -117,8 +229,10 @@ main()
   RUN_TEST( splitAttrPath5 );
   RUN_TEST( splitAttrPath6 );
 
-
-/* -------------------------------------------------------------------------- */
+  RUN_TEST( variantJSON0 );
+  RUN_TEST( variantJSON1 );
+  RUN_TEST( variantJSON2 );
+  RUN_TEST( variantJSON3 );
 
   return ec;
 }


### PR DESCRIPTION
I swear that this is the upper limit of esoteric C++ templates you'll ever need to read in the code-base.

These are _magic_, but the code generation they provide is worth the boilerplate they eliminate <3

- Adds `to_json` and `from_json` conversion for STL `std::variant<...>` types.
- cleanup/doc for existing serializers.
