### PR TITLE
fix: make compile_commands.json on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,8 +337,13 @@ compile_commands.json: $(lastword $(MAKEFILE_LIST))
 compile_commands.json: $(COMMON_HEADERS) $(ALL_SRCS)
 	-$(MAKE) -C $(MAKEFILE_DIR) clean;
 	$(info $$CXX_SYSTEM_INCDIRS is [${CXX_SYSTEM_INCDIRS}])
+
+	$(MKDIR_P) $(MAKEFILE_DIR)/bear.d
+	ln -sf $(shell dirname $(shell which $(BEAR)))/../lib/bear/wrapper bear.d/c++
+
 	EXTRA_CXXFLAGS='$(patsubst %,-isystem %,$(CXX_SYSTEM_INCDIRS))'  \
-	   $(BEAR) --output "$@" -- $(MAKE) -C $(MAKEFILE_DIR) -j all;
+	  PATH="$(MAKEFILE_DIR)/bear.d/:$(PATH)"                         \
+	  $(BEAR) -- $(MAKE) -C $(MAKEFILE_DIR) -j bin;
 
 
 # ---------------------------------------------------------------------------- #

--- a/Makefile
+++ b/Makefile
@@ -324,15 +324,21 @@ cdb: compile_commands.json
 
 
 # Get system include paths from `nix' C++ compiler.
-CXX_SYSTEM_INCDIRS := $(shell                                                \
-  $(CXX) -E -Wp,-v -xc++ /dev/null 2>&1 1>/dev/null|$(GREP) '^ /nix/store')
+# Filter out framework directory, e.g.
+# /nix/store/q2d0ya7rc5kmwbwvsqc2djvv88izn1q6-apple-framework-CoreFoundation-11.0.0/Library/Frameworks (framework directory)
+# We might be able to strip '(framework directory)' instead and append
+# CoreFoundation.framework/Headers but I don't think we need to.
+CXX_SYSTEM_INCDIRS := $(shell                                \
+  $(CXX) -E -Wp,-v -xc++ /dev/null 2>&1 1>/dev/null          \
+  |$(GREP) -v 'framework directory'|$(GREP) '^ /nix/store')
 
 compile_commands.json: flake.nix flake.lock pkg-fun.nix
 compile_commands.json: $(lastword $(MAKEFILE_LIST))
 compile_commands.json: $(COMMON_HEADERS) $(ALL_SRCS)
 	-$(MAKE) -C $(MAKEFILE_DIR) clean;
+	$(info $$CXX_SYSTEM_INCDIRS is [${CXX_SYSTEM_INCDIRS}])
 	EXTRA_CXXFLAGS='$(patsubst %,-isystem %,$(CXX_SYSTEM_INCDIRS))'  \
-	  $(BEAR) --output "$@" -- $(MAKE) -C $(MAKEFILE_DIR) -j all;
+	   $(BEAR) --output "$@" -- $(MAKE) -C $(MAKEFILE_DIR) -j all;
 
 
 # ---------------------------------------------------------------------------- #

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ compile_commands.json: $(COMMON_HEADERS) $(ALL_SRCS)
 	$(info $$CXX_SYSTEM_INCDIRS is [${CXX_SYSTEM_INCDIRS}])
 
 	$(MKDIR_P) $(MAKEFILE_DIR)/bear.d
-	ln -sf $(shell dirname $(shell which $(BEAR)))/../lib/bear/wrapper bear.d/c++
+	ln -sf $(shell dirname $(shell command -v $(BEAR)))/../lib/bear/wrapper bear.d/c++
 
 	EXTRA_CXXFLAGS='$(patsubst %,-isystem %,$(CXX_SYSTEM_INCDIRS))'  \
 	  PATH="$(MAKEFILE_DIR)/bear.d/:$(PATH)"                         \


### PR DESCRIPTION
On mac, the command to generate CXX_SYSTEM_INCDIRS prints out the line: /nix/store/q2d0ya7rc5kmwbwvsqc2djvv88izn1q6-apple-framework-CoreFoundation-11.0.0/Library/Frameworks (framework directory) The '(framework directory)' then causes commands using CXX_SYSTEM_INCDIRS to fail with:
sh: -c: line 1: syntax error near unexpected token `('

Filter out that line since it's probably not frequently needed.