### PR TITLE
style: drop separators from tests' main functions

### DIFF
--- a/tests/pkgdb.cc
+++ b/tests/pkgdb.cc
@@ -987,9 +987,6 @@ main( int argc, char *argv[] )
   int ec = EXIT_SUCCESS;
 #define RUN_TEST( ... ) _RUN_TEST( ec, __VA_ARGS__ )
 
-  /* --------------------------------------------------------------------------
-   */
-
   nix::verbosity = nix::lvlWarn;
   if ( ( 1 < argc ) && ( std::string_view( argv[1] ) == "-v" ) )
     {
@@ -1000,9 +997,6 @@ main( int argc, char *argv[] )
   flox::NixState nstate;
 
 
-  /* --------------------------------------------------------------------------
-   */
-
   auto [fd, path] = nix::createTempFile( "test-pkgdb.sql" );
   fd.close();
 
@@ -1010,12 +1004,7 @@ main( int argc, char *argv[] )
 
   flox::FloxFlake flake( nstate.getState(), ref );
 
-
-  /* --------------------------------------------------------------------------
-   */
-
   {
-
     flox::pkgdb::PkgDb db( flake.lockedFlake, path );
 
     RUN_TEST( addOrGetAttrSetId0, db );
@@ -1047,18 +1036,10 @@ main( int argc, char *argv[] )
     RUN_TEST( getPackages_semver0, db );
   }
 
-
-  /* --------------------------------------------------------------------------
-   */
-
   /* XXX: You may find it useful to preserve the file and print it for some
    *      debugging efforts. */
   std::filesystem::remove( path );
   // std::cerr << path << std::endl;
-
-
-  /* --------------------------------------------------------------------------
-   */
 
   return ec;
 }

--- a/tests/registry.cc
+++ b/tests/registry.cc
@@ -5,7 +5,6 @@
  * @brief Tests for `flox::Registry` interfaces.
  *
  *
- *
  * -------------------------------------------------------------------------- */
 
 #include <cstdlib>
@@ -157,9 +156,6 @@ main( int argc, char *argv[] )
   int exitCode = EXIT_SUCCESS;
 #define RUN_TEST( ... ) _RUN_TEST( exitCode, __VA_ARGS__ )
 
-  /* --------------------------------------------------------------------------
-   */
-
   nix::verbosity = nix::lvlWarn;
   if ( ( 1 < argc ) && ( std::string_view( argv[1] ) == "-v" ) )  // NOLINT
     {
@@ -169,22 +165,11 @@ main( int argc, char *argv[] )
   /* Initialize `nix' */
   flox::NixState nstate;
 
-
-  /* --------------------------------------------------------------------------
-   */
-
-
-  /* --------------------------------------------------------------------------
-   */
-
-  {
-
-    RUN_TEST( FloxFlakeInputRegistry0 );
-    RUN_TEST( ManifestFileMixinHappyPath );
-    RUN_TEST( ManifestFileMixinGetRegWithoutFile );
-    RUN_TEST( ManifestFileMixinGetRegCached );
-    RUN_TEST( ManifestFileMixinEmptyPath );
-  }
+  RUN_TEST( FloxFlakeInputRegistry0 );
+  RUN_TEST( ManifestFileMixinHappyPath );
+  RUN_TEST( ManifestFileMixinGetRegWithoutFile );
+  RUN_TEST( ManifestFileMixinGetRegCached );
+  RUN_TEST( ManifestFileMixinEmptyPath );
 
 
   return exitCode;

--- a/tests/resolver.cc
+++ b/tests/resolver.cc
@@ -156,34 +156,20 @@ main( int argc, char * argv[] )
   int exitCode = EXIT_SUCCESS;
 #define RUN_TEST( ... ) _RUN_TEST( exitCode, __VA_ARGS__ )
 
-  /* --------------------------------------------------------------------------
-   */
-
   nix::verbosity = nix::lvlWarn;
   if ( ( 1 < argc ) && ( std::string_view( argv[1] ) == "-v" ) )  // NOLINT
     {
       nix::verbosity = nix::lvlDebug;
     }
 
-
-  /* --------------------------------------------------------------------------
-   */
-
   /* Make a temporary directory for cache DBs to ensure tests
    * are reproducible. */
   std::string cacheDir = nix::createTempDir();
   setenv( "PKGDB_CACHEDIR", cacheDir.c_str(), 1 );
 
-
-  /* --------------------------------------------------------------------------
-   */
-
-  {
-
-    RUN_TEST( resolve0 );
-    RUN_TEST( resolveStabilities );
-    RUN_TEST( resolveInput );
-  }
+  RUN_TEST( resolve0 );
+  RUN_TEST( resolveStabilities );
+  RUN_TEST( resolveInput );
 
   /* Cleanup the temporary directory. */
   nix::deletePath( cacheDir );


### PR DESCRIPTION
Deletes some wonky separators in functions that `make fmt` indents and breaks over multiple lines.