### PR TITLE
fix: use multiple outputs to isolate boost-dev

### DIFF
--- a/pkg-fun.nix
+++ b/pkg-fun.nix
@@ -38,10 +38,10 @@
                     ( ! ( builtins.elem ext ignoredExts ) );
     in notIgnored && notResult;
   };
-  propagatedBuildInputs = [semver nix.dev boost];
+  propagatedBuildInputs = [semver nix.dev];
   nativeBuildInputs     = [pkg-config];
   buildInputs           = [
-    sqlite.dev nlohmann_json argparse sqlite3pp toml11 yaml-cpp
+    sqlite.dev nlohmann_json argparse sqlite3pp toml11 yaml-cpp boost
   ];
   nix_INCDIR     = nix.dev.outPath + "/include";
   boost_CFLAGS   = "-I" + boost.dev.outPath + "/include";
@@ -60,6 +60,7 @@
   # Checks require internet
   doCheck          = false;
   doInstallCheck   = false;
+  outputs = ["out" "dev"];
   meta.mainProgram = "pkgdb";
 }
 


### PR DESCRIPTION
Another option is to not use manual boost_CFLAGS, but this seems cleaner.

boost-dev becomes a part of the pc file:
```
lib/pkgconfig/flox-pkgdb.pc: …clude/nix/config.h -I/nix/store/1kprdajc7d9s1lvcn8vddqf4gvbp8cxw-boost-1.79.0-dev/include
```

Goal is to not include all of boost development in runtime closure. This is a 200MB difference in the closure size.