### PR TITLE
Parse Manifest Descriptor fields

### DIFF
--- a/include/flox/core/util.hh
+++ b/include/flox/core/util.hh
@@ -353,6 +353,28 @@ bool hasPrefix( std::string_view prefix, std::string_view str );
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief trim from start ( in place ). */
+std::string & ltrim( std::string & str );
+
+/** @brief trim from end ( in place ). */
+std::string & rtrim( std::string & str );
+
+/** @brief trim from both ends ( in place ). */
+std::string & trim( std::string & str );
+
+
+/** @brief trim from start ( copying ). */
+[[nodiscard]] std::string ltrim_copy( std::string_view str );
+
+/** @brief trim from end ( copying ). */
+[[nodiscard]] std::string rtrim_copy( std::string_view str );
+
+/** @brief trim from both ends ( copying ). */
+[[nodiscard]] std::string trim_copy( std::string_view str );
+
+
+/* -------------------------------------------------------------------------- */
+
 }    /* End namespace `flox' */
 
 

--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -99,10 +99,20 @@ concept pkg_descriptor_typename = std::derived_from<T, PkgDescriptorBase>;
  */
 struct PkgQueryArgs : public PkgDescriptorBase {
 
+  /* From `PkgDescriptorBase':
+   *   std::optional<std::string> name;
+   *   std::optional<std::string> pname;
+   *   std::optional<std::string> version;
+   *   std::optional<std::string> semver;
+   */
+
   /** Filter results by partial match on pname, pkgAttrName, or description */
   std::optional<std::string> partialMatch;
 
-  /** Filter results by an exact match on either `pname` or `pkgAttrName`. To match just `pname` see @a flox::pkgdb::PkgDescriptorBase. */
+  /**
+   * Filter results by an exact match on either `pname` or `pkgAttrName`.
+   * To match just `pname` see @a flox::pkgdb::PkgDescriptorBase.
+   */
   std::optional<std::string> pnameOrPkgAttrName;
 
   /** Filter results to those explicitly marked with the given licenses. */

--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -1,0 +1,180 @@
+/* ========================================================================== *
+ *
+ * @file flox/resolver/descriptor.hh
+ *
+ * @brief A set of user inputs used to set input preferences and query
+ *        parameters during resolution.
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <string>
+#include <functional>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "flox/pkgdb/pkg-query.hh"
+#include "flox/resolver/params.hh"
+#include "flox/registry.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+namespace flox::resolver {
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Extend and remap fields from @a flox::resolver::PkgDescriptorRaw to
+ *        those found in a `flox` _manifest_.
+ *
+ * This _raw_ struct is defined to generate parsers.
+ * The _real_ form is @a flox::resolver::ManifestDescriptor.
+ */
+struct ManifestDescriptorRaw {
+
+  public:
+
+    /** Match `name`, `pname`, or `pkgAttrName` */
+    std::optional<std::string> name;
+
+    /** Match `version` or `semver` if a modifier is present. */
+    std::optional<std::string> version;
+
+    /** Match a catalog stability. */
+    std::optional<std::string> stability;
+
+    /** @brief A dot separated attribut path, or list representation. */
+    using Path = std::variant<std::string, flox::AttrPath>;
+    /** Match a relative path. */
+    std::optional<Path> path;
+
+    /**
+     * @brief A dot separated attribut path, or list representation.
+     *        May contain `null` members to represent _globs_.
+     */
+    using AbsPath = std::variant<std::string, AttrPathGlob>;
+    /** Match an absolute path, allowing globs for `system`. */
+    std::optional<AbsPath> absPath;
+
+    /** Only resolve for a given set of systems. */
+    std::optional<std::vector<std::string>> systems;
+
+    /** Whether resoution is allowed to fail without producing errors. */
+    std::optional<bool> optional;
+
+    /** Named _group_ that the package is a member of. */
+    std::optional<std::string> packageGroup;
+
+    /** Force resolution is a given input or _flake reference_. */
+      std::optional<std::variant<std::string, nix::fetchers::Attrs>>
+    packageRepository;
+
+    /** Relative path to a `nix` expression file to be evaluated. */
+    std::optional<std::string> input;
+
+};
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @fn void from_json( const nlohmann::json        & jfrom
+ *                   ,       ManifestDescriptorRaw & desc
+ *                   )
+ * @brief Convert a JSON object to an @a flox::InputPreferences.
+ *
+ * @fn void to_json( nlohmann::json & jto, const ManifestDescriptorRaw & desc )
+ * @brief Convert an @a flox::resolver::ManifestDescriptorRaw to a JSON object.
+ */
+/* Generate to_json/from_json functions. */
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT( ManifestDescriptorRaw
+                                               , name
+                                               , version
+                                               , stability
+                                               , path
+                                               , absPath
+                                               , systems
+                                               , optional
+                                               , packageGroup
+                                               , packageRepository
+                                               , input
+                                               )
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Extend and remap fields from @a flox::resolver::PkgDescriptorRaw to
+ *        those found in a `flox` _manifest_.
+ */
+struct ManifestDescriptor {
+
+  public:
+
+    /** Match `name`, `pname`, or `pkgAttrName` */
+    std::optional<std::string> name;
+
+    /** Whether resoution is allowed to fail without producing errors. */
+    bool optional = false;
+
+    /** Named _group_ that the package is a member of. */
+    std::optional<std::string> group;
+
+    /** Match `version`. */
+    std::optional<std::string> version;
+
+    /** Match a semantic version range. */
+    std::optional<std::string> semver;
+
+    /** Match a subtree. */
+    std::optional<Subtree> subtree;
+
+    /** Only resolve for a given set of systems. */
+    std::optional<std::vector<std::string>> systems;
+
+    /** Match a catalog stability. */
+    std::optional<std::string> stability;
+
+    /** Match a relative attribute path. */
+    std::optional<flox::AttrPath> path;
+
+    /** Force resolution is a given input, _flake reference_, or file. */
+    std::optional<std::variant<nix::FlakeRef, std::string>> input;
+
+
+    ManifestDescriptor() = default;
+
+    explicit ManifestDescriptor( const ManifestDescriptorRaw & raw );
+
+
+    /** @brief Reset to default state. */
+    void clear();
+
+    /**
+     * @brief Fill a @a flox::pkgdb::PkgQueryArgs struct with preferences to
+     *        lookup packages.
+     *
+     * NOTE: This DOES NOT clear @a pqa before filling it.
+     * This is intended to be used after filling @a pqa with global preferences.
+     * @param pqa A set of query args to _fill_ with preferences.
+     * @return A reference to the modified query args.
+     */
+    pkgdb::PkgQueryArgs & fillPkgQueryArgs( pkgdb::PkgQueryArgs & pqa ) const;
+
+};
+
+
+/* -------------------------------------------------------------------------- */
+
+}  /* End namespaces `flox::resolver' */
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -110,7 +110,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT( ManifestDescriptorRaw
 
 /**
  * @brief Extend and remap fields from @a flox::resolver::PkgDescriptorRaw to
- *        those found in a `flox` _manifest_.
+ *        @a flox::pkgdb::PkgQueryArgs
  */
 struct ManifestDescriptor {
 

--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -76,7 +76,8 @@ struct ManifestDescriptorRaw {
     /** Relative path to a `nix` expression file to be evaluated. */
     std::optional<std::string> input;
 
-};
+
+};  /* End struct `ManifestDescriptorRaw' */
 
 
 /* -------------------------------------------------------------------------- */
@@ -165,7 +166,8 @@ struct ManifestDescriptor {
      */
     pkgdb::PkgQueryArgs & fillPkgQueryArgs( pkgdb::PkgQueryArgs & pqa ) const;
 
-};
+
+};  /* End struct `ManifestDescriptor' */
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/versions.hh
+++ b/include/versions.hh
@@ -53,6 +53,7 @@ bool isCoercibleToSemver( const std::string & version );
  * This is far from a complete check, but it should be sufficient for our usage.
  * This essentially checks that the first token of the string is a valid range,
  * a `4.2.0 - 5.3.1` style range, or a special token.
+ * ( See expanded discussion below for futher details ).
  *
  * Leading and trailing space is ignored.
  *
@@ -60,6 +61,14 @@ bool isCoercibleToSemver( const std::string & version );
  *
  * This will count _the empty string_ ( `""` ), `*`,  `any`, and `latest`
  * as ranges ( aligning with `node-semver` ).
+ *
+ *
+ * Limitations:
+ * This covers the 99% case to distinguish between a range and "static" version.
+ * The main reason to detect this is because from the CLI we can't immediately
+ * tell whether `<NAME>@<VERSION-OR-SEMVER>` is an exact version match
+ * ( like a date ), or a real range.
+ * This does a "best effort" detection which is suitable for our purposes today.
  *
  * @return `true` iff @a version is a valid _semantic version range_ string.
  *

--- a/include/versions.hh
+++ b/include/versions.hh
@@ -45,6 +45,24 @@ bool isDate( const std::string & version );
 /** @return `true` iff @a version can be interpreted as _semantic version_. */
 bool isCoercibleToSemver( const std::string & version );
 
+/**
+ * @return `true` iff @a version is a valid _semantic version range_ string.
+ *
+ * This is far from a complete check, but it should be sufficient for our usage.
+ * This essentially checks that the first token of the string is a valid range,
+ * a `4.2.0 - 5.3.1` style range, or a special token.
+ *
+ * Leading and trailing space is ignored.
+ *
+ * This will count _exact version matches_ such as `4.2.0` as _ranges_.
+ *
+ * This will count _the empty string_ ( `""` ), `*`,  `any`, and `latest`
+ * as ranges ( aligning with `node-semver` ).
+ *
+ * @see flox::resolver::ManifestDescriptor::semver
+ */
+bool isSemverRange( const std::string & version );
+
 
 /* -------------------------------------------------------------------------- */
 

--- a/include/versions.hh
+++ b/include/versions.hh
@@ -19,12 +19,14 @@
 
 /* -------------------------------------------------------------------------- */
 
-/** Interfaces for analyzing version numbers */
+/** @brief Interfaces for analyzing version numbers. */
 namespace versions {
 
 /* -------------------------------------------------------------------------- */
 
-/** Typed exception wrapper used for version parsing/comparison errors. */
+/**
+ * @brief Typed exception wrapper used for version parsing/comparison errors.
+ */
 class VersionException : public std::exception {
   private:
     std::string msg;
@@ -69,8 +71,9 @@ bool isSemverRange( const std::string & version );
 /* -------------------------------------------------------------------------- */
 
 /**
- * Attempt to coerce strings such as `"v1.0.2"` or `1.0` to valid semantic
- * version strings.
+ * @brief Attempt to coerce strings such as `"v1.0.2"` or `1.0` to valid
+ *        semantic version strings.
+ *
  * @return `std::nullopt` iff @a version cannot be interpreted as
  *          _semantic version_.
  *          A valid semantic version string otherwise.
@@ -81,14 +84,16 @@ std::optional<std::string> coerceSemver( std::string_view version );
 /* -------------------------------------------------------------------------- */
 
 /**
- * Invokes `node-semver` by `exec`.
+ * @brief Invokes `node-semver` by `exec`.
+ *
  * @param args List of arguments to pass to `semver` executable.
  * @return Pair of error-code and output string.
  */
 std::pair<int, std::string> runSemver( const std::list<std::string> & args );
 
 /**
- * Filter a list of versions by a `node-semver` _semantic version range_.
+ * @brief Filter a list of versions by a `node-semver` _semantic version range_.
+ *
  * @param range A _semantic version range_ as taken by `node-semver`.
  * @param versions A list of _semantic versions_ to filter.
  * @return The list of _semantic versions_ from @a versions which fall in the

--- a/include/versions.hh
+++ b/include/versions.hh
@@ -46,7 +46,7 @@ bool isDate( const std::string & version );
 bool isCoercibleToSemver( const std::string & version );
 
 /**
- * @return `true` iff @a version is a valid _semantic version range_ string.
+ * @brief Determine if @a version is a valid _semantic version range_ string.
  *
  * This is far from a complete check, but it should be sufficient for our usage.
  * This essentially checks that the first token of the string is a valid range,
@@ -58,6 +58,8 @@ bool isCoercibleToSemver( const std::string & version );
  *
  * This will count _the empty string_ ( `""` ), `*`,  `any`, and `latest`
  * as ranges ( aligning with `node-semver` ).
+ *
+ * @return `true` iff @a version is a valid _semantic version range_ string.
  *
  * @see flox::resolver::ManifestDescriptor::semver
  */

--- a/src/resolver/descriptor.cc
+++ b/src/resolver/descriptor.cc
@@ -1,0 +1,364 @@
+/* ========================================================================== *
+ *
+ * @file resolver/descriptor.cc
+ *
+ * @brief A set of user inputs used to set input preferences and query
+ *        parameters during resolution.
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#include <regex>
+#include "versions.hh"
+#include "flox/resolver/descriptor.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+namespace flox::resolver {
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Sets either `version` or `semver` on
+ *        a `flox::resolver::ManifestDescriptor`.
+ *
+ * Distinguishes between semver ranges and exact version matchers.
+ * @param desc The descriptor to initialize.
+ * @param version The version description to parse.
+ */
+  static void
+initManifestDescriptorVersion(       ManifestDescriptor & desc
+                             , const std::string        & version
+                             )
+{
+  switch ( version.at( 0 ) )
+    {
+      case '=':
+        desc.version = version.substr( 1 );
+        break;
+
+      case '*':
+      case '~':
+      case '^':
+      case '>':
+      case '<':
+        desc.semver = version;
+        break;
+
+      default:
+        /* If it's a valid semver, then it's not a range. */
+        if ( versions::isSemver( version ) )
+          {
+            desc.version = version;
+          }
+        else /* Otherwise, assume a range. */
+          {
+            desc.semver = version;
+          }
+        break;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Get a `flox::resolver::AttrPathGlob` from a string if necessary. */
+  static AttrPathGlob
+maybeSplitAttrPathGlob( const ManifestDescriptorRaw::AbsPath & absPath )
+{
+  if ( std::holds_alternative<AttrPathGlob>( absPath ) )
+    {
+      return std::get<AttrPathGlob>( absPath );
+    }
+  AttrPathGlob   glob;
+  flox::AttrPath path = splitAttrPath( std::get<std::string>( absPath ) );
+  size_t         idx  = 0;
+  for ( const auto & part : path )
+    {
+      /* Treat `null' or `*' in the second element as a glob. */
+      if ( ( idx == 1 ) && ( ( part == "null" ) || ( part == "*" ) ) )
+        {
+          glob.emplace_back( std::nullopt );
+        }
+      else
+        {
+          glob.emplace_back( part );
+        }
+      ++idx;
+    }
+  return glob;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Sets various fields on a `flox::resolver::ManifestDescriptor`
+ *        based on the `absPath` field.
+ * @param desc The descriptor to initialize.
+ * @param raw The raw description to parse.
+ */
+  static void
+initManifestDescriptorAbsPath(       ManifestDescriptor    & desc
+                             , const ManifestDescriptorRaw & raw
+                             )
+{
+  if ( ! raw.absPath.has_value() )
+    {
+      throw std::runtime_error(
+        "`absPath' must be set when calling "
+        "`flox::resolver::ManifestDescriptor::initManifestDescriptorAbsPath'"
+       );
+    }
+
+  /* You might need to parse a globbed attr path, so handle that first. */
+  AttrPathGlob glob = maybeSplitAttrPathGlob( * raw.absPath );
+
+  if ( glob.size() < 3 )
+    {
+      throw std::runtime_error(
+        "`absPath' must have at least three parts"
+      );
+    }
+
+  const auto & first = glob.front();
+  if ( ! first.has_value() )
+    {
+      throw std::runtime_error(
+        "`absPath' may only have a glob as its second element"
+      );
+    }
+  desc.subtree = Subtree( * first );
+
+  if ( raw.stability.has_value() && ( first.value() != "catalog" ) )
+    {
+      throw std::runtime_error(
+        "`stability' cannot be used with non-catalog paths"
+      );
+    }
+
+  if ( first.value() == "catalog" )
+    {
+      if ( glob.size() < 4 )
+        {
+          throw std::runtime_error(
+            "`absPath' must have at least four parts for catalog paths"
+          );
+        }
+      const auto & third = glob.at( 2 );
+      if ( ! third.has_value() )
+        {
+          throw std::runtime_error(
+            "`absPath' may only have a glob as its second element"
+          );
+        }
+      desc.stability = * third;
+      desc.path      = AttrPath {};
+      for ( auto itr = glob.begin() + 3; itr != glob.end(); ++itr )
+        {
+          const auto & elem = * itr;
+          if ( ! elem.has_value() )
+            {
+              throw std::runtime_error(
+                "`absPath' may only have a glob as its second element"
+              );
+            }
+          desc.path->emplace_back( * elem );
+        }
+    }
+  else
+    {
+      desc.path = AttrPath {};
+      for ( auto itr = glob.begin() + 2; itr != glob.end(); ++itr )
+        {
+          const auto & elem = * itr;
+          if ( ! elem.has_value() )
+            {
+              throw std::runtime_error(
+                "`absPath' may only have a glob as its second element"
+              );
+            }
+          desc.path->emplace_back( * elem );
+        }
+    }
+
+  const auto & second = glob.at( 1 );
+  if ( second.has_value() )
+    {
+      desc.systems = std::vector<std::string> { * second };
+      if ( raw.systems.has_value() && ( * raw.systems != * desc.systems ) )
+        {
+          throw std::runtime_error(
+            "`systems' list conflicts with `absPath' system specification"
+          );
+        }
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+ManifestDescriptor::ManifestDescriptor( const ManifestDescriptorRaw & raw )
+  : name( raw.name )
+  , optional( raw.optional )
+  , group( raw.packageGroup )
+{
+  /* Determine if `version' was a range or not.
+   * NOTE: The string "4.2.0" is not a range, but "4.2" is!
+   *       If you want to explicitly match the `version` field with "4.2" then
+   *       you need to use "=4.2". */
+  if ( raw.version.has_value() )
+    {
+      initManifestDescriptorVersion( * this, * raw.version );
+    }
+
+  /* You have to split `absPath' before doing most other fields. */
+  if ( raw.absPath.has_value() )
+    {
+      initManifestDescriptorAbsPath( * this, raw );
+    }
+  else if ( raw.stability.has_value() )
+    {
+      this->subtree   = Subtree( "catalog" );
+      this->stability = raw.stability;
+    }
+
+  /* Only set if it wasn't handled by `absPath`. */
+  if ( ( ! this->systems.has_value() ) && raw.systems.has_value() )
+    {
+      this->systems = * raw.systems;
+    }
+
+  if ( raw.path.has_value() )
+    {
+      /* Split relative path */
+      flox::AttrPath path;
+      if ( std::holds_alternative<std::string>( * raw.path ) )
+        {
+          path = splitAttrPath( std::get<std::string>( * raw.path ) );
+        }
+      else
+        {
+          path = std::get<AttrPath>( * raw.path );
+        }
+
+      if ( this->path.has_value() )
+        {
+          if ( this->path != path )
+            {
+              throw std::runtime_error(
+                  "`path' conflicts with with `absPath'"
+              );
+            }
+        }
+      else
+        {
+          this->path = path;
+        }
+    }
+
+  if ( raw.packageRepository.has_value() )
+    {
+      if ( raw.input.has_value() )
+        {
+          throw std::runtime_error(
+            "`packageRepository' may not be used with `input'"
+          );
+        }
+
+      if ( std::holds_alternative<std::string>( * raw.packageRepository ) )
+        {
+          this->input =
+            parseFlakeRef( std::get<std::string>( * raw.packageRepository ) );
+        }
+      else
+        {
+          this->input = nix::FlakeRef::fromAttrs(
+            std::get<nix::fetchers::Attrs>( * raw.packageRepository )
+          );
+        }
+      assert( std::holds_alternative<nix::FlakeRef>( * this->input ) );
+    }
+  else if ( raw.input.has_value() )
+    {
+      this->input = * raw.input;
+    }
+
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+  void
+ManifestDescriptor::clear()
+{
+  this->name      = std::nullopt;
+  this->optional  = false;
+  this->group     = std::nullopt;
+  this->version   = std::nullopt;
+  this->semver    = std::nullopt;
+  this->subtree   = std::nullopt;
+  this->systems   = std::nullopt;
+  this->stability = std::nullopt;
+  this->path      = std::nullopt;
+  this->input     = std::nullopt;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+  pkgdb::PkgQueryArgs &
+ManifestDescriptor::fillPkgQueryArgs( pkgdb::PkgQueryArgs & pqa ) const
+{
+  /* Must exactly match either `pname' or `pkgAttrName'. */
+  if ( this->name.has_value() )
+    {
+      pqa.pnameOrPkgAttrName = * this->name;
+    }
+
+  if ( this->version.has_value() )
+    {
+      pqa.version = * this->version;
+    }
+  else if ( this->semver.has_value() )
+    {
+      pqa.semver = * this->semver;
+      /* Use `preferPreRelease' on `~<VERSION>-<TAG>' ranges. */
+      if ( this->semver->at( 0 ) == '~' )
+        {
+          pqa.preferPreReleases = std::regex_match(
+            * this->semver
+          , std::regex( "~[^ ]+-.*", std::regex::ECMAScript )
+          );
+        }
+    }
+
+  if ( this->subtree.has_value() )
+    {
+      pqa.subtrees = std::vector<Subtree> { * this->subtree };
+    }
+
+  if ( this->systems.has_value() ) { pqa.systems = * this->systems; }
+
+  if ( this->stability.has_value() )
+    {
+      pqa.stabilities = std::vector<std::string> { * this->stability };
+    }
+
+  pqa.relPath = this->path;
+
+  return pqa;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+}  /* End namespaces `flox::resolver' */
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/src/resolver/descriptor.cc
+++ b/src/resolver/descriptor.cc
@@ -92,8 +92,9 @@ maybeSplitAttrPathGlob( const ManifestDescriptorRaw::AbsPath & absPath )
   size_t         idx  = 0;
   for ( const auto & part : path )
     {
-      /* Treat `null' or `*' in the second element as a glob. */
-      if ( ( idx == 1 ) && ( ( part == "null" ) || ( part == "*" ) ) )
+      /* Treat `null' or `*' as a glob. */
+      /* TODO we verify that only the second option is a glob elsewhere, but we could do that here instead */
+      if ( ( ( part == "null" ) || ( part == "*" ) ) )
         {
           glob.emplace_back( std::nullopt );
         }

--- a/src/util.cc
+++ b/src/util.cc
@@ -179,11 +179,69 @@ isUInt( std::string_view str )
 hasPrefix( std::string_view prefix, std::string_view str )
 {
   if ( str.size() < prefix.size() ) { return false; }
-  for ( size_t i = 0; i < prefix.size(); ++i )
-    {
-      if ( str[i] != prefix[i] ) { return false; }
-    }
-  return true;
+  return str.find( prefix ) == 0;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+  std::string &
+ltrim( std::string & str )
+{
+  str.erase(
+    str.begin()
+  , std::find_if( str.begin()
+                , str.end()
+                , []( unsigned char chr ) { return ! std::isspace( chr ); }
+                )
+  );
+  return str;
+}
+
+  std::string &
+rtrim( std::string & str )
+{
+  str.erase(
+    std::find_if( str.rbegin()
+                , str.rend()
+                , []( unsigned char chr ) { return ! std::isspace( chr ); }
+                ).base()
+  , str.end()
+  );
+  return str;
+}
+
+  std::string &
+trim( std::string & str )
+{
+  rtrim( str );
+  ltrim( str );
+  return str;
+}
+
+
+  std::string
+ltrim_copy( std::string_view str )
+{
+  std::string rsl( str );
+  ltrim( rsl );
+  return rsl;
+}
+
+  std::string
+rtrim_copy( std::string_view str )
+{
+  std::string rsl( str );
+  rtrim( rsl );
+  return rsl;
+}
+
+  std::string
+trim_copy( std::string_view str )
+{
+  std::string rsl( str );
+  trim( rsl );
+  return rsl;
 }
 
 

--- a/tests/data/manifest/manifest0.toml
+++ b/tests/data/manifest/manifest0.toml
@@ -24,7 +24,7 @@
     # Resolve this to "packages" or equivalent which is
     # isolated to its own closure and added to PATH only.
     [install.charasay]
-    semver = "^12.2"
+    version = "^12.2"
 
 
     # 3. If someone's a bit picky they might want to request a specific version:

--- a/tests/data/manifest/manifest0.yaml
+++ b/tests/data/manifest/manifest0.yaml
@@ -78,7 +78,7 @@ install:
   # Resolve this to "packages" or equivalent which is
   # isolated to its own closure and added to PATH only.
   charasay:
-    semver: ^2
+    version: ^2
 
   # 3. If someone's a bit picky they might want to request a specific version:
   # Resolve this to "packages" or equivalent which is isolated

--- a/tests/manifest.cc
+++ b/tests/manifest.cc
@@ -70,7 +70,7 @@ test_parseManifestDescriptor0()
 
   flox::resolver::ManifestDescriptorRaw raw = R"( {
     "name": "foo"
-  , "version": "1.2.3"
+  , "version": "4.2.0"
   , "optional": true
   , "packageGroup": "blue"
   , "packageRepository": "nixpkgs"
@@ -79,7 +79,12 @@ test_parseManifestDescriptor0()
   flox::resolver::ManifestDescriptor descriptor( raw );
 
   EXPECT_EQ( * descriptor.name, "foo" );
-  EXPECT_EQ( * descriptor.version, "1.2.3" );
+
+  /* Ensure this string was detected as an _exact_ version match. */
+  EXPECT( ! descriptor.semver.has_value() );
+  EXPECT( descriptor.version.has_value() );
+  EXPECT_EQ( * descriptor.version, "4.2.0" );
+
   EXPECT_EQ( * descriptor.group, "blue" );
   EXPECT_EQ( descriptor.optional, true );
 
@@ -99,6 +104,52 @@ test_parseManifestDescriptor0()
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief Test descriptor parsing of semver ranges and version matches. */
+  bool
+test_parseManifestDescriptor1()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "name": "foo"
+  , "version": "^4.2.0"
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  /* Expect detection of semver range. */
+  EXPECT( ! descriptor.version.has_value() );
+  EXPECT( descriptor.semver.has_value() );
+  EXPECT_EQ( * descriptor.semver, "^4.2.0" );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test descriptor parsing of semver ranges and version matches. */
+  bool
+test_parseManifestDescriptor2()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "name": "foo"
+  , "version": "4.2"
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  /* Expect detection of semver range. */
+  EXPECT( ! descriptor.version.has_value() );
+  EXPECT( descriptor.semver.has_value() );
+  EXPECT_EQ( * descriptor.semver, "4.2" );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
   int
 main()
 {
@@ -110,6 +161,8 @@ main()
   RUN_TEST( yamlToJSON0 );
 
   RUN_TEST( parseManifestDescriptor0 );
+  RUN_TEST( parseManifestDescriptor1 );
+  RUN_TEST( parseManifestDescriptor2 );
 
   return ec;
 }

--- a/tests/manifest.cc
+++ b/tests/manifest.cc
@@ -106,7 +106,7 @@ test_parseManifestDescriptor0()
 
 /** @brief Test descriptor parsing of semver ranges and version matches. */
   bool
-test_parseManifestDescriptor1()
+test_parseManifestDescriptor_version0()
 {
 
   flox::resolver::ManifestDescriptorRaw raw = R"( {
@@ -129,7 +129,7 @@ test_parseManifestDescriptor1()
 
 /** @brief Test descriptor parsing of semver ranges and version matches. */
   bool
-test_parseManifestDescriptor2()
+test_parseManifestDescriptor_version1()
 {
 
   flox::resolver::ManifestDescriptorRaw raw = R"( {
@@ -150,6 +150,222 @@ test_parseManifestDescriptor2()
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief Test descriptor parsing of semver ranges and version matches. */
+  bool
+test_parseManifestDescriptor_version2()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "name": "foo"
+  , "version": "=4.2"
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  /* Expect detection of exact version match.
+   * Ensure the leading `=` is stripped. */
+  EXPECT( ! descriptor.semver.has_value() );
+  EXPECT( descriptor.version.has_value() );
+  EXPECT_EQ( * descriptor.version, "4.2" );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test descriptor parsing of semver ranges and version matches. */
+  bool
+test_parseManifestDescriptor_version3()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "name": "foo"
+  , "version": ""
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  /* Expect detection glob/_any_ version match. */
+  EXPECT( descriptor.semver.has_value() );
+  EXPECT( ! descriptor.version.has_value() );
+  EXPECT_EQ( * descriptor.semver, "" );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test descriptor parsing inline inputs. */
+  bool
+test_parseManifestDescriptor_input0()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "name": "foo"
+  , "packageRepository": {
+      "type": "github"
+    , "owner": "NixOS"
+    , "repo": "nixpkgs"
+    }
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  EXPECT( descriptor.input.has_value() );
+  EXPECT( std::holds_alternative<nix::FlakeRef>( * descriptor.input ) );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test descriptor parsing inline inputs. */
+  bool
+test_parseManifestDescriptor_input1()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "name": "foo"
+  , "input": "./pkgs/foo/default.nix"
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  EXPECT( descriptor.input.has_value() );
+  EXPECT( std::holds_alternative<std::string>( * descriptor.input ) );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test descriptor `path`/`absPath` parsing. */
+  bool
+test_parseManifestDescriptor_path0()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "absPath": "legacyPackages.null.hello"
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  EXPECT( descriptor.subtree.has_value() );
+  EXPECT_EQ( * descriptor.subtree, flox::ST_LEGACY );
+  EXPECT( ! descriptor.systems.has_value() );
+  EXPECT( ! descriptor.stability.has_value() );
+  EXPECT( descriptor.path.has_value() );
+  EXPECT( ( * descriptor.path ) == ( flox::AttrPath { "hello" } ) );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test descriptor `path`/`absPath` parsing. */
+  bool
+test_parseManifestDescriptor_path1()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "absPath": "legacyPackages.*.hello"
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  EXPECT( descriptor.subtree.has_value() );
+  EXPECT_EQ( * descriptor.subtree, flox::ST_LEGACY );
+  EXPECT( ! descriptor.systems.has_value() );
+  EXPECT( ! descriptor.stability.has_value() );
+  EXPECT( descriptor.path.has_value() );
+  EXPECT( ( * descriptor.path ) == ( flox::AttrPath { "hello" } ) );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test descriptor `path`/`absPath` parsing. */
+  bool
+test_parseManifestDescriptor_path2()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "absPath": ["legacyPackages", null, "hello"]
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  EXPECT( descriptor.subtree.has_value() );
+  EXPECT_EQ( * descriptor.subtree, flox::ST_LEGACY );
+  EXPECT( ! descriptor.systems.has_value() );
+  EXPECT( ! descriptor.stability.has_value() );
+  EXPECT( descriptor.path.has_value() );
+  EXPECT( ( * descriptor.path ) == ( flox::AttrPath { "hello" } ) );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test descriptor `path`/`absPath` parsing. */
+  bool
+test_parseManifestDescriptor_path3()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "absPath": ["legacyPackages", "*", "hello"]
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  EXPECT( descriptor.subtree.has_value() );
+  EXPECT_EQ( * descriptor.subtree, flox::ST_LEGACY );
+  EXPECT( ! descriptor.systems.has_value() );
+  EXPECT( ! descriptor.stability.has_value() );
+  EXPECT( descriptor.path.has_value() );
+  EXPECT( ( * descriptor.path ) == ( flox::AttrPath { "hello" } ) );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test descriptor `path`/`absPath` parsing. */
+  bool
+test_parseManifestDescriptor_path4()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "absPath": ["legacyPackages", "x86_64-linux", "hello"]
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  EXPECT( descriptor.subtree.has_value() );
+  EXPECT_EQ( * descriptor.subtree, flox::ST_LEGACY );
+  EXPECT( descriptor.systems.has_value() );
+  EXPECT( ( * descriptor.systems ) ==
+          ( std::vector<std::string> { "x86_64-linux" } )
+        );
+  EXPECT( ! descriptor.stability.has_value() );
+  EXPECT( descriptor.path.has_value() );
+  EXPECT( ( * descriptor.path ) == ( flox::AttrPath { "hello" } ) );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
   int
 main()
 {
@@ -161,8 +377,22 @@ main()
   RUN_TEST( yamlToJSON0 );
 
   RUN_TEST( parseManifestDescriptor0 );
-  RUN_TEST( parseManifestDescriptor1 );
-  RUN_TEST( parseManifestDescriptor2 );
+
+  RUN_TEST( parseManifestDescriptor_version0 );
+  RUN_TEST( parseManifestDescriptor_version1 );
+  RUN_TEST( parseManifestDescriptor_version2 );
+  RUN_TEST( parseManifestDescriptor_version3 );
+
+  RUN_TEST( parseManifestDescriptor_input0 );
+  RUN_TEST( parseManifestDescriptor_input1 );
+
+  RUN_TEST( parseManifestDescriptor_path0 );
+  RUN_TEST( parseManifestDescriptor_path1 );
+  RUN_TEST( parseManifestDescriptor_path2 );
+  RUN_TEST( parseManifestDescriptor_path3 );
+  RUN_TEST( parseManifestDescriptor_path4 );
+
+  // TODO: test stability absPath
 
   return ec;
 }

--- a/tests/manifest.cc
+++ b/tests/manifest.cc
@@ -366,6 +366,34 @@ test_parseManifestDescriptor_path4()
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief Test descriptor `path`/`absPath` parsing. */
+  bool
+test_parseManifestDescriptor_path5()
+{
+
+  flox::resolver::ManifestDescriptorRaw raw = R"( {
+    "absPath": ["catalog", "x86_64-linux", "stable", "hello", "4.2.0"]
+  } )"_json;
+
+  flox::resolver::ManifestDescriptor descriptor( raw );
+
+  EXPECT( descriptor.subtree.has_value() );
+  EXPECT_EQ( * descriptor.subtree, flox::ST_CATALOG );
+  EXPECT( descriptor.systems.has_value() );
+  EXPECT( ( * descriptor.systems ) ==
+          ( std::vector<std::string> { "x86_64-linux" } )
+        );
+  EXPECT( descriptor.stability.has_value() );
+  EXPECT_EQ( * descriptor.stability, "stable" );
+  EXPECT( descriptor.path.has_value() );
+  EXPECT( ( * descriptor.path ) == ( flox::AttrPath { "hello", "4.2.0" } ) );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
   int
 main()
 {
@@ -391,8 +419,7 @@ main()
   RUN_TEST( parseManifestDescriptor_path2 );
   RUN_TEST( parseManifestDescriptor_path3 );
   RUN_TEST( parseManifestDescriptor_path4 );
-
-  // TODO: test stability absPath
+  RUN_TEST( parseManifestDescriptor_path5 );
 
   return ec;
 }

--- a/tests/manifest.cc
+++ b/tests/manifest.cc
@@ -78,6 +78,7 @@ test_parseManifestDescriptor0()
 
   flox::resolver::ManifestDescriptor descriptor( raw );
 
+  EXPECT( descriptor.name.has_value() );
   EXPECT_EQ( * descriptor.name, "foo" );
 
   /* Ensure this string was detected as an _exact_ version match. */
@@ -85,10 +86,12 @@ test_parseManifestDescriptor0()
   EXPECT( descriptor.version.has_value() );
   EXPECT_EQ( * descriptor.version, "4.2.0" );
 
+  EXPECT( descriptor.group.has_value() );
   EXPECT_EQ( * descriptor.group, "blue" );
   EXPECT_EQ( descriptor.optional, true );
 
   /* We expect this to be recognized as an _indirect flake reference_. */
+  EXPECT( descriptor.input.has_value() );
   EXPECT( std::holds_alternative<nix::FlakeRef>( * descriptor.input ) );
   auto flakeRef = std::get<nix::FlakeRef>( * descriptor.input );
 
@@ -397,8 +400,9 @@ test_parseManifestDescriptor_path5()
   int
 main()
 {
-  int ec = EXIT_SUCCESS;
-# define RUN_TEST( ... )  _RUN_TEST( ec, __VA_ARGS__ )
+  int exitCode = EXIT_SUCCESS;
+  //NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+# define RUN_TEST( ... )  _RUN_TEST( exitCode, __VA_ARGS__ )
 
   RUN_TEST( tomlToJSON0 );
 
@@ -421,7 +425,7 @@ main()
   RUN_TEST( parseManifestDescriptor_path4 );
   RUN_TEST( parseManifestDescriptor_path5 );
 
-  return ec;
+  return exitCode;
 }
 
 

--- a/tests/test.hh
+++ b/tests/test.hh
@@ -39,7 +39,7 @@ static const size_t fullPkgCount     = 64040;
 
 /* -------------------------------------------------------------------------- */
 
-/** Wrap a test function pretty printing its name on failure. */
+/** @brief Wrap a test function pretty printing its name on failure. */
 template <typename F, typename ... Args>
   static int
 runTest( std::string_view name, F f, Args && ... args )
@@ -64,8 +64,9 @@ runTest( std::string_view name, F f, Args && ... args )
 /* -------------------------------------------------------------------------- */
 
 /**
- * Wrap a test routine which returns an exit code, and set a provided variable
- * to the resulting code on failure.
+ * @brief Wrap a test routine which returns an exit code, and set a provided
+ *        variable to the resulting code on failure.
+ *
  * This pattern allows early tests to still run later ones, while preserving
  * a "global" exit status.
  * 
@@ -73,20 +74,21 @@ runTest( std::string_view name, F f, Args && ... args )
  * "must specify at least one argument for '...' parameter of variadic macro"
  * https://github.com/llvm/llvm-project/issues/50951
  */
-#define _RUN_TEST( _EXIT_CODE, _NAME, ... )                     \
-  {                                                             \
-    int exitCode = runTest(             ( # _NAME )             \
-                      ,             ( test_ ## _NAME )          \
-          __VA_OPT__( , ) __VA_ARGS__                           \
-                      );                                        \
-    if ( exitCode != EXIT_SUCCESS ) { _EXIT_CODE = exitCode; }  \
+#define _RUN_TEST( _EXIT_CODE, _NAME, ... )                       \
+  {                                                               \
+    int _exitCode = runTest(             ( # _NAME )              \
+                       ,             ( test_ ## _NAME )           \
+           __VA_OPT__( , ) __VA_ARGS__                            \
+                       );                                         \
+    if ( _exitCode != EXIT_SUCCESS ) { _EXIT_CODE = _exitCode; }  \
   }
 
 
 /* -------------------------------------------------------------------------- */
 
 /**
- * For use inside of a function which returns a boolean.
+ * @brief For use inside of a function which returns a boolean.
+ *
  * Assert that and expression is `true', otherwise print it and return `false'.
  */
 #define EXPECT( EXPR )                      \
@@ -100,7 +102,8 @@ runTest( std::string_view name, F f, Args && ... args )
 
 
 /**
- * For use inside of a function which returns a boolean.
+ * @brief For use inside of a function which returns a boolean.
+ *
  * Assert that two expressions produce equal results, otherwise print them and
  * return `false'.
  */

--- a/tests/util.cc
+++ b/tests/util.cc
@@ -215,6 +215,18 @@ test_variantJSON3()
 
 /* -------------------------------------------------------------------------- */
 
+  bool
+test_hasPrefix0()
+{
+  EXPECT( flox::hasPrefix( "foo", "foobar" ) );
+  EXPECT( ! flox::hasPrefix( "bar", "foobar" ) );
+  EXPECT( ! flox::hasPrefix( "foobar", "foo" ) );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
   int
 main()
 {
@@ -233,6 +245,8 @@ main()
   RUN_TEST( variantJSON1 );
   RUN_TEST( variantJSON2 );
   RUN_TEST( variantJSON3 );
+
+  RUN_TEST( hasPrefix0 );
 
   return ec;
 }

--- a/tests/versions.cc
+++ b/tests/versions.cc
@@ -38,7 +38,7 @@ test_isSemver0()
 
 /* -------------------------------------------------------------------------- */
 
-/* Must be `%Y-%m-%d` or `%m-%d-%Y` and may contain trailing characters. */
+/** @brief `%Y-%m-%d` or `%m-%d-%Y` but may contain trailing characters. */
   bool
 test_isDate0()
 {
@@ -60,6 +60,30 @@ test_isDate0()
 
 /* -------------------------------------------------------------------------- */
 
+  bool
+test_isSemverRange0()
+{
+  EXPECT( versions::isSemverRange( "^4.2.0" ) );
+  EXPECT( versions::isSemverRange( "4.2.0" ) );
+  EXPECT( versions::isSemverRange( "4.2" ) );
+  EXPECT( versions::isSemverRange( "4 - 5" ) );
+
+  EXPECT( ! versions::isSemverRange( "howdy" ) );
+  EXPECT( ! versions::isSemverRange( "howdy ^4.2.0" ) );
+
+  /* Globs/special */
+  EXPECT( versions::isSemverRange( "" ) );
+  EXPECT( versions::isSemverRange( "*" ) );
+  EXPECT( versions::isSemverRange( "latest" ) );
+  EXPECT( versions::isSemverRange( "any" ) );
+  EXPECT( versions::isSemverRange( " * " ) );
+
+  return  true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
   int
 main()
 {
@@ -69,6 +93,7 @@ main()
   RUN_TEST( semverSat1 );
   RUN_TEST( isSemver0 );
   RUN_TEST( isDate0 );
+  RUN_TEST( isSemverRange0 );
 
   return ec;
 }


### PR DESCRIPTION
This covers parsing for manifest _descriptors_, being entries under `installs.<ID> = <DESCRIPTOR>`.