### PR TITLE
follow nixpkgs/release-23.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,15 +42,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691697597,
-        "narHash": "sha256-ceZ8kndUbs9S1mpB+8DyegukCz4cl+VvVphctdG+RSQ=",
+        "lastModified": 1697828342,
+        "narHash": "sha256-DSaN5aa+Kyo84GoQL1dIg0H9AMLl8yU4q+uN2AjEi4s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a584ba59f5934de6abf8ccf71508145c505e280",
+        "rev": "96f7c64907ccdb53e36b3c02b5165dfd491ec0db",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "release-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,8 @@
 
 # ---------------------------------------------------------------------------- #
 
-  inputs.nixpkgs.url                      = "github:NixOS/nixpkgs";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-23.05";
+
   inputs.floco.url                        = "github:aakropotkin/floco";
   inputs.floco.inputs.nixpkgs.follows     = "/nixpkgs";
   inputs.argparse.url                     = "github:aakropotkin/argparse";
@@ -34,7 +35,11 @@
 
 # ---------------------------------------------------------------------------- #
 
+    /* Use nix@2.15 */
+    overlays.nix = final: prev: { nix = prev.nixVersions.nix_2_15; };
+    /* Aggregate dependency overlays. */
     overlays.deps = nixpkgs.lib.composeManyExtensions [
+      overlays.nix
       floco.overlays.default
       sqlite3pp.overlays.default
       argparse.overlays.default


### PR DESCRIPTION
Use `github:NixOS/nixpkgs/release-23.05` branch for `nixpkgs` input.
Make use of `nix@2.15` explicit in overlay.