### PR TITLE
feat: catch nix errors

### DIFF
--- a/include/flox/flox-flake.hh
+++ b/include/flox/flox-flake.hh
@@ -17,6 +17,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "flox/core/exceptions.hh"
 #include "flox/core/nix-state.hh"
 #include "flox/core/types.hh"
 
@@ -115,6 +116,40 @@ public:
   openCursor( const AttrPath & path );
 
 }; /* End class `FloxFlake' */
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief An exception thrown when locking a flake */
+class LockFlakeException : public FloxException
+{
+
+private:
+
+  static constexpr std::string_view categoryMsg = "error locking flake";
+
+public:
+
+  explicit LockFlakeException( std::string_view contextMsg )
+    : FloxException( contextMsg )
+  {}
+  explicit LockFlakeException( std::string_view contextMsg,
+                               const char *     caughtMsg )
+    : FloxException( contextMsg, caughtMsg )
+  {}
+
+  [[nodiscard]] error_category
+  getErrorCode() const noexcept override
+  {
+    return EC_NIX_LOCK_FLAKE;
+  }
+
+  [[nodiscard]] std::string_view
+  getCategoryMessage() const noexcept override
+  {
+    return this->categoryMsg;
+  }
+
+}; /* End class `LockFlakeException' */
 
 
 /* -------------------------------------------------------------------------- */

--- a/src/flox-flake.cc
+++ b/src/flox-flake.cc
@@ -22,11 +22,24 @@ namespace flox {
 
 /* -------------------------------------------------------------------------- */
 
-FloxFlake::FloxFlake( const nix::ref<nix::EvalState> & state,
-                      const nix::FlakeRef &            ref )
-  : state( state )
-  , lockedFlake( nix::flake::lockFlake( *this->state, ref, defaultLockFlags ) )
-{}
+FloxFlake::FloxFlake( const nix::ref<nix::EvalState> &state,
+                      const nix::FlakeRef            &ref )
+try : state( state ),
+  lockedFlake( nix::flake::lockFlake( *this->state, ref, defaultLockFlags ) )
+  {}
+catch ( const std::exception &err )
+  {
+
+    throw LockFlakeException(
+      "failed to lock flake \"" + ref.to_string() + "\"",
+      nix::filterANSIEscapes( err.what(), true ).c_str() );
+  }
+catch ( ... )
+  {
+
+    throw LockFlakeException( "failed to lock flake \"" + ref.to_string()
+                              + "\"" );
+  }
 
 
 /* -------------------------------------------------------------------------- */
@@ -44,12 +57,12 @@ FloxFlake::openEvalCache()
         *this->state,
         [&]()
         {
-          nix::Value * vFlake = this->state->allocValue();
+          nix::Value *vFlake = this->state->allocValue();
           nix::flake::callFlake( *this->state, this->lockedFlake, *vFlake );
           this->state->forceAttrs( *vFlake,
                                    nix::noPos,
                                    "while parsing cached flake data" );
-          nix::Attr * aOutputs
+          nix::Attr *aOutputs
             = vFlake->attrs->get( this->state->symbols.create( "outputs" ) );
           assert( aOutputs != nullptr );
           return aOutputs->value;
@@ -62,10 +75,10 @@ FloxFlake::openEvalCache()
 /* -------------------------------------------------------------------------- */
 
 MaybeCursor
-FloxFlake::maybeOpenCursor( const AttrPath & path )
+FloxFlake::maybeOpenCursor( const AttrPath &path )
 {
   MaybeCursor cur = this->openEvalCache()->getRoot();
-  for ( const auto & part : path )
+  for ( const auto &part : path )
     {
       cur = cur->maybeGetAttr( part );
       if ( cur == nullptr ) { break; }
@@ -77,10 +90,10 @@ FloxFlake::maybeOpenCursor( const AttrPath & path )
 /* -------------------------------------------------------------------------- */
 
 Cursor
-FloxFlake::openCursor( const AttrPath & path )
+FloxFlake::openCursor( const AttrPath &path )
 {
   Cursor cur = this->openEvalCache()->getRoot();
-  for ( const auto & part : path ) { cur = cur->getAttr( part ); }
+  for ( const auto &part : path ) { cur = cur->getAttr( part ); }
   return cur;
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -88,9 +88,24 @@ main( int argc, char *argv[] )
         {
           std::cout << nlohmann::json( err ).dump() << std::endl;
         }
-      else { std::cerr << err.what() << std::endl; }
+      else { std::cerr << err.whatString() << std::endl; }
 
       return err.getErrorCode();
+    }
+  // TODO: we may want to catch these closer to where they are originally thrown
+  catch ( const nix::Error &err )
+    {
+      if ( ! isatty( STDERR_FILENO ) )
+        {
+          nlohmann::json error = {
+            { "exit_code", flox::EC_NIX },
+            { "message", nix::filterANSIEscapes( err.what(), true ) },
+          };
+          std::cout << error << std::endl;
+        }
+      else { std::cerr << err.what() << std::endl; }
+
+      return flox::EC_NIX;
     }
   catch ( const std::exception &err )
     {

--- a/src/pkgdb/input.cc
+++ b/src/pkgdb/input.cc
@@ -85,9 +85,9 @@ PkgDbInput::scrapePrefix( const flox::AttrPath & prefix )
 {
   if ( this->getDbReadOnly()->completedAttrSet( prefix ) ) { return; }
 
-  Todos       todo;
-  bool        wasRW = this->dbRW != nullptr;
-  MaybeCursor root  = this->getFlake()->maybeOpenCursor( prefix );
+  Todos todo;
+  bool  wasRW = this->dbRW != nullptr;
+  MaybeCursor root = this->getFlake()->maybeOpenCursor( prefix );
 
   if ( root == nullptr ) { return; }
 
@@ -111,12 +111,12 @@ PkgDbInput::scrapePrefix( const flox::AttrPath & prefix )
       /* Mark the prefix and its descendants as "done" */
       dbRW->setPrefixDone( row, true );
     }
-  catch ( const nix::EvalError & )
+  catch ( const nix::EvalError & err )
     {
       txn.rollback();
       /* Close the r/w connection if we opened it. */
       if ( ! wasRW ) { this->closeDbReadWrite(); }
-      throw;
+      throw NixEvalException( "error scraping flake", err );
     }
 
   /* Close the transaction. */

--- a/src/registry.cc
+++ b/src/registry.cc
@@ -147,20 +147,28 @@ FloxFlakeInput::getSubtrees()
         }
       else
         {
-          auto root = this->getFlake()->openEvalCache()->getRoot();
-          if ( root->maybeGetAttr( "catalog" ) != nullptr )
+          try
             {
-              this->enabledSubtrees = std::vector<Subtree> { ST_CATALOG };
+              auto root = this->getFlake()->openEvalCache()->getRoot();
+              if ( root->maybeGetAttr( "catalog" ) != nullptr )
+                {
+                  this->enabledSubtrees = std::vector<Subtree> { ST_CATALOG };
+                }
+              else if ( root->maybeGetAttr( "packages" ) != nullptr )
+                {
+                  this->enabledSubtrees = std::vector<Subtree> { ST_PACKAGES };
+                }
+              else if ( root->maybeGetAttr( "legacyPackages" ) != nullptr )
+                {
+                  this->enabledSubtrees = std::vector<Subtree> { ST_LEGACY };
+                }
+              else { this->enabledSubtrees = std::vector<Subtree> {}; }
             }
-          else if ( root->maybeGetAttr( "packages" ) != nullptr )
+          catch ( const nix::EvalError &err )
             {
-              this->enabledSubtrees = std::vector<Subtree> { ST_PACKAGES };
+              throw NixEvalException( "could not determine flake subtrees",
+                                      err );
             }
-          else if ( root->maybeGetAttr( "legacyPackages" ) != nullptr )
-            {
-              this->enabledSubtrees = std::vector<Subtree> { ST_LEGACY };
-            }
-          else { this->enabledSubtrees = std::vector<Subtree> {}; }
         }
     }
   return *this->enabledSubtrees;


### PR DESCRIPTION
- Add LockFlakeException to catch any exceptions thrown while calling nix::flake::lockFlake
- Add NixEvalException to catch nix::EvalError
- Catch any other nix::Error in main()
- Minor fix: use whatString instead of what for FloxException in main, as it will contain more information