### PR TITLE
feat: add RegistryFileMixin

### DIFF
--- a/include/flox/core/command.hh
+++ b/include/flox/core/command.hh
@@ -121,6 +121,45 @@ struct AttrPathMixin {
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief Extend a command state blob with registry inputs loaded from "path". */
+struct RegistryFileMixin {
+
+  std::optional<std::filesystem::path> registryPath;
+  std::optional<RegistryRaw> registryRaw;
+
+  protected:
+    /**
+     * @brief Loads the registry.
+     * 
+     * Requires that the registry file is already set.
+     * 
+     */
+    void loadRegistry();
+
+  public:
+
+    /**
+     * @brief Sets the path to the registry file to load.
+     *
+     */
+    argparse::Argument & addRegistryFileArg( argparse::ArgumentParser & parser );
+
+    /**
+     * @brief Sets the path to the registry file.
+     * 
+     */
+    void setRegistryPath(const std::filesystem::path & path);
+
+    /**
+     * @brief Returns the @a RegistryRaw from the provided file path.
+     * 
+     */
+    const RegistryRaw & getRegistryRaw();
+
+};  /* End struct `RegistryFileMixin' */
+
+/* -------------------------------------------------------------------------- */
+
 }  /* End namespaces `flox::command' */
 
 

--- a/src/command.cc
+++ b/src/command.cc
@@ -220,6 +220,10 @@ RegistryFileMixin::addRegistryFileArg( argparse::ArgumentParser & parser )
   void
 RegistryFileMixin::setRegistryPath(const std::filesystem::path & path)
 {
+  if ( path.empty() )
+    {
+      throw FloxException( "provided registry path is empty" );
+    }
   this->registryPath = path;
 }
 

--- a/tests/data/registry/registry0.json
+++ b/tests/data/registry/registry0.json
@@ -1,0 +1,51 @@
+{
+    "inputs": {
+        "nixpkgs": {
+            "from": {
+                "type": "github",
+                "owner": "NixOS",
+                "repo": "nixpkgs",
+                "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+            },
+            "subtrees": [
+                "legacyPackages"
+            ]
+        },
+        "floco": {
+            "from": {
+                "type": "github",
+                "owner": "aakropotkin",
+                "repo": "floco",
+                "rev": "1e84b4b16bba5746e1195fa3a4d8addaaf2d9ef4"
+            },
+            "subtrees": [
+                "packages"
+            ]
+        },
+        "nixpkgs-flox": {
+            "from": {
+                "type": "github",
+                "owner": "flox",
+                "repo": "nixpkgs-flox",
+                "rev": "feb593b6844a96dd4e17497edaabac009be05709"
+            },
+            "subtrees": [
+                "catalog"
+            ],
+            "stabilities": [
+                "stable"
+            ]
+        }
+    },
+    "defaults": {
+        "subtrees": null,
+        "stabilities": [
+            "stable"
+        ]
+    },
+    "priority": [
+        "nixpkgs",
+        "floco",
+        "nixpkgs-flox"
+    ]
+}

--- a/tests/registry.cc
+++ b/tests/registry.cc
@@ -14,6 +14,7 @@
 #include <nlohmann/json.hpp>
 
 #include "flox/registry.hh"
+#include "flox/core/command.hh"
 #include "test.hh"
 
 
@@ -52,6 +53,61 @@ test_FloxFlakeInputRegistry0()
 
 /* -------------------------------------------------------------------------- */
 
+  bool
+test_RegistryFileMixinHappyPath()
+{
+  using namespace flox;
+
+  flox::command::RegistryFileMixin rfm;
+  rfm.setRegistryPath( TEST_DATA_DIR "/registry/registry0.json" );
+  RegistryRaw regRaw = rfm.getRegistryRaw();
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+  bool
+test_RegistryFileMixinGetRegWithoutFile()
+{
+  using namespace flox;
+
+  flox::command::RegistryFileMixin rfm;
+  // rfm.setRegistryPath( TEST_DATA_DIR "/registry/registry0.json" );
+  try
+    {
+      RegistryRaw regRaw = rfm.getRegistryRaw();
+      return false;
+    }
+  catch ( FloxException & )
+    {
+      return true;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+  bool
+test_RegistryFileMixinGetRegCached()
+{
+  using namespace flox;
+
+  flox::command::RegistryFileMixin rfm;
+  rfm.setRegistryPath( TEST_DATA_DIR "/registry/registry0.json" );
+  RegistryRaw regRaw = rfm.getRegistryRaw();
+  // You don't need the registry path if the registry is cached. If it's not
+  // cached then you'll get an exception trying to open this file.
+  rfm.registryPath = std::nullopt;
+  RegistryRaw regRawCached = rfm.getRegistryRaw();
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
   int
 main( int argc, char * argv[] )
 {
@@ -73,45 +129,7 @@ main( int argc, char * argv[] )
 /* -------------------------------------------------------------------------- */
 
   /* Initialize common registry. */
-  flox::from_json( R"( {
-      "inputs": {
-        "nixpkgs": {
-          "from": {
-            "type": "github"
-          , "owner": "NixOS"
-          , "repo": "nixpkgs"
-          , "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1"
-          }
-        , "subtrees": ["legacyPackages"]
-        }
-      , "floco": {
-          "from": {
-            "type": "github"
-          , "owner": "aakropotkin"
-          , "repo": "floco"
-          , "rev": "1e84b4b16bba5746e1195fa3a4d8addaaf2d9ef4"
-          }
-        , "subtrees": ["packages"]
-        }
-      , "nixpkgs-flox": {
-          "from": {
-            "type": "github"
-          , "owner": "flox"
-          , "repo": "nixpkgs-flox"
-          , "rev": "feb593b6844a96dd4e17497edaabac009be05709"
-          }
-        , "subtrees": ["catalog"]
-        , "stabilities": ["stable"]
-        }
-      }
-    , "defaults": {
-        "subtrees": null
-      , "stabilities": ["stable"]
-      }
-    , "priority": ["nixpkgs", "floco", "nixpkgs-flox"]
-    } )"_json
-  , commonRegistry
-  );
+  flox::from_json( TEST_DATA_DIR "/registry/registry0.json", commonRegistry );
 
 
 /* -------------------------------------------------------------------------- */
@@ -119,6 +137,9 @@ main( int argc, char * argv[] )
   {
 
     RUN_TEST( FloxFlakeInputRegistry0 );
+    RUN_TEST( RegistryFileMixinHappyPath );
+    RUN_TEST( RegistryFileMixinGetRegWithoutFile );
+    RUN_TEST( RegistryFileMixinGetRegCached );
 
   }
 

--- a/tests/registry.cc
+++ b/tests/registry.cc
@@ -26,12 +26,6 @@ using namespace nlohmann::literals;
 
 /* -------------------------------------------------------------------------- */
 
-/* Initialized in `main' */
-// static flox::RegistryRaw commonRegistry;  // NOLINT
-
-
-/* -------------------------------------------------------------------------- */
-
   bool
 test_FloxFlakeInputRegistry0()
 {
@@ -80,9 +74,31 @@ test_RegistryFileMixinGetRegWithoutFile()
   using namespace flox;
 
   flox::command::RegistryFileMixin rfm;
-  // rfm.setRegistryPath( TEST_DATA_DIR "/registry/registry0.json" );
+  // Try loading the registry without setting the path
   try
     {
+      RegistryRaw regRaw = rfm.getRegistryRaw();
+      return false;
+    }
+  catch ( FloxException & )
+    {
+      return true;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+  bool
+test_RegistryFileMixinEmptyPath()
+{
+  using namespace flox;
+
+  flox::command::RegistryFileMixin rfm;
+  // Try loading the registry without setting the path
+  try
+    {
+      rfm.setRegistryPath( "" );
       RegistryRaw regRaw = rfm.getRegistryRaw();
       return false;
     }
@@ -144,6 +160,7 @@ main( int argc, char * argv[] )
     RUN_TEST( RegistryFileMixinHappyPath );
     RUN_TEST( RegistryFileMixinGetRegWithoutFile );
     RUN_TEST( RegistryFileMixinGetRegCached );
+    RUN_TEST( RegistryFileMixinEmptyPath );
 
   }
 

--- a/tests/registry.cc
+++ b/tests/registry.cc
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <cstdlib>
+#include <fstream>
 
 #include <nlohmann/json.hpp>
 
@@ -26,7 +27,7 @@ using namespace nlohmann::literals;
 /* -------------------------------------------------------------------------- */
 
 /* Initialized in `main' */
-static flox::RegistryRaw commonRegistry;  // NOLINT
+// static flox::RegistryRaw commonRegistry;  // NOLINT
 
 
 /* -------------------------------------------------------------------------- */
@@ -36,8 +37,13 @@ test_FloxFlakeInputRegistry0()
 {
   using namespace flox;
 
+  std::ifstream regFile( TEST_DATA_DIR "/registry/registry0.json" );
+  nlohmann::json json = nlohmann::json::parse( regFile );
+  flox::RegistryRaw regRaw;
+  json.get_to( regRaw );
+
   FloxFlakeInputFactory           factory;
-  Registry<FloxFlakeInputFactory> registry( commonRegistry, factory );
+  Registry<FloxFlakeInputFactory> registry( regRaw, factory );
   size_t count = 0;
   for ( const auto & [name, flake] : registry )
     {
@@ -128,8 +134,6 @@ main( int argc, char * argv[] )
 
 /* -------------------------------------------------------------------------- */
 
-  /* Initialize common registry. */
-  flox::from_json( TEST_DATA_DIR "/registry/registry0.json", commonRegistry );
 
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This PR adds a `RegistryFileMixin` that adds the ability to load a `registry.json` file via path provided to `pkgdb`.