### PR TITLE
feat: replace FloxExceptions with custom ones

### DIFF
--- a/include/flox/core/command.hh
+++ b/include/flox/core/command.hh
@@ -173,6 +173,54 @@ public:
 
 }; /* End struct `RegistryFileMixin' */
 
+/** @brief An exception thrown when the value of registryPath is invalid */
+class InvalidRegistryFileException : public FloxException
+{
+private:
+
+  static constexpr std::string_view categoryMsg
+    = "invalid value for registry file";
+
+public:
+
+  explicit InvalidRegistryFileException( std::string_view contextMsg )
+    : FloxException( contextMsg )
+  {}
+  [[nodiscard]] error_category
+  get_error_code() const noexcept override
+  {
+    return EC_INVALID_REGISTRY_FILE;
+  }
+  [[nodiscard]] std::string_view
+  category_message() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+}; /* End class `InvalidRegistryFileException' */
+
+/** @brief An exception thrown when a command line argument is invalid */
+class InvalidArgException : public FloxException
+{
+private:
+
+  static constexpr std::string_view categoryMsg = "invalid argument";
+
+public:
+
+  explicit InvalidArgException( std::string_view contextMsg )
+    : FloxException( contextMsg )
+  {}
+  [[nodiscard]] error_category
+  get_error_code() const noexcept override
+  {
+    return EC_INVALID_ARG;
+  }
+  [[nodiscard]] std::string_view
+  category_message() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+}; /* End class `InvalidArgException' */
 /* -------------------------------------------------------------------------- */
 
 }  // namespace flox::command

--- a/include/flox/core/exceptions.hh
+++ b/include/flox/core/exceptions.hh
@@ -25,10 +25,34 @@ enum error_category {
   EC_OKAY = 0,
   // Returned for any exception that doesn't have an error_code(), i.e.
   // exceptions we haven't wrapped in a custom exception
-  EC_FAILURE               = 1,
-  EC_FLOX_EXCEPTION        = 100,
-  EC_PKG_QUERY_INVALID_ARG = 101,
-  EC_TOML_TO_JSON          = 102
+  EC_FAILURE        = 1,
+  EC_FLOX_EXCEPTION = 100,
+  // A command line argument is invalid.
+  EC_INVALID_ARG = 101,
+  // A package descriptor in a manifest is invalid.
+  EC_INVALID_MANIFEST_DESCRIPTOR = 102,
+  // A PkgDescriptorRaw is invalid.
+  EC_INVALID_PKG_DESCRIPTOR = 103,
+  // Errors concerning validity of package query parameters
+  EC_INVALID_PKG_QUERY_ARG = 104,
+  // A registry has invalid contents.
+  EC_INVALID_REGISTRY = 105,
+  // The value of registryPath is invalid.
+  EC_INVALID_REGISTRY_FILE = 106,
+  // Exception initializing a `FlakePackage`
+  EC_PACKAGE_INIT = 107,
+  // Exception parsing `QueryParams` from JSON
+  EC_PARSE_QUERY_PARAMS = 108,
+  // Exception parsing `QueryPreferences` from JSON
+  EC_PARSE_QUERY_PREFERENCES = 109,
+  // Exception parsing `SearchQuery` from JSON
+  EC_PARSE_SEARCH_QUERY = 110,
+  // For generic exceptions thrown by `flox::pkgdb::*` classes
+  EC_PKG_DB = 111,
+  // Exception converting TOML to JSON
+  EC_TOML_TO_JSON = 112,
+  // Exception converting YAML to JSON
+  EC_YAML_TO_JSON = 113,
 }; /* End enum `error_category' */
 
 
@@ -40,8 +64,7 @@ class FloxException : public std::exception
 private:
 
   // Corresponds to an error_category, in this case EC_FLOX_EXCEPTION
-  static constexpr std::string_view categoryMsg
-    = "error encountered running pkgdb";
+  static constexpr std::string_view categoryMsg = "general error";
   // Additional context added when the error is thrown
   std::optional<std::string> contextMsg;
   // If some other exception was caught before throwing this one, caughtMsg
@@ -57,7 +80,7 @@ public:
     : contextMsg( contextMsg ), caughtMsg( caughtMsg )
   {}
   [[nodiscard]] virtual error_category
-  error_code() const noexcept
+  get_error_code() const noexcept
   {
     return EC_FLOX_EXCEPTION;
   };
@@ -74,7 +97,7 @@ public:
   //   and is const, we don't have anywhere to store that dynamic information.
   // - We can't do it at construction time, because we can't call virtual
   //   methods.
-  std::string
+  [[nodiscard]] std::string
   what_string() const noexcept;
 };
 

--- a/include/flox/flake-package.hh
+++ b/include/flox/flake-package.hh
@@ -206,6 +206,32 @@ public:
 
 }; /* End class `FlakePackage' */
 
+/** @brief An exception thrown when initializing a `FlakePackage` */
+class PackageInitException : public FloxException
+{
+private:
+
+  static constexpr std::string_view categoryMsg
+    = "error initializing FlakePackage";
+
+public:
+
+  explicit PackageInitException( std::string_view contextMsg )
+    : FloxException( contextMsg )
+  {}
+  [[nodiscard]] error_category
+  get_error_code() const noexcept override
+  {
+    return EC_PACKAGE_INIT;
+  }
+  [[nodiscard]] std::string_view
+  category_message() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+
+}; /* End class `PackageInitException' */
+
 
 /* -------------------------------------------------------------------------- */
 

--- a/include/flox/pkgdb/params.hh
+++ b/include/flox/pkgdb/params.hh
@@ -83,6 +83,31 @@ struct QueryPreferences
 
 }; /* End struct `QueryPreferences' */
 
+/** @brief An exception thrown when parsing `QueryPreferences` from JSON */
+class ParseQueryPreferencesException : public FloxException
+{
+private:
+
+  static constexpr std::string_view categoryMsg
+    = "error parsing query preferences";
+
+public:
+
+  explicit ParseQueryPreferencesException( std::string_view contextMsg )
+    : FloxException( contextMsg )
+  {}
+  [[nodiscard]] error_category
+  get_error_code() const noexcept override
+  {
+    return EC_PARSE_QUERY_PREFERENCES;
+  }
+  [[nodiscard]] std::string_view
+  category_message() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+}; /* End class `ParseQueryPreferencesException' */
+
 
 /* -------------------------------------------------------------------------- */
 
@@ -182,6 +207,32 @@ struct QueryParams : public QueryPreferences
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief An exception thrown when parsing `QueryParams` from JSON */
+class ParseQueryParamsException : public FloxException
+{
+private:
+
+  static constexpr std::string_view categoryMsg
+    = "error parsing query parameters";
+
+public:
+
+  explicit ParseQueryParamsException( std::string_view contextMsg )
+    : FloxException( contextMsg )
+  {}
+  [[nodiscard]] error_category
+  get_error_code() const noexcept override
+  {
+    return EC_PARSE_QUERY_PARAMS;
+  }
+  [[nodiscard]] std::string_view
+  category_message() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+
+}; /* End class `ParseQueryParamsException' */
+
 template<pkg_descriptor_typename QueryType>
 void
 from_json( const nlohmann::json &jfrom, QueryParams<QueryType> &params )
@@ -207,7 +258,8 @@ from_json( const nlohmann::json &jfrom, QueryParams<QueryType> &params )
         }
       else
         {
-          throw FloxException( "Unexpected preferences field '" + key + '\'' );
+          throw ParseQueryParamsException( "Unexpected preferences field '"
+                                           + key + '\'' );
         }
     }
 }

--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -151,15 +151,17 @@ struct PkgQueryArgs : public PkgDescriptorBase
 
 
   /** @brief Errors concerning validity of package query parameters. */
-  struct InvalidArgException : public flox::FloxException
+  struct InvalidPkgQueryArgException : public flox::FloxException
   {
+  private:
+
+    static constexpr std::string_view categoryMsg
+      = "encountered an error processing query arguments";
 
   public:
 
     enum error_code {
-      PQEC_ERROR = 1 /**< Generic Exception */
       /** Name/{pname,version,semver} are mutually exclusive */
-      ,
       PQEC_MIX_NAME = 2
       /** Version/semver are mutually exclusive */
       ,
@@ -186,12 +188,23 @@ struct PkgQueryArgs : public PkgDescriptorBase
 
   public:
 
-    explicit InvalidArgException( const error_code & ecode = PQEC_ERROR )
-      : flox::FloxException( InvalidArgException::errorMessage( ecode ) )
+    explicit InvalidPkgQueryArgException( const error_code & ecode )
+      : flox::FloxException(
+        InvalidPkgQueryArgException::errorMessage( ecode ) )
       , errorCode( ecode )
     {}
 
-  }; /* End struct `PkgDbQueryInvalidArgException' */
+    [[nodiscard]] flox::error_category
+    get_error_code() const noexcept override
+    {
+      return EC_INVALID_PKG_QUERY_ARG;
+    }
+    [[nodiscard]] std::string_view
+    category_message() const noexcept override
+    {
+      return this->categoryMsg;
+    }
+  }; /* End struct `InvalidPkgQueryArgException' */
 
 
   /** @brief Reset argset to its _default_ state. */
@@ -208,7 +221,7 @@ struct PkgQueryArgs : public PkgDescriptorBase
    * @return `std::nullopt` iff the above conditions are met, an error
    *         code otherwise.
    */
-  [[nodiscard]] std::optional<InvalidArgException::error_code>
+  [[nodiscard]] std::optional<InvalidPkgQueryArgException::error_code>
   validate() const;
 
 }; /* End struct `PkgQueryArgs' */

--- a/include/flox/pkgdb/read.hh
+++ b/include/flox/pkgdb/read.hh
@@ -98,13 +98,27 @@ using sql_rc      = int;                 /**< `SQLITE_*` result code. */
 /* -------------------------------------------------------------------------- */
 
 /** @brief A generic exception thrown by `flox::pkgdb::*` classes. */
-struct PkgDbException : public FloxException
+class PkgDbException : public FloxException
 {
-  std::filesystem::path dbPath;
-  PkgDbException( std::filesystem::path dbPath, std::string_view msg )
-    : FloxException( msg ), dbPath( std::move( dbPath ) )
-  {}
-}; /* End struct `PkgDbException' */
+private:
+
+  static constexpr std::string_view categoryMsg = "error running pkgdb";
+
+public:
+
+  PkgDbException( std::string_view msg ) : FloxException( msg ) {}
+  [[nodiscard]] error_category
+  get_error_code() const noexcept override
+  {
+    return EC_PKG_DB;
+  }
+  [[nodiscard]] std::string_view
+  category_message() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+
+}; /* End class `PkgDbException' */
 
 
 /* -------------------------------------------------------------------------- */
@@ -167,7 +181,6 @@ public:
   {
     explicit NoSuchDatabase( const PkgDbReadOnly & pdb )
       : PkgDbException(
-        pdb.dbPath,
         std::string( "No such database '" + pdb.dbPath.string() + "'." ) )
     {}
   }; /* End struct `NoSuchDatabase' */

--- a/include/flox/registry.hh
+++ b/include/flox/registry.hh
@@ -415,7 +415,8 @@ public:
         /* Throw an exception if a registry input is an indirect reference. */
         if ( pair->second.getFlakeRef()->input.getType() == "flake" )
           {
-            throw FloxException( "registry contained an indirect reference" );
+            throw InvalidRegistryException(
+              "registry contained an indirect reference" );
           }
 
         /* Fill default/fallback values if none are defined. */
@@ -436,6 +437,29 @@ public:
       }
   }
 
+  /** @brief An exception thrown when a registry has invalid contents */
+  class InvalidRegistryException : public FloxException
+  {
+  private:
+
+    static constexpr std::string_view categoryMsg = "invalid registry";
+
+  public:
+
+    explicit InvalidRegistryException( std::string_view contextMsg )
+      : FloxException( contextMsg )
+    {}
+    [[nodiscard]] error_category
+    get_error_code() const noexcept override
+    {
+      return EC_INVALID_REGISTRY;
+    }
+    [[nodiscard]] std::string_view
+    category_message() const noexcept override
+    {
+      return this->categoryMsg;
+    }
+  }; /* End class `InvalidArgException' */
 
   /**
    * @brief Get an input by name.

--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -172,6 +172,30 @@ public:
 
 }; /* End struct `ManifestDescriptor' */
 
+/** @brief An exception thrown when a package descriptor in a manifest is
+ * invalid */
+class InvalidManifestDescriptorException : public FloxException
+{
+private:
+
+  static constexpr std::string_view categoryMsg = "error in package descriptor";
+
+public:
+
+  explicit InvalidManifestDescriptorException( std::string_view contextMsg )
+    : FloxException( contextMsg )
+  {}
+  [[nodiscard]] error_category
+  get_error_code() const noexcept override
+  {
+    return EC_INVALID_MANIFEST_DESCRIPTOR;
+  }
+  [[nodiscard]] std::string_view
+  category_message() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+}; /* End class `InvalidManifestDescriptorException' */
 
 /* -------------------------------------------------------------------------- */
 

--- a/include/flox/resolver/params.hh
+++ b/include/flox/resolver/params.hh
@@ -110,6 +110,29 @@ struct PkgDescriptorRaw : public pkgdb::PkgDescriptorBase
 
 }; /* End struct `PkgDescriptorRaw' */
 
+/** @brief An exception thrown a PkgDescriptorRaw is invalid */
+class InvalidPkgDescriptorException : public FloxException
+{
+private:
+
+  static constexpr std::string_view categoryMsg = "invalid package query";
+
+public:
+
+  explicit InvalidPkgDescriptorException( std::string_view contextMsg )
+    : FloxException( contextMsg )
+  {}
+  [[nodiscard]] error_category
+  get_error_code() const noexcept override
+  {
+    return EC_INVALID_PKG_DESCRIPTOR;
+  }
+  [[nodiscard]] std::string_view
+  category_message() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+}; /* End class `InvalidPkgDescriptorException' */
 
 /* -------------------------------------------------------------------------- */
 

--- a/include/flox/search/params.hh
+++ b/include/flox/search/params.hh
@@ -65,20 +65,47 @@ struct SearchQuery : public pkgdb::PkgDescriptorBase
    * @return A reference to the modified query args.
    */
   pkgdb::PkgQueryArgs &
-  fillPkgQueryArgs( pkgdb::PkgQueryArgs & pqa ) const;
+  fillPkgQueryArgs( pkgdb::PkgQueryArgs &pqa ) const;
 
 }; /* End struct "SearchQuery' */
 
+/** @brief An exception thrown when parsing `SearchQuery` from JSON */
+class ParseSearchQueryException : public FloxException
+{
+private:
+
+  static constexpr std::string_view categoryMsg = "error parsing search query";
+
+public:
+
+  explicit ParseSearchQueryException( std::string_view contextMsg )
+    : FloxException( contextMsg )
+  {}
+  explicit ParseSearchQueryException( std::string_view contextMsg,
+                                      const char      *caughtMsg )
+    : FloxException( contextMsg, caughtMsg )
+  {}
+  [[nodiscard]] error_category
+  get_error_code() const noexcept override
+  {
+    return EC_PARSE_SEARCH_QUERY;
+  }
+  [[nodiscard]] std::string_view
+  category_message() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+}; /* End class `ParseSearchQueryException' */
 
 /* -------------------------------------------------------------------------- */
 
 /** @brief Convert a JSON object to a @a flox::search::SearchQuery. */
 void
-from_json( const nlohmann::json & jfrom, SearchQuery & qry );
+from_json( const nlohmann::json &jfrom, SearchQuery &qry );
 
 /** @brief Convert a @a flox::search::SearchQuery to a JSON object. */
 void
-to_json( nlohmann::json & jto, const SearchQuery & qry );
+to_json( nlohmann::json &jto, const SearchQuery &qry );
 
 
 /* -------------------------------------------------------------------------- */

--- a/src/command.cc
+++ b/src/command.cc
@@ -185,7 +185,8 @@ RegistryFileMixin::setRegistryPath( const std::filesystem::path & path )
 {
   if ( path.empty() )
     {
-      throw FloxException( "provided registry path is empty" );
+      throw InvalidRegistryFileException(
+        "provided registry path is empty string" );
     }
   this->registryPath = path;
 }
@@ -203,8 +204,7 @@ RegistryFileMixin::loadRegistry()
 {
   if ( ! this->registryPath.has_value() )
     {
-      throw FloxException( "You must provide a path to a 'registry.json', "
-                           "see the '--registry-file' option." );
+      throw InvalidRegistryFileException( "registry path is null" );
     }
   std::ifstream  f( *( this->registryPath ) );
   nlohmann::json json = nlohmann::json::parse( f );

--- a/src/flake-package.cc
+++ b/src/flake-package.cc
@@ -20,7 +20,7 @@ FlakePackage::init( bool checkDrv )
 {
   if ( this->_pathS.size() < 3 )
     {
-      throw FloxException(
+      throw PackageInitException(
         "Package::init(): Package attribute paths must have at least 3 "
         "elements - the path '"
         + this->_cursor->getAttrPathStr() + "' is too short." );
@@ -28,7 +28,7 @@ FlakePackage::init( bool checkDrv )
 
   if ( checkDrv && ( ! this->_cursor->isDerivation() ) )
     {
-      throw FloxException(
+      throw PackageInitException(
         "Package::init(): Packages must be derivations but the attrset at '"
         + this->_cursor->getAttrPathStr()
         + "' does not set `.type = \"derivation\"'." );
@@ -41,9 +41,9 @@ FlakePackage::init( bool checkDrv )
     }
   catch ( const std::invalid_argument & /* unused */ )
     {
-      throw FloxException( "FlakePackage::init(): Invalid subtree name '"
-                           + this->_pathS[0] + "' at path '"
-                           + this->_cursor->getAttrPathStr() + "'." );
+      throw PackageInitException( "FlakePackage::init(): Invalid subtree name '"
+                                  + this->_pathS[0] + "' at path '"
+                                  + this->_cursor->getAttrPathStr() + "'." );
     }
 
   this->_system = this->_pathS[1];

--- a/src/main.cc
+++ b/src/main.cc
@@ -50,10 +50,10 @@ main( int argc, char * argv[] )
     {
       prog.parse_args( argc, argv );
     }
-  catch ( const flox::pkgdb::PkgQuery::InvalidArgException & err )
+  catch ( const flox::pkgdb::PkgQuery::InvalidPkgQueryArgException & err )
     {
       // TODO: DRY ( see search/command.cc )
-      int exitCode = flox::EC_PKG_QUERY_INVALID_ARG;
+      int exitCode = flox::EC_INVALID_PKG_QUERY_ARG;
       exitCode += static_cast<int>( err.errorCode );
       for ( int i = 1; i < argc; ++i )
         {
@@ -97,10 +97,10 @@ main( int argc, char * argv[] )
       if ( prog.is_subcommand_used( "search" ) ) { return cmdSearch.run(); }
       if ( prog.is_subcommand_used( "resolve" ) ) { return cmdResolve.run(); }
     }
-  catch ( const flox::pkgdb::PkgQuery::InvalidArgException & err )
+  catch ( const flox::pkgdb::PkgQuery::InvalidPkgQueryArgException & err )
     {
       // TODO: DRY ( see search/command.cc )
-      int exitCode = flox::EC_PKG_QUERY_INVALID_ARG;
+      int exitCode = flox::EC_INVALID_PKG_QUERY_ARG;
       exitCode += static_cast<int>( err.errorCode );
       for ( int i = 1; i < argc; ++i )
         {

--- a/src/pkgdb/command.cc
+++ b/src/pkgdb/command.cc
@@ -153,9 +153,10 @@ PkgDbMixin<T>::addTargetArg( argparse::ArgumentParser & parser )
               {
                 if ( std::filesystem::exists( target ) )
                   {
-                    throw FloxException( "Argument '" + target
-                                         + "' is neither a flake "
-                                           "reference or SQLite3 database" );
+                    throw command::InvalidArgException(
+                      "Argument '" + target
+                      + "' is neither a flake "
+                        "reference nor SQLite3 database" );
                   }
                 throw;
               }

--- a/src/pkgdb/input.cc
+++ b/src/pkgdb/input.cc
@@ -57,7 +57,6 @@ PkgDbInput::init()
   if ( dbVersions != sqlVersions )
     {
       throw PkgDbException(
-        this->dbPath,
         nix::fmt( "Incompatible Flox PkgDb schema versions ( %u, %u )",
                   dbVersions.tables,
                   dbVersions.views ) );

--- a/src/pkgdb/params.cc
+++ b/src/pkgdb/params.cc
@@ -80,8 +80,8 @@ from_json( const nlohmann::json & jfrom, QueryPreferences & prefs )
                 }
               else
                 {
-                  throw FloxException( "Unexpected preferences field 'allow."
-                                       + akey + '\'' );
+                  throw ParseQueryPreferencesException(
+                    "Unexpected preferences field 'allow." + akey + '\'' );
                 }
             }
         }
@@ -97,8 +97,8 @@ from_json( const nlohmann::json & jfrom, QueryPreferences & prefs )
                 }
               else
                 {
-                  throw FloxException( "Unexpected preferences field 'semver."
-                                       + skey + '\'' );
+                  throw ParseQueryPreferencesException(
+                    "Unexpected preferences field 'semver." + skey + '\'' );
                 }
             }
         }

--- a/src/pkgdb/pkg-query.cc
+++ b/src/pkgdb/pkg-query.cc
@@ -34,8 +34,8 @@ PkgDescriptorBase::clear()
 /* -------------------------------------------------------------------------- */
 
 std::string
-PkgQueryArgs::InvalidArgException::errorMessage(
-  const PkgQueryArgs::InvalidArgException::error_code & ecode )
+PkgQueryArgs::InvalidPkgQueryArgException::errorMessage(
+  const PkgQueryArgs::InvalidPkgQueryArgException::error_code & ecode )
 {
   switch ( ecode )
     {
@@ -66,20 +66,16 @@ PkgQueryArgs::InvalidArgException::errorMessage(
       case PQEC_INVALID_MATCH_STYLE:
         return "Query `matchStyle' must be set when `match' is used";
         break;
-      default:
-      case PQEC_ERROR:
-        return "Encountered and error processing query arguments";
-        break;
     }
 }
 
 
 /* -------------------------------------------------------------------------- */
 
-std::optional<PkgQueryArgs::InvalidArgException::error_code>
+std::optional<PkgQueryArgs::InvalidPkgQueryArgException::error_code>
 PkgQueryArgs::validate() const
 {
-  using error_code = PkgQueryArgs::InvalidArgException::error_code;
+  using error_code = PkgQueryArgs::InvalidPkgQueryArgException::error_code;
 
   if ( this->name.has_value()
        && ( this->pname.has_value() || this->version.has_value()
@@ -456,7 +452,7 @@ PkgQuery::init()
   /* Validate parameters */
   if ( auto maybe_ec = this->validate(); maybe_ec != std::nullopt )
     {
-      throw PkgQueryArgs::InvalidArgException( *maybe_ec );
+      throw PkgQueryArgs::InvalidPkgQueryArgException( *maybe_ec );
     }
 
   this->addSelection( "*" );

--- a/src/pkgdb/read.cc
+++ b/src/pkgdb/read.cc
@@ -118,7 +118,6 @@ PkgDbReadOnly::loadLockedFlake()
   else if ( this->fingerprint != fingerprint )
     {
       throw PkgDbException(
-        this->dbPath,
         nix::fmt( "database '%s' fingerprint '%s' does not match expected '%s'",
                   this->dbPath,
                   fingerprintStr,
@@ -226,7 +225,6 @@ PkgDbReadOnly::getDescription( row_id descriptionId )
   if ( itr == qryId.end() )
     {
       throw PkgDbException(
-        this->dbPath,
         nix::fmt( "No such Descriptions.id %llu.", descriptionId ) );
     }
   return ( *itr ).get<std::string>( 0 );
@@ -275,7 +273,6 @@ PkgDbReadOnly::getAttrSetId( const flox::AttrPath & path )
       if ( itr == qryId.end() )
         {
           throw PkgDbException(
-            this->dbPath,
             nix::fmt( "No such AttrSet '%s'.",
                       nix::concatStringsSep( ".", path ) ) );
         }
@@ -303,8 +300,7 @@ PkgDbReadOnly::getAttrSetPath( row_id row )
       /* Handle no such path. */
       if ( itr == qry.end() )
         {
-          throw PkgDbException( this->dbPath,
-                                nix::fmt( "No such `AttrSet.id' %llu.", row ) );
+          throw PkgDbException( nix::fmt( "No such `AttrSet.id' %llu.", row ) );
         }
       row = ( *itr ).get<long long>( 0 );
       path.push_front( ( *itr ).get<std::string>( 1 ) );
@@ -335,7 +331,6 @@ PkgDbReadOnly::getPackageId( const flox::AttrPath & path )
   if ( itr == qry.end() )
     {
       throw PkgDbException(
-        this->dbPath,
         nix::fmt( "No such package %s.", nix::concatStringsSep( ".", path ) ) );
     }
   return ( *itr ).get<long long>( 0 );
@@ -356,8 +351,7 @@ PkgDbReadOnly::getPackagePath( row_id row )
   /* Handle no such path. */
   if ( itr == qry.end() )
     {
-      throw PkgDbException( this->dbPath,
-                            nix::fmt( "No such `Packages.id' %llu.", row ) );
+      throw PkgDbException( nix::fmt( "No such `Packages.id' %llu.", row ) );
     }
   flox::AttrPath path = this->getAttrSetPath( ( *itr ).get<long long>( 0 ) );
   path.emplace_back( ( *itr ).get<std::string>( 1 ) );

--- a/src/pkgdb/write.cc
+++ b/src/pkgdb/write.cc
@@ -27,8 +27,7 @@ PkgDb::initViews()
 {
   if ( sql_rc rcode = this->execute_all( sql_views ); isSQLError( rcode ) )
     {
-      throw PkgDbException( this->dbPath,
-                            nix::fmt( "Failed to initialize views:(%d) %s",
+      throw PkgDbException( nix::fmt( "Failed to initialize views:(%d) %s",
                                       rcode,
                                       this->db.error_msg() ) );
     }
@@ -51,8 +50,7 @@ PkgDb::updateViews()
 
   if ( sql_rc rcode = updateViews.execute_all(); isSQLError( rcode ) )
     {
-      throw PkgDbException( this->dbPath,
-                            nix::fmt( "Failed to update PkgDb Views:(%d) %s",
+      throw PkgDbException( nix::fmt( "Failed to update PkgDb Views:(%d) %s",
                                       rcode,
                                       this->db.error_msg() ) );
     }
@@ -70,7 +68,6 @@ PkgDb::initTables()
   if ( sql_rc rcode = this->execute( sql_versions ); isSQLError( rcode ) )
     {
       throw PkgDbException(
-        this->dbPath,
         nix::fmt( "Failed to initialize DbVersions table:(%d) %s",
                   rcode,
                   this->db.error_msg() ) );
@@ -79,7 +76,6 @@ PkgDb::initTables()
   if ( sql_rc rcode = this->execute_all( sql_input ); isSQLError( rcode ) )
     {
       throw PkgDbException(
-        this->dbPath,
         nix::fmt( "Failed to initialize LockedFlake table:(%d) %s",
                   rcode,
                   this->db.error_msg() ) );
@@ -88,7 +84,6 @@ PkgDb::initTables()
   if ( sql_rc rcode = this->execute_all( sql_attrSets ); isSQLError( rcode ) )
     {
       throw PkgDbException(
-        this->dbPath,
         nix::fmt( "Failed to initialize AttrSets table:(%d) %s",
                   rcode,
                   this->db.error_msg() ) );
@@ -97,7 +92,6 @@ PkgDb::initTables()
   if ( sql_rc rcode = this->execute_all( sql_packages ); isSQLError( rcode ) )
     {
       throw PkgDbException(
-        this->dbPath,
         nix::fmt( "Failed to initialize Packages table:(%d) %s",
                   rcode,
                   this->db.error_msg() ) );
@@ -120,8 +114,7 @@ PkgDb::initVersions()
   defineVersions.bind( 2, static_cast<int>( sqlVersions.views ) );
   if ( sql_rc rcode = defineVersions.execute(); isSQLError( rcode ) )
     {
-      throw PkgDbException( this->dbPath,
-                            nix::fmt( "Failed to write DbVersions info:(%d) %s",
+      throw PkgDbException( nix::fmt( "Failed to write DbVersions info:(%d) %s",
                                       rcode,
                                       this->db.error_msg() ) );
     }
@@ -159,7 +152,6 @@ PkgDb::writeInput()
   if ( sql_rc rcode = cmd.execute(); isSQLError( rcode ) )
     {
       throw PkgDbException(
-        this->dbPath,
         nix::fmt( "Failed to write LockedFlaked info:(%d) %s",
                   rcode,
                   this->db.error_msg() ) );
@@ -188,7 +180,6 @@ PkgDb::addOrGetAttrSetId( const std::string & attrName, row_id parent )
       if ( row == qryId.end() )
         {
           throw PkgDbException(
-            this->dbPath,
             nix::fmt( "Failed to add AttrSet.id 'AttrSets[%ull].%s':(%d) %s",
                       parent,
                       attrName,
@@ -244,8 +235,7 @@ PkgDb::addOrGetDescriptionId( const std::string & description )
     nix::fmt( "Adding new description to database: %s.", description ) );
   if ( sql_rc rcode = cmd.execute(); isSQLError( rcode ) )
     {
-      throw PkgDbException( this->dbPath,
-                            nix::fmt( "Failed to add Description '%s':(%d) %s",
+      throw PkgDbException( nix::fmt( "Failed to add Description '%s':(%d) %s",
                                       description,
                                       rcode,
                                       this->db.error_msg() ) );
@@ -344,8 +334,7 @@ PkgDb::addPackage( row_id               parentId,
     }
   if ( sql_rc rcode = cmd.execute(); isSQLError( rcode ) )
     {
-      throw PkgDbException( this->dbPath,
-                            nix::fmt( "Failed to write Package '%s':(%d) %s",
+      throw PkgDbException( nix::fmt( "Failed to write Package '%s':(%d) %s",
                                       pkg._fullName,
                                       rcode,
                                       this->db.error_msg() ) );
@@ -375,13 +364,11 @@ PkgDb::setPrefixDone( row_id prefixId, bool done )
   cmd.bind( 2, static_cast<long long>( prefixId ) );
   if ( sql_rc rcode = cmd.execute(); isSQLError( rcode ) )
     {
-      throw PkgDbException(
-        this->dbPath,
-        nix::fmt(
-          "Failed to set AttrSets.done for subtree '%s':(%d) %s",
-          nix::concatStringsSep( ".", this->getAttrSetPath( prefixId ) ),
-          rcode,
-          this->db.error_msg() ) );
+      throw PkgDbException( nix::fmt(
+        "Failed to set AttrSets.done for subtree '%s':(%d) %s",
+        nix::concatStringsSep( ".", this->getAttrSetPath( prefixId ) ),
+        rcode,
+        this->db.error_msg() ) );
     }
 }
 

--- a/src/resolver/descriptor.cc
+++ b/src/resolver/descriptor.cc
@@ -114,7 +114,7 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
 {
   if ( ! raw.absPath.has_value() )
     {
-      throw FloxException(
+      throw InvalidManifestDescriptorException(
         "`absPath' must be set when calling "
         "`flox::resolver::ManifestDescriptor::initManifestDescriptorAbsPath'" );
     }
@@ -124,20 +124,21 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
 
   if ( glob.size() < 3 )
     {
-      throw FloxException( "`absPath' must have at least three parts" );
+      throw InvalidManifestDescriptorException(
+        "`absPath' must have at least three parts" );
     }
 
   const auto & first = glob.front();
   if ( ! first.has_value() )
     {
-      throw FloxException(
+      throw InvalidManifestDescriptorException(
         "`absPath' may only have a glob as its second element" );
     }
   desc.subtree = Subtree( *first );
 
   if ( raw.stability.has_value() && ( first.value() != "catalog" ) )
     {
-      throw FloxException(
+      throw InvalidManifestDescriptorException(
         "`stability' cannot be used with non-catalog paths" );
     }
 
@@ -145,13 +146,13 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
     {
       if ( glob.size() < 4 )
         {
-          throw FloxException(
+          throw InvalidManifestDescriptorException(
             "`absPath' must have at least four parts for catalog paths" );
         }
       const auto & third = glob.at( 2 );
       if ( ! third.has_value() )
         {
-          throw FloxException(
+          throw InvalidManifestDescriptorException(
             "`absPath' may only have a glob as its second element" );
         }
       desc.stability = *third;
@@ -161,7 +162,7 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
           const auto & elem = *itr;
           if ( ! elem.has_value() )
             {
-              throw FloxException(
+              throw InvalidManifestDescriptorException(
                 "`absPath' may only have a glob as its second element" );
             }
           desc.path->emplace_back( *elem );
@@ -175,7 +176,7 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
           const auto & elem = *itr;
           if ( ! elem.has_value() )
             {
-              throw FloxException(
+              throw InvalidManifestDescriptorException(
                 "`absPath' may only have a glob as its second element" );
             }
           desc.path->emplace_back( *elem );
@@ -189,7 +190,7 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
       desc.systems = std::vector<std::string> { *second };
       if ( raw.systems.has_value() && ( *raw.systems != *desc.systems ) )
         {
-          throw FloxException(
+          throw InvalidManifestDescriptorException(
             "`systems' list conflicts with `absPath' system specification" );
         }
     }
@@ -241,7 +242,8 @@ ManifestDescriptor::ManifestDescriptor( const ManifestDescriptorRaw & raw )
         {
           if ( this->path != path )
             {
-              throw FloxException( "`path' conflicts with with `absPath'" );
+              throw InvalidManifestDescriptorException(
+                "`path' conflicts with with `absPath'" );
             }
         }
       else { this->path = path; }
@@ -251,7 +253,7 @@ ManifestDescriptor::ManifestDescriptor( const ManifestDescriptorRaw & raw )
     {
       if ( raw.input.has_value() )
         {
-          throw FloxException(
+          throw InvalidManifestDescriptorException(
             "`packageRepository' may not be used with `input'" );
         }
 

--- a/src/resolver/params.cc
+++ b/src/resolver/params.cc
@@ -105,7 +105,7 @@ PkgDescriptorRaw::fillPkgQueryArgs( pkgdb::PkgQueryArgs &pqa ) const
         {
           if ( this->path->size() < 3 )
             {
-              throw FloxException(
+              throw InvalidPkgDescriptorException(
                 "Absolute attribute paths must have at least three elements" );
             }
           Subtree subtree = Subtree::parseSubtree( *this->path->at( 0 ) );
@@ -118,7 +118,7 @@ PkgDescriptorRaw::fillPkgQueryArgs( pkgdb::PkgQueryArgs &pqa ) const
             {
               if ( this->path->size() < 4 )
                 {
-                  throw FloxException(
+                  throw InvalidPkgDescriptorException(
                     "Absolute attribute paths in catalogs must have at "
                     "least four elements" );
                 }

--- a/src/search/command.cc
+++ b/src/search/command.cc
@@ -100,10 +100,10 @@ SearchCommand::run()
         }
       return EXIT_SUCCESS;
     }
-  catch ( const pkgdb::PkgQuery::InvalidArgException & err )
+  catch ( const pkgdb::PkgQuery::InvalidPkgQueryArgException & err )
     {
       // TODO: DRY ( see main.cc )
-      int exitCode = EC_PKG_QUERY_INVALID_ARG;
+      int exitCode = EC_INVALID_PKG_QUERY_ARG;
       exitCode += static_cast<int>( err.errorCode );
       std::cout << "{ \"error\": \"" << err.what()
                 << "\", \"code\": " << exitCode << " }" << std::endl;

--- a/src/search/params.cc
+++ b/src/search/params.cc
@@ -40,13 +40,13 @@ from_json( const nlohmann::json &jfrom, SearchQuery &qry )
       }
     catch ( const nlohmann::json::exception &err )
       {
-        throw FloxException( "Failed to parse search query field: 'query." + key
-                             + "':\n  " + err.what() );
+        throw ParseSearchQueryException( "parsing field: 'query." + key + "'",
+                                         err.what() );
       }
     catch ( ... )
       {
-        throw FloxException( "Failed to parse search query field: 'query." + key
-                             + "'." );
+        throw ParseSearchQueryException( "parsing field: 'query." + key
+                                         + "'." );
       }
   };
 
@@ -59,8 +59,8 @@ from_json( const nlohmann::json &jfrom, SearchQuery &qry )
       else if ( key == "match" ) { getOrFail( key, value, qry.partialMatch ); }
       else
         {
-          throw FloxException( "Unrecognized search query key: 'query." + key
-                               + "'." );
+          throw ParseSearchQueryException( "unrecognized key: 'query." + key
+                                           + "'." );
         }
     }
 }

--- a/src/tomlToJSON.cc
+++ b/src/tomlToJSON.cc
@@ -22,29 +22,33 @@ namespace flox {
 /* -------------------------------------------------------------------------- */
 
 /** @brief An exception thrown when converting TOML to JSON */
-struct TOMLToJSONException : public FloxException
+class TOMLToJSONException : public FloxException
 {
+private:
+
   static constexpr std::string_view categoryMsg
     = "error converting TOML to JSON";
 
-  TOMLToJSONException( std::string_view contextMsg )
+public:
+
+  explicit TOMLToJSONException( std::string_view contextMsg )
     : FloxException( contextMsg )
   {}
-  TOMLToJSONException( std::string_view contextMsg, const char *caughtMsg )
+  explicit TOMLToJSONException( std::string_view contextMsg,
+                                const char      *caughtMsg )
     : FloxException( contextMsg, caughtMsg )
   {}
-  error_category
-  error_code() const noexcept override
+  [[nodiscard]] error_category
+  get_error_code() const noexcept override
   {
     return EC_TOML_TO_JSON;
   }
-  std::string_view
+  [[nodiscard]] std::string_view
   category_message() const noexcept override
   {
     return this->categoryMsg;
   }
-
-}; /* End struct `TOMLToJSONException' */
+}; /* End class `TOMLToJSONException' */
 
 
 nlohmann::json

--- a/src/yamlToJSON.cc
+++ b/src/yamlToJSON.cc
@@ -21,6 +21,37 @@ namespace flox {
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief An exception thrown when converting YAML to JSON */
+class YAMLToJSONException : public FloxException
+{
+private:
+
+  static constexpr std::string_view categoryMsg
+    = "error converting YAML to JSON";
+
+public:
+
+  explicit YAMLToJSONException( std::string_view contextMsg )
+    : FloxException( contextMsg )
+  {}
+  explicit YAMLToJSONException( std::string_view contextMsg,
+                                const char      *caughtMsg )
+    : FloxException( contextMsg, caughtMsg )
+  {}
+  [[nodiscard]] error_category
+  get_error_code() const noexcept override
+  {
+    return EC_YAML_TO_JSON;
+  }
+  [[nodiscard]] std::string_view
+  category_message() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+
+}; /* End class `YAMLToJSONException' */
+
+
 nlohmann::json
 yamlToJSON( std::string_view yaml )
 {
@@ -79,11 +110,11 @@ yamlToJSON( std::string_view yaml )
           break;
 
         case YAML::NodeType::Undefined:
-          throw FloxException( "YAML node has an undefined type" );
+          throw YAMLToJSONException( "YAML node has an undefined type" );
           break;
 
         default:
-          throw FloxException( "YAML node has an unrecognized type" );
+          throw YAMLToJSONException( "YAML node has an unrecognized type" );
           break;
       }
   }; /* End fn `visit()' */
@@ -98,12 +129,11 @@ yamlToJSON( std::string_view yaml )
     }
   catch ( const std::exception &e )
     {
-      throw FloxException( "while parsing a YAML string: "
-                           + std::string( e.what() ) );
+      throw YAMLToJSONException( "while parsing a YAML string", e.what() );
     }
   catch ( ... )
     {
-      throw FloxException( "while parsing a YAML string: unknown error" );
+      throw YAMLToJSONException( "while parsing a YAML string" );
     }
 
   assert( false ); /* Unreachable */

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
+exceptions
 is_sqlite3
 manifest
 pkgdb

--- a/tests/exceptions.cc
+++ b/tests/exceptions.cc
@@ -1,0 +1,65 @@
+/* ========================================================================== *
+ *
+ * @file resolver.cc
+ *
+ * @brief Tests for `flox::exceptions`.
+ *
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#include <cstdlib>
+#include <iostream>
+
+#include "flox/core/command.hh"
+#include "flox/core/exceptions.hh"
+#include "test.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+using namespace flox;
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test what_string correctly calls virtual methods. */
+bool
+test_what_string()
+{
+  FloxException base( "context" );
+  EXPECT_EQ( base.what_string(), "general error: context" );
+
+  command::InvalidArgException derived( "context" );
+  FloxException*               derived_ptr = &derived;
+
+  EXPECT_EQ( derived_ptr->what_string(), "invalid argument: context" );
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+int
+main()
+{
+  int exitCode = EXIT_SUCCESS;
+#define RUN_TEST( ... ) _RUN_TEST( exitCode, __VA_ARGS__ )
+
+  /* --------------------------------------------------------------------------
+   */
+
+  {
+
+    RUN_TEST( what_string );
+  }
+
+  return exitCode;
+}
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/tests/pkgdb.cc
+++ b/tests/pkgdb.cc
@@ -292,7 +292,6 @@ test_PkgQuery0( flox::pkgdb::PkgDb &db )
   if ( flox::pkgdb::sql_rc rc = cmd.execute(); flox::pkgdb::isSQLError( rc ) )
     {
       throw flox::pkgdb::PkgDbException(
-        db.dbPath,
         nix::fmt( "Failed to write Package 'hello':(%d) %s",
                   rc,
                   db.db.error_msg() ) );
@@ -383,7 +382,6 @@ test_PkgQuery1( flox::pkgdb::PkgDb &db )
   if ( flox::pkgdb::sql_rc rc = cmd.execute(); flox::pkgdb::isSQLError( rc ) )
     {
       throw flox::pkgdb::PkgDbException(
-        db.dbPath,
         nix::fmt( "Failed to write Packages:(%d) %s", rc, db.db.error_msg() ) );
     }
   flox::pkgdb::PkgQueryArgs qargs;
@@ -477,7 +475,6 @@ test_PkgQuery2( flox::pkgdb::PkgDb &db )
   if ( flox::pkgdb::sql_rc rc = cmd.execute(); flox::pkgdb::isSQLError( rc ) )
     {
       throw flox::pkgdb::PkgDbException(
-        db.dbPath,
         nix::fmt( "Failed to write Packages:(%d) %s", rc, db.db.error_msg() ) );
     }
   flox::pkgdb::PkgQueryArgs qargs;
@@ -638,7 +635,6 @@ test_getPackages0( flox::pkgdb::PkgDb &db )
   if ( flox::pkgdb::sql_rc rc = cmd.execute(); flox::pkgdb::isSQLError( rc ) )
     {
       throw flox::pkgdb::PkgDbException(
-        db.dbPath,
         nix::fmt( "Failed to write Packages:(%d) %s", rc, db.db.error_msg() ) );
     }
 
@@ -717,7 +713,6 @@ test_getPackages1( flox::pkgdb::PkgDb &db )
   if ( flox::pkgdb::sql_rc rc = cmd.execute(); flox::pkgdb::isSQLError( rc ) )
     {
       throw flox::pkgdb::PkgDbException(
-        db.dbPath,
         nix::fmt( "Failed to write Packages:(%d) %s", rc, db.db.error_msg() ) );
     }
 
@@ -802,7 +797,6 @@ test_getPackages2( flox::pkgdb::PkgDb &db )
   if ( flox::pkgdb::sql_rc rc = cmd.execute(); flox::pkgdb::isSQLError( rc ) )
     {
       throw flox::pkgdb::PkgDbException(
-        db.dbPath,
         nix::fmt( "Failed to write Packages:(%d) %s", rc, db.db.error_msg() ) );
     }
 
@@ -850,7 +844,6 @@ test_DbPackage0( flox::pkgdb::PkgDb &db )
   if ( flox::pkgdb::sql_rc rc = cmd.execute(); flox::pkgdb::isSQLError( rc ) )
     {
       throw flox::pkgdb::PkgDbException(
-        db.dbPath,
         nix::fmt( "Failed to write Packages:(%d) %s", rc, db.db.error_msg() ) );
     }
   row_id pkgId = db.db.last_insert_rowid();
@@ -920,7 +913,6 @@ test_getPackages_semver0( flox::pkgdb::PkgDb &db )
   if ( flox::pkgdb::sql_rc rc = cmd.execute(); flox::pkgdb::isSQLError( rc ) )
     {
       throw flox::pkgdb::PkgDbException(
-        db.dbPath,
         nix::fmt( "Failed to write Packages:(%d) %s", rc, db.db.error_msg() ) );
     }
 


### PR DESCRIPTION
Having custom exceptions with their own error codes will allow better handling of errors when consuming pkgdb output from Rust.

Also remove dbPath from PkgDbException as it was not being used.