### PR TITLE
feat: FloxException changes to enable JSON errors

### DIFF
--- a/include/flox/core/exceptions.hh
+++ b/include/flox/core/exceptions.hh
@@ -22,11 +22,13 @@ namespace flox {
 /* -------------------------------------------------------------------------- */
 
 enum error_category {
-  EC_OKAY                  = 0,
+  EC_OKAY = 0,
+  // Returned for any exception that doesn't have an error_code(), i.e.
+  // exceptions we haven't wrapped in a custom exception
   EC_FAILURE               = 1,
-  FLOX_EXCEPTION           = 100,
+  EC_FLOX_EXCEPTION        = 100,
   EC_PKG_QUERY_INVALID_ARG = 101,
-  TOML_TO_JSON             = 102
+  EC_TOML_TO_JSON          = 102
 }; /* End enum `error_category' */
 
 
@@ -37,13 +39,13 @@ class FloxException : public std::exception
 {
 private:
 
-  // corresponds to an error_category, in this case FLOX_EXCEPTION
+  // Corresponds to an error_category, in this case EC_FLOX_EXCEPTION
   static constexpr std::string_view categoryMsg
     = "error encountered running pkgdb";
-  // additional context added when the error is thrown
+  // Additional context added when the error is thrown
   std::optional<std::string> contextMsg;
-  // if some other exception was caught before throwing this one, caughtMsg
-  // contains what() of that exception
+  // If some other exception was caught before throwing this one, caughtMsg
+  // contains what() of that exception.
   std::optional<std::string> caughtMsg;
 
 public:
@@ -57,7 +59,7 @@ public:
   [[nodiscard]] virtual error_category
   error_code() const noexcept
   {
-    return FLOX_EXCEPTION;
+    return EC_FLOX_EXCEPTION;
   };
   [[nodiscard]] virtual std::string_view
   category_message() const noexcept

--- a/include/flox/core/exceptions.hh
+++ b/include/flox/core/exceptions.hh
@@ -3,13 +3,14 @@
  * @file flox/core/exceptions.hh
  *
  * @brief Definitions of various `std::exception` children used for throwing
- *        throwing errors with nice messages and typed discrimination.
+ *        errors with nice messages and typed discrimination.
  *
  *
  * -------------------------------------------------------------------------- */
 
 #pragma once
 
+#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -23,7 +24,9 @@ namespace flox {
 enum error_category {
   EC_OKAY                  = 0,
   EC_FAILURE               = 1,
-  EC_PKG_QUERY_INVALID_ARG = 100
+  FLOX_EXCEPTION           = 100,
+  EC_PKG_QUERY_INVALID_ARG = 101,
+  TOML_TO_JSON             = 102
 }; /* End enum `error_category' */
 
 
@@ -34,16 +37,43 @@ class FloxException : public std::exception
 {
 private:
 
-  std::string msg;
+  // corresponds to an error_category, in this case FLOX_EXCEPTION
+  static constexpr std::string_view categoryMsg
+    = "error encountered running pkgdb";
+  // additional context added when the error is thrown
+  std::optional<std::string> contextMsg;
+  // if some other exception was caught before throwing this one, caughtMsg
+  // contains what() of that exception
+  std::optional<std::string> caughtMsg;
 
 public:
 
-  explicit FloxException( std::string_view msg ) : msg( msg ) {}
-  [[nodiscard]] const char *
-  what() const noexcept override
+  explicit FloxException( std::string_view contextMsg )
+    : contextMsg( contextMsg )
+  {}
+  explicit FloxException( std::string_view contextMsg, const char * caughtMsg )
+    : contextMsg( contextMsg ), caughtMsg( caughtMsg )
+  {}
+  [[nodiscard]] virtual error_category
+  error_code() const noexcept
   {
-    return this->msg.c_str();
-  }
+    return FLOX_EXCEPTION;
+  };
+  [[nodiscard]] virtual std::string_view
+  category_message() const noexcept
+  {
+    return this->categoryMsg;
+  };
+  // We can't override what() properly because we'd need to dynamically call
+  // virtual methods.
+  // - We don't want to force overriding what() in every child class, because
+  //   that would be a pain.
+  // - We can't do that when calling what(), because what() returns a char *
+  //   and is const, we don't have anywhere to store that dynamic information.
+  // - We can't do it at construction time, because we can't call virtual
+  //   methods.
+  std::string
+  what_string() const noexcept;
 };
 
 

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -1,0 +1,50 @@
+/* ========================================================================== *
+ *
+ * @file flox/exceptions.cc
+ *
+ * @brief Definitions of various `std::exception` children used for throwing
+ *        errors with nice messages and typed discrimination.
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+
+
+#include "flox/core/exceptions.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+namespace flox {
+
+/* -------------------------------------------------------------------------- */
+std::string
+FloxException::what_string() const noexcept
+{
+  std::string msg( this->category_message() );
+  if ( this->contextMsg.has_value() )
+    {
+      msg += ": ";
+      msg += *( this->contextMsg );
+    }
+  if ( this->caughtMsg.has_value() )
+    {
+      msg += ": ";
+      msg += *( this->caughtMsg );
+    }
+  return msg;
+}
+
+/* -------------------------------------------------------------------------- */
+
+}  // namespace flox
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/src/tomlToJSON.cc
+++ b/src/tomlToJSON.cc
@@ -27,7 +27,6 @@ struct TOMLToJSONException : public FloxException
   static constexpr std::string_view categoryMsg
     = "error converting TOML to JSON";
 
-  std::filesystem::path dbPath;
   TOMLToJSONException( std::string_view contextMsg )
     : FloxException( contextMsg )
   {}
@@ -37,7 +36,7 @@ struct TOMLToJSONException : public FloxException
   error_category
   error_code() const noexcept override
   {
-    return TOML_TO_JSON;
+    return EC_TOML_TO_JSON;
   }
   std::string_view
   category_message() const noexcept override

--- a/src/tomlToJSON.cc
+++ b/src/tomlToJSON.cc
@@ -21,6 +21,33 @@ namespace flox {
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief An exception thrown when converting TOML to JSON */
+struct TOMLToJSONException : public FloxException
+{
+  static constexpr std::string_view categoryMsg
+    = "error converting TOML to JSON";
+
+  std::filesystem::path dbPath;
+  TOMLToJSONException( std::string_view contextMsg )
+    : FloxException( contextMsg )
+  {}
+  TOMLToJSONException( std::string_view contextMsg, const char *caughtMsg )
+    : FloxException( contextMsg, caughtMsg )
+  {}
+  error_category
+  error_code() const noexcept override
+  {
+    return TOML_TO_JSON;
+  }
+  std::string_view
+  category_message() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+
+}; /* End struct `TOMLToJSONException' */
+
+
 nlohmann::json
 tomlToJSON( std::string_view toml )
 {
@@ -88,12 +115,11 @@ tomlToJSON( std::string_view toml )
     }
   catch ( const std::exception &e )  // TODO: toml::syntax_error
     {
-      throw FloxException( "while parsing a TOML string: "
-                           + std::string( e.what() ) );
+      throw TOMLToJSONException( "while parsing a TOML string", e.what() );
     }
   catch ( ... )
     {
-      throw FloxException( "while parsing a TOML string: unknown error" );
+      throw TOMLToJSONException( "while parsing a TOML string" );
     }
 
   assert( false ); /* Unreachable */


### PR DESCRIPTION
FloxException will be used as the base class for all pkgdb exceptions, and they need to be able to be passed as JSON. The JSON output will be of the form:
{
  "error_code": 102,
  "category_message": "error converting TOML to JSON",
  "context_message": "while parsing a TOML string",
  "caught_message": "contents of e.what()"
}

Make the necessary changes to FloxException to store this information, and add a TOMLToJSONException to demonstrate how FloxException will be used as a base class.