### PR TITLE
chore: tidy and format

### DIFF
--- a/include/flox/core/nix-state.hh
+++ b/include/flox/core/nix-state.hh
@@ -67,7 +67,7 @@ class NixStoreMixin {
      * This may be useful if you wish to avoid a non-default store.
      * @param store An open `nix` store connection.
      */
-    explicit NixStoreMixin( nix::ref<nix::Store> & store )
+    explicit NixStoreMixin( const nix::ref<nix::Store> & store )
       : store( static_cast<std::shared_ptr<nix::Store>>( store ) )
     {
       initNix();

--- a/include/flox/pkgdb/command.hh
+++ b/include/flox/pkgdb/command.hh
@@ -30,6 +30,7 @@ struct DbPathMixin
     argparse::Argument &
   addDatabasePathOption( argparse::ArgumentParser & parser );
 
+
 };  /* End struct `DbPathMixin' */
 
 
@@ -60,6 +61,7 @@ struct PkgDbMixin
    */
   argparse::Argument & addTargetArg( argparse::ArgumentParser & parser );
 
+
 };  /* End struct `PkgDbMixin' */
 
 
@@ -69,27 +71,28 @@ struct PkgDbMixin
  * @brief Scrape a flake prefix producing a SQLite3 database with
  *        package metadata.
  */
-struct ScrapeCommand
+class ScrapeCommand
   : public DbPathMixin
   , public command::AttrPathMixin
   , public command::InlineInputMixin
 {
 
-  protected:
+  private:
 
+    command::VerboseParser    parser;
     std::optional<PkgDbInput> input;
+    /** Whether to force re-evaluation. */
+    bool force = false;
 
-    bool force = false;  /**< Whether to force re-evaluation. */
+    /** @brief Initialize @a input from @a registryInput. */
+    void initInput();
 
 
   public:
 
-    command::VerboseParser parser;
-
     ScrapeCommand();
 
-    /** @brief Initialize @a input from @a registryInput. */
-    void initInput();
+    [[nodiscard]] command::VerboseParser & getParser() { return this->parser; }
 
     /**
      * @brief Execute the `scrape` routine.
@@ -97,7 +100,8 @@ struct ScrapeCommand
      */
     int run();
 
-};  /* End struct `ScrapeCommand' */
+
+};  /* End class `ScrapeCommand' */
 
 
 /* -------------------------------------------------------------------------- */
@@ -118,86 +122,102 @@ struct ScrapeCommand
  * - `pkgdb get db FLAKE-REF`
  *   + Print the absolute path to the associated flake's db.
  */
-struct GetCommand
+class GetCommand
   : public PkgDbMixin<PkgDbReadOnly>
   , public command::AttrPathMixin
 {
 
-  command::VerboseParser parser;          /**< `get`       parser */
-  command::VerboseParser pId;             /**< `get id`    parser */
-  command::VerboseParser pPath;           /**< `get path`  parser */
-  command::VerboseParser pDone;           /**< `get done`  parser */
-  command::VerboseParser pFlake;          /**< `get flake` parser */
-  command::VerboseParser pDb;             /**< `get db`    parser */
-  command::VerboseParser pPkg;            /**< `get pkg`   parser */
-  bool                   isPkg  = false;
-  row_id                 id     = 0;
+  private:
 
-  GetCommand();
+    command::VerboseParser parser;          /**< `get`       parser */
+    command::VerboseParser pId;             /**< `get id`    parser */
+    command::VerboseParser pPath;           /**< `get path`  parser */
+    command::VerboseParser pDone;           /**< `get done`  parser */
+    command::VerboseParser pFlake;          /**< `get flake` parser */
+    command::VerboseParser pDb;             /**< `get db`    parser */
+    command::VerboseParser pPkg;            /**< `get pkg`   parser */
+    bool                   isPkg  = false;
+    row_id                 id     = 0;
 
-  /**
-   * @brief Execute the `get id` routine.
-   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
-   */
-  int runId();
+    /**
+     * @brief Execute the `get id` routine.
+     * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+     */
+    int runId();
 
-  /**
-   * @brief Execute the `get done` routine.
-   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
-   */
-  int runDone();
+    /**
+     * @brief Execute the `get done` routine.
+     * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+     */
+    int runDone();
 
-  /**
-   * @brief Execute the `get path` routine.
-   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
-   */
-  int runPath();
+    /**
+     * @brief Execute the `get path` routine.
+     * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+     */
+    int runPath();
 
-  /**
-   * @brief Execute the `get flake` routine.
-   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
-   */
-  int runFlake();
+    /**
+     * @brief Execute the `get flake` routine.
+     * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+     */
+    int runFlake();
 
-  /**
-   * @brief Execute the `get db` routine.
-   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
-   */
-  int runDb();
+    /**
+     * @brief Execute the `get db` routine.
+     * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+     */
+    int runDb();
 
-  /**
-   * @brief Execute the `get pkg` routine.
-   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
-   */
-  int runPkg();
+    /**
+     * @brief Execute the `get pkg` routine.
+     * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+     */
+    int runPkg();
 
-  /**
-   * @brief Execute the `get` routine.
-   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
-   */
-  int run();
 
-};  /* End struct `GetCommand' */
+  public:
+
+    GetCommand();
+
+    [[nodiscard]] command::VerboseParser & getParser() { return this->parser; }
+
+    /**
+     * @brief Execute the `get` routine.
+     * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+     */
+    int run();
+
+
+};  /* End class `GetCommand' */
 
 
 /* -------------------------------------------------------------------------- */
 
-struct ListCommand {
+class ListCommand {
 
-  command::VerboseParser               parser;
-  std::optional<std::filesystem::path> cacheDir;
-  bool                                 json      = false;
-  bool                                 basenames = false;
+  private:
 
-  ListCommand();
+    command::VerboseParser               parser;
+    std::optional<std::filesystem::path> cacheDir;
+    bool                                 json      = false;
+    bool                                 basenames = false;
 
-  /**
-   * @brief Execute the `list` routine.
-   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
-   */
-  int run();
 
-};  /* End struct `ListCommand' */
+  public:
+
+    ListCommand();
+
+    [[nodiscard]] command::VerboseParser & getParser() { return this->parser; }
+
+    /**
+     * @brief Execute the `list` routine.
+     * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+     */
+    int run();
+
+
+};  /* End class `ListCommand' */
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/flox/pkgdb/input.hh
+++ b/include/flox/pkgdb/input.hh
@@ -22,8 +22,6 @@ namespace flox::pkgdb {
 /** @brief A @a RegistryInput that opens a @a PkgDb associated with a flake. */
 class PkgDbInput : public FloxFlakeInput {
 
-/* -------------------------------------------------------------------------- */
-
   private:
 
     /* Provided by `FloxFlakeInput':
@@ -100,7 +98,6 @@ class PkgDbInput : public FloxFlakeInput {
       this->init();
     }
 
-
     /**
      * @brief Construct a @a PkgDbInput from a @a RegistryInput and a path to
      *        the directory where the database should be cached.
@@ -126,7 +123,6 @@ class PkgDbInput : public FloxFlakeInput {
       this->init();
     }
 
-
     /**
      * @return The read-only database connection handle.
      */
@@ -137,22 +133,18 @@ class PkgDbInput : public FloxFlakeInput {
       return static_cast<nix::ref<PkgDbReadOnly>>( this->dbRO );
     }
 
-
     /**
      * @brief Open a read/write database connection if one is not open, and
      *        return a handle.
      */
     [[nodiscard]] nix::ref<PkgDb> getDbReadWrite();
 
-
     /** @brief Close the read/write database connection if it is open. */
     void closeDbReadWrite() { this->dbRW = nullptr; }
-
 
     /** @return Filesystem path to the flake's package database. */
     [[nodiscard]]
     std::filesystem::path getDbPath() const { return this->dbPath; }
-
 
     /**
      * @brief Ensure that an attribute path prefix has been scraped.
@@ -167,7 +159,6 @@ class PkgDbInput : public FloxFlakeInput {
      */
     void scrapePrefix( const flox::AttrPath & prefix );
 
-
     /**
      * @brief Scrape all prefixes indicated by @a InputPreferences for
      *        @a systems.
@@ -175,10 +166,8 @@ class PkgDbInput : public FloxFlakeInput {
      */
     void scrapeSystems( const std::vector<std::string> & systems );
 
-
     /** @brief Add/set a shortname for this input. */
     void setName( std::string_view name ) { this->name = name; }
-
 
     /**
      * @brief Get an identifier for this input.
@@ -192,7 +181,6 @@ class PkgDbInput : public FloxFlakeInput {
         this->getFlake()->lockedFlake.flake.lockedRef.to_string()
       );
     }
-
 
     /** @brief Get a JSON representation of a row in the database. */
     [[nodiscard]] nlohmann::json getRowJSON( row_id row );
@@ -237,6 +225,7 @@ class PkgDbInputFactory {
       );
     }
 
+
 };  /* End class `PkgDbInputFactory' */
 
 
@@ -255,9 +244,13 @@ class PkgDbRegistryMixin : virtual protected NixStoreMixin {
 
   private:
 
+    /* From `NixStoreMixin':
+     *   std::shared_ptr<nix::Store> store
+     */
+
     bool force = false;  /**< Whether to force re-evaluation of flakes. */
 
-    std::shared_ptr<Registry<pkgdb::PkgDbInputFactory>> registry;
+    std::shared_ptr<Registry<PkgDbInputFactory>> registry;
 
 
   protected:

--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -41,14 +41,29 @@ using row_id = uint64_t;  /**< A _row_ index in a SQLite3 table. */
 
 /** @brief Minimal set of query parameters related to a single package. */
 struct PkgDescriptorBase {
+
   std::optional<std::string> name;    /**< Filter results by exact `name`. */
   std::optional<std::string> pname;   /**< Filter results by exact `pname`. */
   std::optional<std::string> version; /**< Filter results by exact version. */
   std::optional<std::string> semver;  /**< Filter results by version range. */
 
+
+  /* Base struct boilerplate */
+  PkgDescriptorBase()                             = default;
+  PkgDescriptorBase( const PkgDescriptorBase &  ) = default;
+  PkgDescriptorBase(       PkgDescriptorBase && ) = default;
+
+  virtual ~PkgDescriptorBase() = default;
+
+  PkgDescriptorBase & operator=( const PkgDescriptorBase &  ) = default;
+  PkgDescriptorBase & operator=(       PkgDescriptorBase && ) = default;
+
   /** @brief Reset to default state. */
   virtual void clear();
-};
+
+
+};  /* End struct `PkgDescriptorBase' */
+
 
 /**
  * @fn void from_json( const nlohmann::json & j, PkgDescriptorBase & pdb )
@@ -157,7 +172,7 @@ struct PkgQueryArgs : public PkgDescriptorBase {
 
 
   /** @brief Reset argset to its _default_ state. */
-  virtual void clear() override;
+  void clear() override;
 
   /**
    * @brief Sanity check parameters.
@@ -314,8 +329,7 @@ class PkgQuery : public PkgQueryArgs {
      * from @a binds before being executed.
      * @return An unbound SQL query string.
      */
-    [[nodiscard]]
-    std::string str() const;
+    [[nodiscard]] std::string str() const;
 
     /**
      * @brief Create a bound SQLite query ready for execution.
@@ -335,6 +349,7 @@ class PkgQuery : public PkgQueryArgs {
      */
     [[nodiscard]]
     std::vector<row_id> execute( sqlite3pp::database & pdb ) const;
+
 
 };  /* End class `PkgQuery' */
 

--- a/include/flox/resolver/command.hh
+++ b/include/flox/resolver/command.hh
@@ -28,7 +28,8 @@ struct ResolveCommand : public pkgdb::PkgDbRegistryMixin {
 
   private:
 
-    ResolveOneParams params;
+    ResolveOneParams       params;  /**< Query arguments and inputs */
+    command::VerboseParser parser;  /**< Query arguments and inputs parser */
 
     /**
      * @brief Add argument to any parser to construct
@@ -45,15 +46,11 @@ struct ResolveCommand : public pkgdb::PkgDbRegistryMixin {
 
   protected:
 
-      [[nodiscard]]
-      virtual RegistryRaw
-    getRegistryRaw() override
-    {
-      return this->params.registry;
-    }
+    [[nodiscard]]
+    RegistryRaw getRegistryRaw() override { return this->params.registry; }
 
       [[nodiscard]]
-      virtual std::vector<std::string> &
+      std::vector<std::string> &
     getSystems() override
     {
       return this->params.systems;
@@ -62,9 +59,9 @@ struct ResolveCommand : public pkgdb::PkgDbRegistryMixin {
 
   public:
 
-    command::VerboseParser parser;
-
     ResolveCommand();
+
+    [[nodiscard]] command::VerboseParser & getParser() { return this->parser; }
 
     /**
      * @brief Execute the `resolve` routine.
@@ -72,6 +69,7 @@ struct ResolveCommand : public pkgdb::PkgDbRegistryMixin {
      * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
      */
     int run();
+
 
 };  /* End struct `ResolveCommand' */
 

--- a/include/flox/resolver/command.hh
+++ b/include/flox/resolver/command.hh
@@ -24,7 +24,7 @@ namespace flox::resolver {
  * @brief Resolve a set of package requirements to a set of
  *        satisfactory installables.
  */
-struct ResolveCommand : public pkgdb::PkgDbRegistryMixin {
+class ResolveCommand : public pkgdb::PkgDbRegistryMixin {
 
   private:
 
@@ -71,7 +71,7 @@ struct ResolveCommand : public pkgdb::PkgDbRegistryMixin {
     int run();
 
 
-};  /* End struct `ResolveCommand' */
+};  /* End class `ResolveCommand' */
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/flox/resolver/command.hh
+++ b/include/flox/resolver/command.hh
@@ -24,7 +24,7 @@ namespace flox::resolver {
  * @brief Resolve a set of package requirements to a set of
  *        satisfactory installables.
  */
-class ResolveCommand : public pkgdb::PkgDbRegistryMixin {
+class ResolveCommand : pkgdb::PkgDbRegistryMixin {
 
   private:
 
@@ -42,9 +42,6 @@ class ResolveCommand : public pkgdb::PkgDbRegistryMixin {
 
     [[nodiscard]]
     PkgDescriptorRaw getQuery() const { return this->params.query; }
-
-
-  protected:
 
     [[nodiscard]]
     RegistryRaw getRegistryRaw() override { return this->params.registry; }

--- a/include/flox/resolver/params.hh
+++ b/include/flox/resolver/params.hh
@@ -91,7 +91,7 @@ struct PkgDescriptorRaw : public pkgdb::PkgDescriptorBase {
 
 
   /** @brief Reset to default state. */
-  virtual void clear() override;
+  void clear() override;
 
   /**
    * @brief Fill a @a flox::pkgdb::PkgQueryArgs struct with preferences to

--- a/include/flox/search/command.hh
+++ b/include/flox/search/command.hh
@@ -55,7 +55,8 @@ class SearchCommand : public pkgdb::PkgDbRegistryMixin, public PkgQueryMixin {
 
   private:
 
-    SearchParams params;
+    SearchParams           params;  /**< Query arguments and inputs */
+    command::VerboseParser parser;  /**< Query arguments and inputs parser */
 
     /**
      * @brief Add argument to any parser to construct
@@ -78,8 +79,6 @@ class SearchCommand : public pkgdb::PkgDbRegistryMixin, public PkgQueryMixin {
 
   public:
 
-    command::VerboseParser parser;
-
     SearchCommand();
 
     /** @brief Display a single row from the given @a input. */
@@ -89,13 +88,16 @@ class SearchCommand : public pkgdb::PkgDbRegistryMixin, public PkgQueryMixin {
       std::cout << input.getRowJSON( row ).dump() << std::endl;
     }
 
+    [[nodiscard]] command::VerboseParser & getParser() { return this->parser; }
+
     /**
      * @brief Execute the `search` routine.
      * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
      */
     int run();
 
-};  /* End struct `ScrapeCommand' */
+
+};  /* End class `ScrapeCommand' */
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/flox/search/command.hh
+++ b/include/flox/search/command.hh
@@ -45,13 +45,14 @@ struct PkgQueryMixin {
    */
   std::vector<pkgdb::row_id> queryDb( pkgdb::PkgDbReadOnly & pdb ) const;
 
+
 };  /* End struct `PkgQueryMixin' */
 
 
 /* -------------------------------------------------------------------------- */
 
 /** @brief Search flakes for packages satisfying a set of filters. */
-class SearchCommand : public pkgdb::PkgDbRegistryMixin, public PkgQueryMixin {
+class SearchCommand : pkgdb::PkgDbRegistryMixin, PkgQueryMixin {
 
   private:
 
@@ -65,15 +66,12 @@ class SearchCommand : public pkgdb::PkgDbRegistryMixin, public PkgQueryMixin {
       argparse::Argument &
     addSearchParamArgs( argparse::ArgumentParser & parser );
 
-
-  protected:
-
       [[nodiscard]]
-      virtual RegistryRaw
+      RegistryRaw
     getRegistryRaw() override { return this->params.registry; }
 
       [[nodiscard]]
-      virtual std::vector<std::string> &
+      std::vector<std::string> &
     getSystems() override { return this->params.systems; }
 
 
@@ -82,7 +80,7 @@ class SearchCommand : public pkgdb::PkgDbRegistryMixin, public PkgQueryMixin {
     SearchCommand();
 
     /** @brief Display a single row from the given @a input. */
-      void
+      static void
     showRow( pkgdb::PkgDbInput & input, pkgdb::row_id row )
     {
       std::cout << input.getRowJSON( row ).dump() << std::endl;

--- a/src/main.cc
+++ b/src/main.cc
@@ -29,16 +29,16 @@ main( int argc, char * argv[] )
   prog.add_description( "CRUD operations for package metadata" );
 
   flox::pkgdb::ScrapeCommand cmdScrape;
-  prog.add_subparser( cmdScrape.parser );
+  prog.add_subparser( cmdScrape.getParser() );
 
   flox::pkgdb::GetCommand cmdGet;
-  prog.add_subparser( cmdGet.parser );
+  prog.add_subparser( cmdGet.getParser() );
 
   flox::pkgdb::ListCommand cmdList;
-  prog.add_subparser( cmdList.parser );
+  prog.add_subparser( cmdList.getParser() );
 
   flox::search::SearchCommand cmdSearch;
-  prog.add_subparser( cmdSearch.parser );
+  prog.add_subparser( cmdSearch.getParser() );
 
   flox::resolver::ResolveCommand cmdResolve;
   prog.add_subparser( cmdResolve.getParser() );

--- a/src/main.cc
+++ b/src/main.cc
@@ -41,7 +41,7 @@ main( int argc, char * argv[] )
   prog.add_subparser( cmdSearch.parser );
 
   flox::resolver::ResolveCommand cmdResolve;
-  prog.add_subparser( cmdResolve.parser );
+  prog.add_subparser( cmdResolve.getParser() );
 
 
   /* Parse Args */


### PR DESCRIPTION
Fixes various `clang-tidy` warnings and normalizes some formatting/docs.

This largely exists to separate _misc_ changes from another draft PR to reduce its diff to _important_ content.