### PR TITLE
refactor: split `main` method into `run` and error handling

### DIFF
--- a/include/flox/core/exceptions.hh
+++ b/include/flox/core/exceptions.hh
@@ -101,8 +101,7 @@ public:
   [[nodiscard]] std::string
   what_string() const noexcept;
 
-  [[nodiscard]] nlohmann::json
-  to_json() const noexcept;
+  friend void to_json( nlohmann::json & jto, const FloxException & err );
 };
 
 

--- a/include/flox/core/exceptions.hh
+++ b/include/flox/core/exceptions.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <nlohmann/json.hpp>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -99,6 +100,9 @@ public:
   //   methods.
   [[nodiscard]] std::string
   what_string() const noexcept;
+
+  [[nodiscard]] nlohmann::json
+  to_json() const noexcept;
 };
 
 

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -12,7 +12,6 @@
 #include <filesystem>
 #include <fstream>
 
-
 #include "flox/core/exceptions.hh"
 
 
@@ -40,31 +39,27 @@ FloxException::what_string() const noexcept
 
 /* -------------------------------------------------------------------------- */
 
-nlohmann::json
-FloxException::to_json() const noexcept
+void
+to_json( nlohmann::json & jto, const FloxException & err )
 {
-
   std::string msg;
-  if ( this->contextMsg.has_value() )
+  if ( err.contextMsg.has_value() )
     {
       msg += ": ";
-      msg += *( this->contextMsg );
+      msg += *( err.contextMsg );
     }
-  if ( this->caughtMsg.has_value() )
+  if ( err.caughtMsg.has_value() )
     {
       msg += ": ";
-      msg += *( this->caughtMsg );
+      msg += *( err.caughtMsg );
     }
 
-  nlohmann::json json = {
-    { "exit_code", this->get_error_code() },
+  jto = {
+    { "exit_code", err.get_error_code() },
     { "message", msg },
-    { "category", this->category_message() },
+    { "category", err.category_message() },
   };
-
-  return json;
 }
-
 
 }  // namespace flox
 

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -40,6 +40,32 @@ FloxException::what_string() const noexcept
 
 /* -------------------------------------------------------------------------- */
 
+nlohmann::json
+FloxException::to_json() const noexcept
+{
+
+  std::string msg;
+  if ( this->contextMsg.has_value() )
+    {
+      msg += ": ";
+      msg += *( this->contextMsg );
+    }
+  if ( this->caughtMsg.has_value() )
+    {
+      msg += ": ";
+      msg += *( this->caughtMsg );
+    }
+
+  nlohmann::json json = {
+    { "exit_code", this->get_error_code() },
+    { "message", msg },
+    { "category", this->category_message() },
+  };
+
+  return json;
+}
+
+
 }  // namespace flox
 
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -80,17 +80,25 @@ main( int argc, char *argv[] )
     }
   catch ( const flox::FloxException &err )
     {
-      std::cout << err.to_json() << std::endl;
+      if ( ! isatty( STDERR_FILENO ) )
+        {
+          std::cout << err.to_json() << std::endl;
+        }
+      else { std::cerr << err.what() << std::endl; }
+
       return err.get_error_code();
     }
   catch ( const std::exception &err )
     {
-      nlohmann::json error = {
-        { "exit_code", EXIT_FAILURE },
-        { "message", err.what() },
-      };
-
-      std::cout << error << std::endl;
+      if ( ! isatty( STDERR_FILENO ) )
+        {
+          nlohmann::json error = {
+            { "exit_code", EXIT_FAILURE },
+            { "message", err.what() },
+          };
+          std::cout << error << std::endl;
+        }
+      else { std::cerr << err.what() << std::endl; }
 
       return flox::EC_FAILURE;
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -82,7 +82,7 @@ main( int argc, char *argv[] )
     {
       if ( ! isatty( STDERR_FILENO ) )
         {
-          std::cout << err.to_json() << std::endl;
+          std::cout << nlohmann::json( err ).dump() << std::endl;
         }
       else { std::cerr << err.what() << std::endl; }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -11,6 +11,7 @@
 #include <iostream>
 
 #include "flox/core/command.hh"
+#include "flox/core/exceptions.hh"
 #include "flox/pkgdb/command.hh"
 #include "flox/pkgdb/write.hh"
 #include "flox/resolver/command.hh"
@@ -20,9 +21,8 @@
 /* -------------------------------------------------------------------------- */
 
 int
-main( int argc, char * argv[] )
+run( int argc, char *argv[] )
 {
-
   /* Define arg parsers. */
 
   flox::command::VerboseParser prog( "pkgdb", FLOX_PKGDB_VERSION );
@@ -50,90 +50,50 @@ main( int argc, char * argv[] )
     {
       prog.parse_args( argc, argv );
     }
-  catch ( const flox::pkgdb::PkgQuery::InvalidPkgQueryArgException & err )
+  catch ( const std::runtime_error &err )
     {
-      // TODO: DRY ( see search/command.cc )
-      int exitCode = flox::EC_INVALID_PKG_QUERY_ARG;
-      exitCode += static_cast<int>( err.errorCode );
-      for ( int i = 1; i < argc; ++i )
-        {
-          if ( std::string_view( argv[i] ) == "search" )
-            {
-              std::cout << "{ \"error\": \"" << err.what()
-                        << "\", \"code\": " << exitCode << " }" << std::endl;
-              return exitCode;
-            }
-        }
-      std::cerr << "ERROR: " << err.what() << std::endl;
-      std::cerr << prog << std::endl;
-      return exitCode;
+      throw flox::command::InvalidArgException( err.what() );
     }
-  catch ( const std::exception & err )
-    {
-      // TODO: DRY ( see search/command.cc )
-      for ( int i = 1; i < argc; ++i )
-        {
-          if ( std::string_view( argv[i] ) == "search" )
-            {
-              std::cout << "{ \"error\": \"" << err.what()
-                        << "\", \"code\": " << flox::EC_FAILURE << " }"
-                        << std::endl;
-              return flox::EC_FAILURE;
-            }
-        }
-      std::cerr << "ERROR: " << err.what() << std::endl;
-      std::cerr << prog << std::endl;
-      return flox::EC_FAILURE;
-    }
-
 
   /* Run subcommand */
 
+  if ( prog.is_subcommand_used( "scrape" ) ) { return cmdScrape.run(); }
+  if ( prog.is_subcommand_used( "get" ) ) { return cmdGet.run(); }
+  if ( prog.is_subcommand_used( "list" ) ) { return cmdList.run(); }
+  if ( prog.is_subcommand_used( "search" ) ) { return cmdSearch.run(); }
+  if ( prog.is_subcommand_used( "resolve" ) ) { return cmdResolve.run(); }
+
+  // TODO: better error for this,
+  // likely only occurs if we add a new command without handling it (?)
+  throw flox::FloxException( "unrecognized command" );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+int
+main( int argc, char *argv[] )
+{
   try
     {
-      if ( prog.is_subcommand_used( "scrape" ) ) { return cmdScrape.run(); }
-      if ( prog.is_subcommand_used( "get" ) ) { return cmdGet.run(); }
-      if ( prog.is_subcommand_used( "list" ) ) { return cmdList.run(); }
-      if ( prog.is_subcommand_used( "search" ) ) { return cmdSearch.run(); }
-      if ( prog.is_subcommand_used( "resolve" ) ) { return cmdResolve.run(); }
+      return run( argc, argv );
     }
-  catch ( const flox::pkgdb::PkgQuery::InvalidPkgQueryArgException & err )
+  catch ( const flox::FloxException &err )
     {
-      // TODO: DRY ( see search/command.cc )
-      int exitCode = flox::EC_INVALID_PKG_QUERY_ARG;
-      exitCode += static_cast<int>( err.errorCode );
-      for ( int i = 1; i < argc; ++i )
-        {
-          if ( std::string_view( argv[i] ) == "search" )
-            {
-              std::cout << "{ \"error\": \"" << err.what()
-                        << "\", \"code\": " << exitCode << " }" << std::endl;
-              return exitCode;
-            }
-        }
-      std::cerr << "ERROR: " << err.what() << std::endl;
-      std::cerr << prog << std::endl;
-      return exitCode;
+      std::cout << err.to_json() << std::endl;
+      return err.get_error_code();
     }
-  catch ( const std::exception & err )
+  catch ( const std::exception &err )
     {
-      // TODO: DRY ( see search/command.cc )
-      for ( int i = 1; i < argc; ++i )
-        {
-          if ( std::string_view( argv[i] ) == "search" )
-            {
-              std::cout << "{ \"error\": \"" << err.what()
-                        << "\", \"code\": " << flox::EC_FAILURE << " }"
-                        << std::endl;
-              return flox::EC_FAILURE;
-            }
-        }
-      std::cerr << "ERROR: " << err.what() << std::endl;
-      std::cerr << prog << std::endl;
+      nlohmann::json error = {
+        { "exit_code", EXIT_FAILURE },
+        { "message", err.what() },
+      };
+
+      std::cout << error << std::endl;
+
       return flox::EC_FAILURE;
     }
-
-  return EXIT_FAILURE;
 }
 
 

--- a/src/search/command.cc
+++ b/src/search/command.cc
@@ -86,36 +86,17 @@ SearchCommand::SearchCommand() : parser( "search" )
 int
 SearchCommand::run()
 {
-  try
+  pkgdb::PkgQueryArgs args;
+  for ( const auto & [name, input] : *this->getPkgDbRegistry() )
     {
-      pkgdb::PkgQueryArgs args;
-      for ( const auto & [name, input] : *this->getPkgDbRegistry() )
+      this->params.fillPkgQueryArgs( name, args );
+      this->query = pkgdb::PkgQuery( args );
+      for ( const auto & row : this->queryDb( *input->getDbReadOnly() ) )
         {
-          this->params.fillPkgQueryArgs( name, args );
-          this->query = pkgdb::PkgQuery( args );
-          for ( const auto & row : this->queryDb( *input->getDbReadOnly() ) )
-            {
-              this->showRow( *input, row );
-            }
+          this->showRow( *input, row );
         }
-      return EXIT_SUCCESS;
     }
-  catch ( const pkgdb::PkgQuery::InvalidPkgQueryArgException & err )
-    {
-      // TODO: DRY ( see main.cc )
-      int exitCode = EC_INVALID_PKG_QUERY_ARG;
-      exitCode += static_cast<int>( err.errorCode );
-      std::cout << "{ \"error\": \"" << err.what()
-                << "\", \"code\": " << exitCode << " }" << std::endl;
-      return exitCode;
-    }
-  catch ( const std::exception & err )
-    {
-      // TODO: DRY ( see main.cc )
-      std::cout << "{ \"error\": \"" << err.what()
-                << "\", \"code\": " << EC_FAILURE << " }" << std::endl;
-      return EC_FAILURE;
-    }
+  return EXIT_SUCCESS;
 }
 
 


### PR DESCRIPTION
* `main` now just invokes run and handles terminal exceptions.
* `FloxExceptions` can be formatted as json
* Error handling for search was dropped for the global error handling in `main`
