### PR TITLE
fix: compiler warnings

### DIFF
--- a/include/flox/pkgdb/input.hh
+++ b/include/flox/pkgdb/input.hh
@@ -257,7 +257,8 @@ private:
    *   std::shared_ptr<nix::Store> store
    */
 
-  bool force = false; /**< Whether to force re-evaluation of flakes. */
+  [[maybe_unused]] bool force
+    = false; /**< Whether to force re-evaluation of flakes. */
 
   std::shared_ptr<Registry<PkgDbInputFactory>> registry;
 

--- a/src/resolver/descriptor.cc
+++ b/src/resolver/descriptor.cc
@@ -47,7 +47,7 @@ initManifestDescriptorVersion( ManifestDescriptor & desc,
    * We identify `=` as an explicit _exact version_ match. */
   switch ( trimmed.at( 0 ) )
     {
-      case '=': desc.version = std::move( trimmed.substr( 1 ) ); break;
+      case '=': desc.version = trimmed.substr( 1 ); break;
 
       case '*':
       case '~':


### PR DESCRIPTION
Remove unnecessary move:
src/resolver/descriptor.cc:52:24: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
        desc.version = std::move( trimmed.substr( 1 ) );
                       ^
src/resolver/descriptor.cc:52:24: note: remove std::move call here
        desc.version = std::move( trimmed.substr( 1 ) );
                       ^~~~~~~~~~~                    ~
Mark force unused:
include/flox/pkgdb/input.hh:251:10: warning: private field 'force' is not used [-Wunused-private-field]
    bool force = false;  /**< Whether to force re-evaluation of flakes. */
         ^