### PR TITLE
feat: no indirect flake refs

### DIFF
--- a/include/flox/registry.hh
+++ b/include/flox/registry.hh
@@ -398,6 +398,12 @@ class Registry {
           , [&]( const auto & pair ) { return pair.first == _name.get(); }
           );
 
+          /* Throw an exception if a registry input is an indirect reference. */
+          if ( pair->second.getFlakeRef()->input.getType() == "flake" )
+            {
+              throw FloxException( "registry contained an indirect reference" );
+            }
+
           /* Fill default/fallback values if none are defined. */
           RegistryInput input = pair->second;
           if ( ! input.subtrees.has_value() )

--- a/tests/data/registry/registry1.json
+++ b/tests/data/registry/registry1.json
@@ -1,0 +1,63 @@
+{
+    "inputs": {
+        "nixpkgs": {
+            "from": {
+                "type": "github",
+                "owner": "NixOS",
+                "repo": "nixpkgs",
+                "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+            },
+            "subtrees": [
+                "legacyPackages"
+            ]
+        },
+        "floco": {
+            "from": {
+                "type": "github",
+                "owner": "aakropotkin",
+                "repo": "floco",
+                "rev": "1e84b4b16bba5746e1195fa3a4d8addaaf2d9ef4"
+            },
+            "subtrees": [
+                "packages"
+            ]
+        },
+        "nixpkgs-flox": {
+            "from": {
+                "type": "github",
+                "owner": "flox",
+                "repo": "nixpkgs-flox",
+                "rev": "feb593b6844a96dd4e17497edaabac009be05709"
+            },
+            "subtrees": [
+                "catalog"
+            ],
+            "stabilities": [
+                "stable"
+            ]
+        },
+        "nixpkgs2": {
+            "from": {
+                "id": "nixpkgs2",
+                "type": "indirect"
+            },
+            "to": {
+                "type": "github",
+                "owner": "NixOS",
+                "repo": "nixpkgs",
+                "ref": "release-23.05"
+            }
+        }
+    },
+    "defaults": {
+        "subtrees": null,
+        "stabilities": [
+            "stable"
+        ]
+    },
+    "priority": [
+        "nixpkgs",
+        "floco",
+        "nixpkgs-flox"
+    ]
+}

--- a/tests/registry.cc
+++ b/tests/registry.cc
@@ -130,6 +130,27 @@ test_RegistryFileMixinGetRegCached()
 
 /* -------------------------------------------------------------------------- */
 
+  bool
+test_RegistryNoIndirectRefs()
+{
+  using namespace flox;
+
+  flox::command::RegistryFileMixin rfm;
+  rfm.setRegistryPath( TEST_DATA_DIR "/registry/registry1.json" );
+  try
+    {
+       RegistryRaw regRaw = rfm.getRegistryRaw();
+       return false;
+    }
+  catch ( FloxException &)
+    {
+      return true;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
   int
 main( int argc, char * argv[] )
 {


### PR DESCRIPTION
This PR disallows constructing a `Registry` from inputs that contain indirect flake references so that resolution is pure.