### PR TITLE
doc: document query argument parsers

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -944,7 +944,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = README.md CONTRIBUTING.md src include  \
-                         docs/registry.md docs/search.md
+                         docs/registry.md docs/search.md        \
+                         docs/params-to-sql.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/params-to-sql.md
+++ b/docs/params-to-sql.md
@@ -22,7 +22,36 @@ This document will help you navigate these various structures and help you
 identify common patterns among them.
 
 
-## Query Argument Data
+## Terminology
+
+- Registry : A collection of _flake ref inputs_ assigned _short names_
+             or _aliases_ which comprise the pool of package sets to be queried.
+- Descriptor : An abstract description of a dependency by indicating
+               _requirements_ to be satisfied.
+               These are simply put a collection of user defined filters.
+               The most common descriptor is
+               _"give me a package with the name X"_, or maybe 
+               _"give me a package with the name X with version between 3-4"_.
+- Preferences : Settings or filters which apply to _all_ descriptors or 
+                registry inputs.
+                These may overlap with some _descriptor_ filters, but may be
+                defined _globally_ for convenience.
+                These are things like
+                _"limit search results to those with the following licenses: 
+                X, Y, Z_, or
+                _"treat prefer pre-release versions of sofware over the previous 
+                major release"_.
+
+
+## Query Argument and Registry Data
+
+The pipeline from user input into `PkgQueryArgs` and `RegistryRaw` structures
+is split across a few base classes in an attempt to avoid repeating common
+processes in multiple places - this comes at the expense of making it slightly
+harder for readers to trace; the aim of this section is to aggregate all of
+classes related to this transformation in one place, and describe their
+relationships to one another.
+
 
 ### PkgQueryArgs
 

--- a/docs/params-to-sql.md
+++ b/docs/params-to-sql.md
@@ -199,7 +199,13 @@ struct PkgQueryArgs : public PkgDescriptorBase
 ```
 
 
-### flox::pkgdb::QueryPreferences
+### flox::pkgdb::QueryPreferences ( to be deprecated )
+
+NOTE: This structure is expected to be deprecated and replaced by a subset of
+      the `flox::resolver::ManifestRaw::Options` fields.
+      The current fields and fallback behavior there are identical, but
+      fallback handling was moved to an intermediate struct
+      `flox::resolver::UnlockedManifest`.
 
 Declared in
 [<pkgdb>/include/flox/pkgdb/params.hh](../include/flox/pkgdb/params.hh).
@@ -472,6 +478,13 @@ which describes an environment.
 Parts of this file are used to essentially construct something similar to
 the `flox::pkgdb::QueryParams<QueryType>` structure.
 
+The `flox::resolver::ManifestRaw` struct intends to exactly match the format
+of the file so that it can be used to validate its syntax, and be converted
+without any loss of detail into JSON ( to become a part of a lockfile ).
+With that in mind, no default fields are handled in this struct; instead
+handling of fallbacks is done in a related class
+`flox::resolver::UnlockedManifest`.
+
 While some fields in this file are not relevant to resolution/search all of them
 will be shown here.
 Here is its declaration:
@@ -518,6 +531,7 @@ struct ManifestRaw
   Options options;
 
   // Contains descriptors to be resolved.
+  // FIXME: This should be `ManifestDescriptorRaw`! ( to be fixed soon )
   std::unordered_map<std::string, ManifestDescriptor> install;
 
   RegistryRaw registry;
@@ -542,7 +556,7 @@ struct ManifestRaw
 NOTE: This struct is not in use by the `flox` CLI and was created strictly for
 testing resolution with `pkgdb resolve` in our own test suite.
 It is expected to be removed in the near future in favor
-of `flox::resolver::ManifestDescriptor`.
+of `flox::resolver::ManifestDescriptorRaw`.
 
 Declared in
 [<pkgdb>/include/flox/resolver/params.hh](../include/flox/resolver/params.hh).

--- a/docs/params-to-sql.md
+++ b/docs/params-to-sql.md
@@ -1,0 +1,19 @@
+# Query Arguments -> SQL Query Pipeline
+
+`pkgdb` exposes a number of interfaces for running complex queries against its
+underlying collection of package databases, making them easy for callers to use.
+These interfaces also help ensure consistent behavior and ranking between
+_search_ and _resolution_ queries.
+
+In order the ensure the behaviors of these two categories of queries are
+consistent they share a common underlying _query builder_ called a
+[PkgQuery](../include/flox/pkgdb/pkg-query.hh).
+This class takes a set of filter rules provided by the caller, called
+`PkgQueryArgs`, and can either emit a SQL `SELECT` statement as a string or
+run that query on databases using `PkgQuery::bind()` or `PkgQuery::execute()`.
+
+Throughout this codebase you will find various `struct` and `class` definitions
+which essentially exist to parse user input from JSON, TOML, or YAML and convert
+them into `PkgQueryArgs` and `Registry<PkgDbInput>` _registries_; just remember
+that past the tangled boilerplate of those routines - we're just moving fields
+from the user's input, into these `PkgQueryArgs` or a set of `PkgDbInput`s.

--- a/docs/params-to-sql.md
+++ b/docs/params-to-sql.md
@@ -52,6 +52,13 @@ harder for readers to trace; the aim of this section is to aggregate all of
 classes related to this transformation in one place, and describe their
 relationships to one another.
 
+Note that various existing parameter sets such as `flox::pkgdb::QueryParams`
+and `flox::resolver::PkgDescriptorRaw` are likely going to be replaced
+by `flox::resolver::ManifestRaw` and `flox::resolver::ManifestDescriptor` in
+the future.
+Nonetheless, they are discussed here to help other developers understand their
+functional and historical relationships with one another.
+
 
 ### flox::pkgdb::PkgDescriptorBase
 
@@ -95,6 +102,19 @@ Contained by:
 - `flox::pkgdb::QueryParams<pkg_descriptor_typename QueryType>`
   + Uses `pkg_descriptor_typename` concept to accept any child of
     `PkgDescriptorBase` as a template parameter.
+    
+    
+### flox::RegistryRaw
+
+Declared in [<pkgdb>/include/flox/registry.hh](../include/flox/registry.hh).
+
+This structure holds information about _flake inputs_ whose package databases
+should be scraped, some settings associated with each to indicate which
+_subtrees_/_stabilities_ should be searched, and the _priority_ order results
+should be _ranked_ by.
+
+A more detailed look at _registries_ and their fields can be
+found [here](./registry.md).
 
 
 ### flox::pkgdb::PkgQueryArgs
@@ -244,3 +264,356 @@ struct QueryPreferences
   
 };
 ```
+
+Child classes:
+- `flox::pkgdb::QueryParams`
+
+
+### flox::pkgdb::QueryParams ( to be deprecated )
+
+NOTE: This structure is expected to be deprecated in favor of a subset
+      of `flox::resolver::ManifestRaw` ( specifically its `options` and
+      `registry` fields ).
+
+Declared in
+[<pkgdb>/include/flox/pkgdb/params.hh](../include/flox/pkgdb/params.hh).
+
+This template is a _generic_ set of fields used to perform queries, which
+accepts a descriptor as a template argument.
+This allows this structure to be used for multiple use cases while avoiding
+repeated definitions of various fallback fields and conversion
+to `PkgQueryArgs`; however the _real_ purpose is to ensure consistency in
+these behaviors across different sets of parameters.
+
+At a high level `QueryParams` holds _preferences_
+( by extending `flox::pkgdb::QueryPreferences` ), a `flox::RegistryRaw`, and
+a _descriptor_ ( being any child class of `flox::pkgdb::PkgDescriptorBase` ).
+Here is its declaration:
+
+```c++
+template<pkg_descriptor_typename QueryType>
+struct QueryParams : public QueryPreferences
+{
+
+  using query_type = QueryType;
+
+  /* From `QueryPreferences':
+   *   std::vector<std::string> systems = { nix::settings.thisSystem.get() };
+   *   struct Allows {
+   *     bool unfree = true;
+   *     bool broken = false;
+   *     std::optional<std::vector<std::string>> licenses;
+   *   } allow;
+   *   struct Semver {
+   *     preferPreReleases = false;
+   *   } semver;
+   */
+
+  /** Settings and fetcher information associated with inputs. */
+  RegistryRaw registry;
+
+  /**
+   * @brief A single package descriptor in _raw_ form.
+   *
+   * This requires additional post-processing, such as "pushing down" global
+   * settings, before it can be used to perform resolution.
+   */
+  QueryType query;
+
+  // ...<SNIP>...
+  
+};
+```
+
+Template Instances:
+- `flox::resolver::ResolveOneParams = QueryParams<flox::resolver::PkgDescriptorRaw>`
+- `flox::search::SearchParams = QueryParams<flox::search::SearchQuery>`
+
+
+### flox::search::SearchQuery
+
+Declared in
+[<pkgdb>/include/flox/search/params.hh](../include/flox/search/params.hh).
+
+This set of parameters is used by `pkgdb search` in order to support
+`flox search` and `flox show` sub-commands.
+
+This is an incredibly lightweight extension of `flox::pkgdb::PkgDescriptorBase`
+which simply adds the ability to filter by a partial match on
+`pname`, `pkgAttrName`, or `description` fields ( using `partialMatch` field
+in `flox::pkgdb::PkgQueryArgs` ).
+It has the following declaration:
+
+```c++
+// NOTE: This document may be out of sync with `params.hh'.
+//       The header itself is the _source of truth_.
+/**
+ * @brief A set of query parameters.
+ *
+ * This is essentially a reorganized form of @a flox::pkgdb::PkgQueryArgs
+ * that is suited for JSON input.
+ */
+struct SearchQuery : public pkgdb::PkgDescriptorBase
+{
+
+  /* From `pkgdb::PkgDescriptorBase`:
+   *   std::optional<std::string> name;
+   *   std::optional<std::string> pname;
+   *   std::optional<std::string> version;
+   *   std::optional<std::string> semver;
+   */
+
+  /** Filter results by partial match on pname, pkgAttrName, or description */
+  std::optional<std::string> partialMatch;
+  
+  // ...<SNIP>...
+
+};
+```
+
+Contained by:
+- `flox::search::SearchParams = flox::pkgdb::QueryParams<flox::search::SearchQuery>`
+
+For a detailed look at `SearchParams` see 
+[pkgdb search](./search.md) documentation.
+
+
+### flox::resolver::ManifestDescriptorRaw
+
+Declared in
+[<pkgdb>/include/flox/resolver/descriptor.hh](../include/flox/resolver/descriptor.hh).
+
+This form of descriptor is found in `manifest.{toml,yaml,json}` files, and
+is the only descriptor that does not extend `flox::pkgdb::PkgDescriptorBase`.
+
+It currently uses an intermediate struct `ManifestDescriptor` as an intermediate
+step in its conversion to `flox::pkgdb::PkgQueryArgs`; but these two structures
+may be merged in the future.
+
+It has the following declaration:
+```c++
+struct ManifestDescriptorRaw
+{
+
+public:
+
+  /** 
+   * Match `name`, `pname`, or `pkgAttrName`.
+   * Maps to `flox::pkgdb::PkgQueryArgs::pnameOrPkgAttrName`.
+   */
+  std::optional<std::string> name;
+
+  /** 
+   * Match `version` or `semver` if a modifier is present. 
+   *
+   * Strings beginning with an `=` will filter by exact match on `version`.
+   * Any string which may be interpreted as a semantic version range will
+   * filter on the `semver` field.
+   * All other strings will filter by exact match on `version`.
+   */
+  std::optional<std::string> version;
+
+  /** Match a catalog stability. */
+  std::optional<std::string> stability;
+
+  /** @brief A dot separated attribut path, or list representation. */
+  using Path = std::variant<std::string, flox::AttrPath>;
+  /** Match a relative path. */
+  std::optional<Path> path;
+
+  /**
+   * @brief A dot separated attribut path, or list representation.
+   *        May contain `null` members to represent _globs_.
+   *
+   * NOTE: `AttrPathGlob` is a `std::vector<std::optional<std::string>>`
+   *       which represnts an absolute attribute path which may have
+           `std::nullopt` as its second element to avoid indicating a
+           particular system.
+   */
+  using AbsPath = std::variant<std::string, AttrPathGlob>;
+  /** Match an absolute path, allowing globs for `system`. */
+  std::optional<AbsPath> absPath;
+
+  /** Only resolve for a given set of systems. */
+  std::optional<std::vector<std::string>> systems;
+
+  /** Whether resoution is allowed to fail without producing errors. */
+  std::optional<bool> optional;
+
+  /** Named _group_ that the package is a member of. */
+  std::optional<std::string> packageGroup;
+
+  /** Force resolution is a given input or _flake reference_. */
+  std::optional<std::variant<std::string, nix::fetchers::Attrs>>
+    packageRepository;
+
+  /** Relative path to a `nix` expression file to be evaluated. */
+  std::optional<std::string> input;
+
+};
+```
+
+This descriptor will replace `flox::pkgdb::PkgDescriptorRaw` in the near future.
+
+Contained by:
+- `flox::resolver::ManifestRaw`
+
+
+### flox::resolver::ManifestRaw
+
+NOTE: Today this file is not used to support `flox search` but in the future
+      it will.
+
+Declared in
+[<pkgdb>/include/flox/resolver/manifest.hh](../include/flox/resolver/manifest.hh).
+
+This is our internal representation of a parsed `manifest.{toml,yaml,json}` file
+which describes an environment.
+Parts of this file are used to essentially construct something similar to
+the `flox::pkgdb::QueryParams<QueryType>` structure.
+
+While some fields in this file are not relevant to resolution/search all of them
+will be shown here.
+Here is its declaration:
+
+```c++
+/**
+ * @brief A _raw_ description of an environment to be read from a file.
+ *
+ * This _raw_ struct is defined to generate parsers, and its declarations simply
+ * represent what is considered _valid_.
+ * On its own, it performs no real work, other than to validate the input.
+ */
+struct ManifestRaw
+{
+
+  // NOTE: Unrelated to queries
+  struct EnvBase
+  {
+    std::optional<std::string> floxhub;
+    std::optional<std::string> dir;
+  };
+  std::optional<EnvBase> envBase;
+
+  // Similar to `flox::pkgdb::QueryPreferences`
+  struct Options
+  {
+    std::optional<std::vector<std::string>> systems;
+
+    struct Allows
+    {
+      std::optional<bool>                     unfree;
+      std::optional<bool>                     broken;
+      std::optional<std::vector<std::string>> licenses;
+    };
+    std::optional<Allows> allow;
+
+    struct Semver { std::optional<bool> preferPreReleases; };
+    std::optional<Semver> semver;
+
+    std::optional<std::string> packageGroupingStrategy;
+    std::optional<std::string> activationStrategy;
+    // TODO: Other options
+  };
+  Options options;
+
+  // Contains descriptors to be resolved.
+  std::unordered_map<std::string, ManifestDescriptor> install;
+
+  RegistryRaw registry;
+
+  // NOTE: Unrelated to queries
+  std::unordered_map<std::string, std::string> vars;
+
+  // NOTE: Unrelated to queries
+  struct Hook
+  {
+    std::optional<std::string> script;
+    std::optional<std::string> file;
+  };
+  std::optional<Hook> hook;
+
+};
+```
+
+
+### flox::resolver::PkgDescriptorRaw ( to be deprecated )
+
+NOTE: This struct is not in use by the `flox` CLI and was created strictly for
+testing resolution with `pkgdb resolve` in our own test suite.
+It is expected to be removed in the near future in favor
+of `flox::resolver::ManifestDescriptor`.
+
+Declared in
+[<pkgdb>/include/flox/resolver/params.hh](../include/flox/resolver/params.hh).
+
+This set of parameters extends `flox::pkgdb::PkgDescriptorBase` with the
+largest available set of filtering parameters.
+
+Often these parameters overlap with _global_ settings available in
+`flox::pkgdb::QueryPreferences` fields and `RegistryRaw` fields.
+This allows _global_ defaults to be either overridden
+( in the case of `QueryPreferences` ), or used to skip certain inputs
+( in the case of `RegistryRaw` and the `input` field ).
+
+
+```c++
+/**
+ * @brief A set of query parameters describing _requirements_ for a package.
+ *
+ * In its _raw_ form, we DO NOT expect that "global" filters have been pushed
+ * down into the descriptor, and do not attempt to distinguish from relative or
+ * absolute attribute paths in the @a path field.
+ */
+struct PkgDescriptorRaw : public pkgdb::PkgDescriptorBase
+{
+
+  /* From `pkgdb::PkgDescriptorBase':
+   *   std::optional<std::string> name;    //< Filter results by exact `name`.
+   *   std::optional<std::string> pname;   //< Filter results by exact `pname`.
+   *   std::optional<std::string> version; //< Filter results by exact version.
+   *   std::optional<std::string> semver;  //< Filter results by version range.
+   */
+
+  /**
+   * Filter results by an exact match on either `pname` or `pkgAttrName`.
+   * To match just `pname` see @a flox::pkgdb::PkgDescriptorBase.
+   */
+  std::optional<std::string> pnameOrPkgAttrName;
+
+  /** Restricts resolution to the named registry input. */
+  std::optional<std::string> input;
+
+  /**
+   * An absolute or relative attribut path to a package.
+   *
+   * May contain `std::nullopt` as its second member to indicate that any system
+   * is acceptable.
+   */
+  std::optional<AttrPathGlob> path;
+
+  /**
+   * Restricts resolution to a given subtree.
+   * Restricts resolution to a given subtree.
+   *
+   * This field must not conflict with the @a path field.
+   */
+  std::optional<std::string> subtree;
+
+  /** Restricts resolution to a given stability. */
+  std::optional<std::string> stability;
+
+  /**
+   * Whether pre-releases should be preferred over releases.
+   *
+   * Takes priority over `semver.preferPreReleases` "global" setting.
+   */
+  std::optional<bool> preferPreReleases = false;
+
+  // ...<SNIP>...
+
+};
+```
+
+Contained by:
+- `ResolveOneParams = flox::pkgdb::QueryParams<flox::resolver::PkgDescriptorRaw>`

--- a/docs/params-to-sql.md
+++ b/docs/params-to-sql.md
@@ -635,6 +635,15 @@ Contained by:
 
 ## TODO: Common Routines
 
+### `getBaseQueryArgs`
+
+This routine provides a _base_ set of `PkgQueryArgs` based on global settings
+so that they may be used to create individual descriptors' queries.
+
+This is currently only in use by `flox::resolver::UnlockedManifest`, but is
+preferred for any parameter set containing _global_ settings.
+
+
 ### `fillPkgQueryArgs`
 
 This routine appears on most parameter sets and is used to move parameter fields

--- a/docs/params-to-sql.md
+++ b/docs/params-to-sql.md
@@ -636,7 +636,54 @@ Contained by:
 ## TODO: Common Routines
 
 ### `fillPkgQueryArgs`
+
+This routine appears on most parameter sets and is used to move parameter fields
+into a `PkgQueryArgs` struct.
+
+In some cases these are implemented such that they will not override existing
+values or in other cases they will handle various fallbacks if a value is unset.
+
+
 ### `to_json` and `from_json`
+
+These routines allow a struct to be converted to/from JSON.
+These may be derived from templates, generated using `NLOHMANN_DEFINE_TYPE_*`
+macros, or explicitly defined.
+
+Our preference is to provide explicit definitions for these routines in order to
+emit customized `flox::FloxException` messages instead of the default messages
+created by `nlohmann::json::*` routines.
+
+In some cases `to_json` may not be required or implemented, but nearly all
+parameters have an implementation of `from_json`.
+
+
 ### `clear`
+
+Clears a set of parameters to their default state.
+This is largely used to recycle an existing parameter object
+without reallocating.
+
+
 ### `getRegistryRaw`
+
+This routine appears on parameter sets which contain a `flox::RegistryRaw`
+member or have the ability to reinterpret some of their fields to create
+a `flox::RegistryRaw`.
+
+It largely exists for convenience and to enforce privacy on member variables;
+however the constructor for `flox::pkgdb::PkgDbRegistryMixin`, which is
+responsible for instantiating `flox::pkgdb::PkgDbInput` elements from a
+`flox::RegistryRaw` requires child classes to implement this interface.
+
+
 ### `getSystems`
+
+This routine appears on parameter sets which contain a `systems` list
+member or have the ability to reinterpret some of their fields to create
+a list of _target_ `systems`.
+
+It largely exists for convenience and to enforce privacy on member variables;
+however the constructor for `flox::pkgdb::PkgDbRegistryMixin`, which is
+responsible for instantiating `flox::pkgdb::PkgDbInput` elements from a
+`flox::RegistryRaw` requires child classes to implement this interface.

--- a/docs/params-to-sql.md
+++ b/docs/params-to-sql.md
@@ -10,10 +10,95 @@ consistent they share a common underlying _query builder_ called a
 [PkgQuery](../include/flox/pkgdb/pkg-query.hh).
 This class takes a set of filter rules provided by the caller, called
 `PkgQueryArgs`, and can either emit a SQL `SELECT` statement as a string or
-run that query on databases using `PkgQuery::bind()` or `PkgQuery::execute()`.
+run that query on databases using `PkgQuery::bind( flox::pkgdb::database & )` or
+`PkgQuery::execute( flox::pkgdb::database & )`.
 
 Throughout this codebase you will find various `struct` and `class` definitions
 which essentially exist to parse user input from JSON, TOML, or YAML and convert
 them into `PkgQueryArgs` and `Registry<PkgDbInput>` _registries_; just remember
 that past the tangled boilerplate of those routines - we're just moving fields
 from the user's input, into these `PkgQueryArgs` or a set of `PkgDbInput`s.
+This document will help you navigate these various structures and help you
+identify common patterns among them.
+
+
+## Query Argument Data
+
+### PkgQueryArgs
+
+This is the _finalized_ set of arguments used to actually query a database.
+It has the following fields which are translated into SQL query filters,
+and in the case of the `semver` field additional filtering using `node-semver`
+will be performed.
+
+```c++
+// Taken from <pkgdb>/include/flox/pkgdb/pkg-query.hh
+// NOTE: This document may be out of sync with `pkg-query.hh'.
+//       The header itself is the _source of truth_.
+
+struct PkgQueryArgs : public PkgDescriptorBase
+{
+
+  /* From `PkgDescriptorBase':
+   *   std::optional<std::string> name;    //< Filter results by exact `name`.
+   *   std::optional<std::string> pname;   //< Filter results by exact `pname`.
+   *   std::optional<std::string> version; //< Filter results by exact version.
+   *   std::optional<std::string> semver;  //< Filter results by version range.
+   */
+
+  /** Filter results by partial match on pname, pkgAttrName, or description */
+  std::optional<std::string> partialMatch;
+
+  /**
+   * Filter results by an exact match on either `pname` or `pkgAttrName`.
+   * To match just `pname` see @a flox::pkgdb::PkgDescriptorBase.
+   */
+  std::optional<std::string> pnameOrPkgAttrName;
+
+  /** 
+   * Filter results to those explicitly marked with the given licenses.
+   *
+   * NOTE: License strings should be SPDX Ids ( short names ).
+   */
+  std::optional<std::vector<std::string>> licenses;
+
+  /** Whether to include packages which are explicitly marked `broken`. */
+  bool allowBroken = false;
+
+  /** Whether to include packages which are explicitly marked `unfree`. */
+  bool allowUnfree = true;
+
+  /** Whether pre-release versions should be ordered before releases. */
+  bool preferPreReleases = false;
+
+  /** 
+   * Subtrees to search.
+   * 
+   * NOTE: `Subtree` is an enum of top level flake outputs, being one of
+   * `"catalog"`, `"packages"`, or `"legacyPackages"`.
+   */
+  std::optional<std::vector<Subtree>> subtrees;
+
+  /** Systems to search. Defaults to the current system. */
+  std::vector<std::string> systems = { nix::settings.thisSystem.get() };
+
+  /** 
+   * Stabilities to search ( if any ).
+   *
+   * NOTE: Stabilities must be one of `"stable"`, `"staging"`, or `"unstable"`.
+   */
+  std::optional<std::vector<std::string>> stabilities;
+
+  /**
+   * Relative attribute path to package from its prefix.
+   * For catalogs this is the part following `stability`, and for regular flakes
+   * it is the part following `system`.
+   *
+   * NOTE: @a flox::AttrPath is an alias of `std::vector<std::string>`.
+   */
+  std::optional<flox::AttrPath> relPath;
+  
+  // ...<SNIP>...
+  
+};
+```

--- a/docs/params-to-sql.md
+++ b/docs/params-to-sql.md
@@ -617,3 +617,12 @@ struct PkgDescriptorRaw : public pkgdb::PkgDescriptorBase
 
 Contained by:
 - `ResolveOneParams = flox::pkgdb::QueryParams<flox::resolver::PkgDescriptorRaw>`
+
+
+## TODO: Common Routines
+
+### `fillPkgQueryArgs`
+### `to_json` and `from_json`
+### `clear`
+### `getRegistryRaw`
+### `getSystems`

--- a/include/flox/core/exceptions.hh
+++ b/include/flox/core/exceptions.hh
@@ -34,37 +34,43 @@ enum error_category {
   /** Generic exception emitted by `flox` routines. */
   EC_FLOX_EXCEPTION = 100,
   /** A command line argument is invalid. */
-  EC_INVALID_ARG,
+  EC_INVALID_ARG = 101,
   /** A package descriptor in a manifest is invalid. */
-  EC_INVALID_MANIFEST_DESCRIPTOR,
+  EC_INVALID_MANIFEST_DESCRIPTOR = 102,
   /** A PkgDescriptorRaw is invalid. */
-  EC_INVALID_PKG_DESCRIPTOR,
+  EC_INVALID_PKG_DESCRIPTOR = 103,
   /** Errors concerning validity of package query parameters. */
-  EC_INVALID_PKG_QUERY_ARG,
+  EC_INVALID_PKG_QUERY_ARG = 104,
   /** A registry has invalid contents. */
-  EC_INVALID_REGISTRY,
+  EC_INVALID_REGISTRY = 105,
   /** The value of `manifestPath' is invalid. */
-  EC_INVALID_MANIFEST_FILE,
-  /** `nix::Error` that doesn't fall under a more specific EC_NIX_* category. */
-  EC_NIX,
+  EC_INVALID_MANIFEST_FILE = 106,
+  /**
+   * `nix::Error` that doesn't fall under a more specific `EC_NIX_*` category.
+   */
+  EC_NIX = 107,
   /** `nix::EvalError` */
-  EC_NIX_EVAL,
+  EC_NIX_EVAL = 108,
   /** Exception locking a flake. */
-  EC_NIX_LOCK_FLAKE,
-  /** Exception initializing a `FlakePackage`. */
-  EC_PACKAGE_INIT,
-  /** Exception parsing `QueryParams` from JSON. */
-  EC_PARSE_QUERY_PARAMS,
-  /** Exception parsing `QueryPreferences` from JSON. */
-  EC_PARSE_QUERY_PREFERENCES,
-  /** Exception parsing `SearchQuery` from JSON. */
-  EC_PARSE_SEARCH_QUERY,
+  EC_NIX_LOCK_FLAKE = 109,
+  /** Exception initializing a @a flox::FlakePackage. */
+  EC_PACKAGE_INIT = 110,
+  /** Exception parsing @a flox::pkgdb::QueryParams from JSON. */
+  EC_PARSE_QUERY_PARAMS = 111,
+  /** Exception parsing @a flox::pkgdb::QueryPreferences from JSON. */
+  EC_PARSE_QUERY_PREFERENCES = 112,
+  /** Exception parsing @a flox::search::SearchQuery from JSON. */
+  EC_PARSE_SEARCH_QUERY = 113,
   /** For generic exceptions thrown by `flox::pkgdb::*` classes. */
-  EC_PKG_DB,
+  EC_PKG_DB = 114,
+  /** Exceptions thrown by SQLite3. */
+  EC_SQLITE3 = 115,
+  /** Exception parsing/processing JSON. */
+  EC_JSON = 116,
   /** Exception converting TOML to JSON. */
-  EC_TOML_TO_JSON,
+  EC_TOML_TO_JSON = 117,
   /** Exception converting YAML to JSON. */
-  EC_YAML_TO_JSON,
+  EC_YAML_TO_JSON = 118
 
 }; /* End enum `error_category' */
 

--- a/include/flox/flake-package.hh
+++ b/include/flox/flake-package.hh
@@ -207,7 +207,7 @@ public:
 /* -------------------------------------------------------------------------- */
 
 /**
- * @class
+ * @class flox::PackageInitException
  * @brief An exception thrown when initializing a @a flox::FlakePackage.
  */
 FLOX_DEFINE_EXCEPTION( PackageInitException,

--- a/include/flox/flake-package.hh
+++ b/include/flox/flake-package.hh
@@ -10,17 +10,14 @@
 
 #pragma once
 
-#include <functional>
 #include <memory>
 #include <nix/eval-cache.hh>
-#include <nix/fetchers.hh>
-#include <nix/flake/flake.hh>
 #include <nix/names.hh>
-#include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
 #include <vector>
 
+#include "flox/core/exceptions.hh"
 #include "flox/core/types.hh"
 #include "flox/package.hh"
 

--- a/include/flox/flox-flake.hh
+++ b/include/flox/flox-flake.hh
@@ -120,7 +120,7 @@ public:
 /* -------------------------------------------------------------------------- */
 
 /**
- * @class LockFlakeException
+ * @class flox::LockFlakeException
  * @brief An exception thrown when locking a flake
  */
 FLOX_DEFINE_EXCEPTION( LockFlakeException,

--- a/include/flox/pkgdb/input.hh
+++ b/include/flox/pkgdb/input.hh
@@ -9,13 +9,44 @@
 
 #pragma once
 
-#include "flox/pkgdb/write.hh"
+#include <filesystem>
+#include <memory>
+#include <nlohmann/json_fwd.hpp>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <nix/flake/flake.hh>
+#include <nix/flake/flakeref.hh>
+#include <nix/ref.hh>
+
+#include "flox/core/nix-state.hh"
+#include "flox/core/types.hh"
+#include "flox/flox-flake.hh"
+#include "flox/pkgdb/pkg-query.hh"
+#include "flox/pkgdb/read.hh"
 #include "flox/registry.hh"
 
 
 /* -------------------------------------------------------------------------- */
 
+/* Forward declare */
+namespace nix {
+class Store;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 namespace flox::pkgdb {
+
+/* -------------------------------------------------------------------------- */
+
+/* Forward declare */
+class PkgDb;
 
 /* -------------------------------------------------------------------------- */
 

--- a/include/flox/pkgdb/params.hh
+++ b/include/flox/pkgdb/params.hh
@@ -30,6 +30,8 @@ struct QueryPreferences
   /**
    * Ordered list of systems to be searched.
    * Results will be grouped by system in the order they appear here.
+   *
+   * Defaults to the current system.
    */
   std::vector<std::string> systems = { nix::settings.thisSystem.get() };
 

--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -192,7 +192,7 @@ struct PkgQueryArgs : public PkgDescriptorBase
    *         code otherwise.
    */
   void
-  validate() const;
+  check() const;
 
 
 }; /* End struct `PkgQueryArgs' */

--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -151,7 +151,7 @@ struct PkgQueryArgs : public PkgDescriptorBase
 
 
   /** @brief Errors concerning validity of package query parameters. */
-  struct InvalidPkgQueryArgException : public flox::FloxException
+  class InvalidPkgQueryArgException : public FloxException
   {
 
   public:
@@ -206,7 +206,7 @@ struct PkgQueryArgs : public PkgDescriptorBase
     }
 
 
-  }; /* End struct `InvalidPkgQueryArgException' */
+  }; /* End class `InvalidPkgQueryArgException' */
 
 
   /** @brief Reset argset to its _default_ state. */

--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -97,6 +97,18 @@ concept pkg_descriptor_typename = std::derived_from<T, PkgDescriptorBase>;
 /* -------------------------------------------------------------------------- */
 
 /**
+ * @class flox::pkgdb::InvalidPkgQueryArg
+ * @brief Indicates invalid arguments were set in a
+ *        @a flox::resolver::PkgQueryArgs struct.
+ */
+FLOX_DEFINE_EXCEPTION( InvalidPkgQueryArg,
+                       EC_INVALID_PKG_QUERY_ARG,
+                       "invalid package query argument" )
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
  * @brief Collection of query parameters used to lookup packages in a database.
  *
  * These use a combination of SQL statements and post processing with
@@ -149,72 +161,13 @@ struct PkgQueryArgs : public PkgDescriptorBase
    */
   std::optional<flox::AttrPath> relPath;
 
-
-  /** @brief Errors concerning validity of package query parameters. */
-  class InvalidPkgQueryArgException : public FloxException
-  {
-
-  public:
-
-    enum error_code {
-      /** Name/{pname,version,semver} are mutually exclusive */
-      PQEC_MIX_NAME = 2
-      /** Version/semver are mutually exclusive */
-      ,
-      PQEC_MIX_VERSION_SEMVER = 3,
-      PQEC_INVALID_SEMVER     = 4 /**< Semver Parse Error */
-      ,
-      PQEC_INVALID_LICENSE = 5 /**< License has invalid character */
-      ,
-      PQEC_INVALID_SUBTREE = 6 /**< Unrecognized subtree */
-      ,
-      PQEC_CONFLICTING_SUBTREE = 7 /**< Conflicting subtree/stability */
-      ,
-      PQEC_INVALID_SYSTEM = 8 /**< Unrecognized/unsupported system */
-      ,
-      PQEC_INVALID_STABILITY = 9 /**< Unrecognized stability */
-      ,
-      PQEC_INVALID_MATCH_STYLE = 10 /**< `match` without `matchStyle` */
-    } errorCode;
-
-
-  private:
-
-    static std::string
-    errorMessage( const error_code & ecode );
-
-
-  public:
-
-    explicit InvalidPkgQueryArgException( const error_code & ecode )
-      : flox::FloxException(
-        "encountered an error processing query arguments:",
-        InvalidPkgQueryArgException::errorMessage( ecode ) )
-      , errorCode( ecode )
-    {}
-
-    [[nodiscard]] flox::error_category
-    getErrorCode() const noexcept override
-    {
-      return EC_INVALID_PKG_QUERY_ARG;
-    }
-
-    [[nodiscard]] std::string_view
-    getCategoryMessage() const noexcept override
-    {
-      return "encountered an error processing query arguments";
-    }
-
-
-  }; /* End class `InvalidPkgQueryArgException' */
-
-
   /** @brief Reset argset to its _default_ state. */
   void
   clear() override;
 
   /**
-   * @brief Sanity check parameters.
+   * @brief Sanity check parameters throwing a
+   *        @a flox::pkgdb::InvalidPkgQueryArgs exception if they are invalid.
    *
    * Make sure `systems` are valid systems.
    * Make sure `stabilities` are valid stabilities.
@@ -223,8 +176,9 @@ struct PkgQueryArgs : public PkgDescriptorBase
    * @return `std::nullopt` iff the above conditions are met, an error
    *         code otherwise.
    */
-  [[nodiscard]] std::optional<InvalidPkgQueryArgException::error_code>
+  void
   validate() const;
+
 
 }; /* End struct `PkgQueryArgs' */
 

--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -118,13 +118,13 @@ struct PkgQueryArgs : public PkgDescriptorBase
 {
 
   /* From `PkgDescriptorBase':
-   *   std::optional<std::string> name;
-   *   std::optional<std::string> pname;
-   *   std::optional<std::string> version;
-   *   std::optional<std::string> semver;
+   *   std::optional<std::string> name;    //< Filter results by exact `name`.
+   *   std::optional<std::string> pname;   //< Filter results by exact `pname`.
+   *   std::optional<std::string> version; //< Filter results by exact version.
+   *   std::optional<std::string> semver;  //< Filter results by version range.
    */
 
-  /** Filter results by partial match on pname, pkgAttrName, or description */
+  /** Filter results by partial match on pname, pkgAttrName, or description. */
   std::optional<std::string> partialMatch;
 
   /**
@@ -133,7 +133,11 @@ struct PkgQueryArgs : public PkgDescriptorBase
    */
   std::optional<std::string> pnameOrPkgAttrName;
 
-  /** Filter results to those explicitly marked with the given licenses. */
+  /**
+   * Filter results to those explicitly marked with the given licenses.
+   *
+   * NOTE: License strings should be SPDX Ids ( short names ).
+   */
   std::optional<std::vector<std::string>> licenses;
 
   /** Whether to include packages which are explicitly marked `broken`. */
@@ -145,19 +149,30 @@ struct PkgQueryArgs : public PkgDescriptorBase
   /** Whether pre-release versions should be ordered before releases. */
   bool preferPreReleases = false;
 
-  /** Subtrees to search. */
+  /**
+   * Subtrees to search.
+   *
+   * NOTE: `Subtree` is an enum of top level flake outputs, being one of
+   * `"catalog"`, `"packages"`, or `"legacyPackages"`.
+   */
   std::optional<std::vector<Subtree>> subtrees;
 
-  /** Systems to search */
+  /** Systems to search. Defaults to the current system. */
   std::vector<std::string> systems = { nix::settings.thisSystem.get() };
 
-  /** Stabilities to search ( if any ) */
+  /**
+   * Stabilities to search ( if any ).
+   *
+   * NOTE: Stabilities must be one of `"stable"`, `"staging"`, or `"unstable"`.
+   */
   std::optional<std::vector<std::string>> stabilities;
 
   /**
    * Relative attribute path to package from its prefix.
    * For catalogs this is the part following `stability`, and for regular flakes
    * it is the part following `system`.
+   *
+   * NOTE: @a flox::AttrPath is an alias of `std::vector<std::string>`.
    */
   std::optional<flox::AttrPath> relPath;
 

--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -49,10 +49,20 @@ struct ManifestDescriptorRaw
 
 public:
 
-  /** Match `name`, `pname`, or `pkgAttrName` */
+  /**
+   * Match `name`, `pname`, or `pkgAttrName`.
+   * Maps to `flox::pkgdb::PkgQueryArgs::pnameOrPkgAttrName`.
+   */
   std::optional<std::string> name;
 
-  /** Match `version` or `semver` if a modifier is present. */
+  /**
+   * Match `version` or `semver` if a modifier is present.
+   *
+   * Strings beginning with an `=` will filter by exact match on `version`.
+   * Any string which may be interpreted as a semantic version range will
+   * filter on the `semver` field.
+   * All other strings will filter by exact match on `version`.
+   */
   std::optional<std::string> version;
 
   /** Match a catalog stability. */
@@ -66,6 +76,11 @@ public:
   /**
    * @brief A dot separated attribut path, or list representation.
    *        May contain `null` members to represent _globs_.
+   *
+   * NOTE: `AttrPathGlob` is a `std::vector<std::optional<std::string>>`
+   *       which represnts an absolute attribute path which may have
+           `std::nullopt` as its second element to avoid indicating a
+           particular system.
    */
   using AbsPath = std::variant<std::string, AttrPathGlob>;
   /** Match an absolute path, allowing globs for `system`. */

--- a/include/flox/resolver/manifest.hh
+++ b/include/flox/resolver/manifest.hh
@@ -86,6 +86,7 @@ struct ManifestRaw
   }; /* End struct `Options' */
   Options options;
 
+  // FIXME: This should be `ManifestDescriptorRaw`
   std::unordered_map<std::string, ManifestDescriptor> install;
 
   RegistryRaw registry;

--- a/include/flox/resolver/params.hh
+++ b/include/flox/resolver/params.hh
@@ -104,30 +104,13 @@ struct PkgDescriptorRaw : public pkgdb::PkgDescriptorBase
 
 /* -------------------------------------------------------------------------- */
 
-/** @brief An exception thrown a PkgDescriptorRaw is invalid */
-class InvalidPkgDescriptorException : public FloxException
-{
-
-public:
-
-  explicit InvalidPkgDescriptorException( std::string_view contextMsg )
-    : FloxException( contextMsg )
-  {}
-
-  [[nodiscard]] error_category
-  getErrorCode() const noexcept override
-  {
-    return EC_INVALID_PKG_DESCRIPTOR;
-  }
-
-  [[nodiscard]] std::string_view
-  getCategoryMessage() const noexcept override
-  {
-    return "invalid package query";
-  }
-
-
-}; /* End class `InvalidPkgDescriptorException' */
+/**
+ * @class flox::resolver::InvalidPkgDescriptorException
+ * @brief An exception thrown a PkgDescriptorRaw is invalid
+ */
+FLOX_DEFINE_EXCEPTION( InvalidPkgDescriptorException,
+                       EC_INVALID_PKG_DESCRIPTOR,
+                       "invalid package descriptor" )
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/flox/resolver/params.hh
+++ b/include/flox/resolver/params.hh
@@ -40,10 +40,11 @@ struct PkgDescriptorRaw : public pkgdb::PkgDescriptorBase
 {
 
   /* From `pkgdb::PkgDescriptorBase':
-   *   std::optional<std::string> name;
-   *   std::optional<std::string> pname;
-   *   std::optional<std::string> version;
-   *   std::optional<std::string> semver;
+   *   std::optional<std::string> name;    //< Filter results by exact `name`.
+   *   std::optional<std::string> pname;   //< Filter results by exact `pname`.
+   *   std::optional<std::string> version; //< Filter results by exact version.
+   *   std::optional<std::string> semver;  //< Filter results by version range.
+
    */
 
   /**

--- a/include/flox/resolver/resolve.hh
+++ b/include/flox/resolver/resolve.hh
@@ -9,9 +9,9 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
-#include <optional>
 
 #include <nlohmann/json.hpp>
 
@@ -26,22 +26,25 @@ namespace flox::resolver {
 /* -------------------------------------------------------------------------- */
 
 /** @brief A _resolved_ installable resulting from resolution. */
-struct Resolved {
+struct Resolved
+{
 
   /** @brief A registry input. */
-  struct Input {
-    std::string    name;    /**< Registry input name/id. */
-    nlohmann::json locked;  /**< Locked flake ref attributes. */
-  };  /* End struct `Resolved::Input' */
+  struct Input
+  {
+    std::string    name;   /**< Registry input name/id. */
+    nlohmann::json locked; /**< Locked flake ref attributes. */
+  };                       /* End struct `Resolved::Input' */
 
-  Input          input;  /**< Registry input. */
-  AttrPath       path;   /**< Attribute path to the package. */
-  nlohmann::json info;   /**< Package information. */
+  Input          input; /**< Registry input. */
+  AttrPath       path;  /**< Attribute path to the package. */
+  nlohmann::json info;  /**< Package information. */
 
   /**@brief Reset to default/empty state. */
-  void clear();
+  void
+  clear();
 
-};  /* End struct `Resolved' */
+}; /* End struct `Resolved' */
 
 /**
  * @fn void from_json( const nlohmann::json & j, Resolved::Input & pdb )
@@ -75,11 +78,10 @@ using Descriptor = PkgDescriptorRaw;
  * @param one If `true`, return only the first result.
  * @return A list of resolved packages.
  */
-[[nodiscard]]
-std::vector<Resolved> resolve_v0(       ResolverState & state
-                                , const Descriptor    & descriptor
-                                ,       bool            one        = false
-                                );
+[[nodiscard]] std::vector<Resolved>
+resolve_v0( ResolverState &    state,
+            const Descriptor & descriptor,
+            bool               one = false );
 
 
 /**
@@ -89,7 +91,7 @@ std::vector<Resolved> resolve_v0(       ResolverState & state
  * @param one If `true`, return only the first result.
  * @return A list of resolved packages.
  */
-#define resolve( ... )  resolve_v0( __VA_ARGS__ )
+#define resolve( ... ) resolve_v0( __VA_ARGS__ )
 
 
 /* -------------------------------------------------------------------------- */
@@ -100,11 +102,8 @@ std::vector<Resolved> resolve_v0(       ResolverState & state
  * @param descriptor The package descriptor.
  * @return The best resolved installable or `std:nullopt` if resolution failed.
  */
-  [[nodiscard]]
-  std::optional<Resolved>
-resolveOne_v0(       ResolverState & state
-             , const Descriptor    & descriptor
-             )
+[[nodiscard]] std::optional<Resolved>
+resolveOne_v0( ResolverState & state, const Descriptor & descriptor )
 {
   auto resolved = resolve( state, descriptor, true );
   if ( resolved.empty() ) { return std::nullopt; }
@@ -118,7 +117,7 @@ resolveOne_v0(       ResolverState & state
  * @param descriptor The package descriptor.
  * @return The best resolved installable or `std:nullopt` if resolution failed.
  */
-#define resolveOne( ... )  resolveOne_v0( __VA_ARGS__ )
+#define resolveOne( ... ) resolveOne_v0( __VA_ARGS__ )
 
 
 /* -------------------------------------------------------------------------- */
@@ -130,13 +129,11 @@ resolveOne_v0(       ResolverState & state
  * @param descriptor The package descriptor.
  * @param one If `true`, return only the first result.
  */
-  [[nodiscard]] inline
-  std::vector<Resolved>
-resolveInFlake_v0( const pkgdb::QueryPreferences & preferences
-                 , const RegistryInput           & flake
-                 , const Descriptor              & descriptor
-                 ,       bool                      one         = false
-                 )
+[[nodiscard]] inline std::vector<Resolved>
+resolveInFlake_v0( const pkgdb::QueryPreferences & preferences,
+                   const RegistryInput &           flake,
+                   const Descriptor &              descriptor,
+                   bool                            one = false )
 {
   RegistryRaw registry;
   registry.inputs.emplace( flake.getFlakeRef()->to_string(), flake );
@@ -152,26 +149,22 @@ resolveInFlake_v0( const pkgdb::QueryPreferences & preferences
  * @param descriptor The package descriptor.
  * @param one If `true`, return only the first result.
  */
-  [[nodiscard]] inline
-  std::vector<Resolved>
-resolveInFlake_v0( const pkgdb::QueryPreferences & preferences
-                 , const nix::FlakeRef           & flake
-                 , const Descriptor              & descriptor
-                 ,       bool                      one         = false
-                 )
+[[nodiscard]] inline std::vector<Resolved>
+resolveInFlake_v0( const pkgdb::QueryPreferences & preferences,
+                   const nix::FlakeRef &           flake,
+                   const Descriptor &              descriptor,
+                   bool                            one = false )
 {
-  return resolveInFlake_v0( preferences
-                          , RegistryInput( flake )
-                          , descriptor
-                          , one
-                          );
+  return resolveInFlake_v0( preferences,
+                            RegistryInput( flake ),
+                            descriptor,
+                            one );
 }
-
 
 
 /* -------------------------------------------------------------------------- */
 
-}  /* End Namespace `flox::resolver' */
+}  // namespace flox::resolver
 
 
 /* -------------------------------------------------------------------------- *

--- a/src/command.cc
+++ b/src/command.cc
@@ -14,9 +14,9 @@
 #include <variant>
 #include <vector>
 
+#include "flox/core/command.hh"
 #include "flox/core/types.hh"
 #include "flox/registry.hh"
-#include "flox/core/command.hh"
 
 
 /* -------------------------------------------------------------------------- */

--- a/src/command.cc
+++ b/src/command.cc
@@ -7,19 +7,16 @@
  *
  * -------------------------------------------------------------------------- */
 
-#include <fstream>
-#include <iostream>
+#include <algorithm>
+#include <argparse/argparse.hpp>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
 
-#include <nix/eval-cache.hh>
-#include <nix/eval.hh>
-#include <nix/flake/flake.hh>
-#include <nix/shared.hh>
-#include <nix/store-api.hh>
-
+#include "flox/core/types.hh"
+#include "flox/registry.hh"
 #include "flox/core/command.hh"
-#include "flox/core/util.hh"
-#include "flox/pkgdb/write.hh"
-#include "flox/resolver/manifest.hh"
 
 
 /* -------------------------------------------------------------------------- */

--- a/src/flake-package.cc
+++ b/src/flake-package.cc
@@ -5,7 +5,6 @@
  * -------------------------------------------------------------------------- */
 
 #include "flox/flake-package.hh"
-#include "flox/core/exceptions.hh"
 #include "versions.hh"
 
 

--- a/src/flox-flake.cc
+++ b/src/flox-flake.cc
@@ -8,11 +8,27 @@
  *
  * -------------------------------------------------------------------------- */
 
-/* Provides inline definitions of `allocValue', and `forceAttrs'. */
-#include <nix/eval-inline.hh>
+#include <assert.h>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <nix/attr-set.hh>
+#include <nix/config.hh>
+#include <nix/eval-cache.hh>
+#include <nix/eval-inline.hh> /**< for inline `allocValue', and `forceAttrs'. */
+#include <nix/eval.hh>
+#include <nix/flake/flake.hh>
+#include <nix/flake/flakeref.hh>
+#include <nix/nixexpr.hh>
+#include <nix/ref.hh>
+#include <nix/symbol-table.hh>
+#include <nix/util.hh>
+#include <nix/value.hh>
+#include <optional>
+#include <string>
+#include <vector>
 
-#include "flox/core/exceptions.hh"
-#include "flox/core/util.hh"
+#include "flox/core/types.hh"
 #include "flox/flox-flake.hh"
 
 

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -7,6 +7,8 @@
  *
  * -------------------------------------------------------------------------- */
 
+#include <optional>
+#include <string>
 #include <nix/logging.hh>
 #include <nix/util.hh>
 

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -7,10 +7,10 @@
  *
  * -------------------------------------------------------------------------- */
 
-#include <optional>
-#include <string>
 #include <nix/logging.hh>
 #include <nix/util.hh>
+#include <optional>
+#include <string>
 
 #include "flox/core/nix-state.hh"
 

--- a/src/nix-state.cc
+++ b/src/nix-state.cc
@@ -7,7 +7,7 @@
  *
  * -------------------------------------------------------------------------- */
 
-#include <stddef.h>
+#include <cstddef>
 
 #include <nix/eval.hh>
 #include <nix/shared.hh>

--- a/src/pkgdb/input.cc
+++ b/src/pkgdb/input.cc
@@ -7,7 +7,31 @@
  *
  * -------------------------------------------------------------------------- */
 
+#include <assert.h>
+#include <list>
+#include <map>
+#include <nix/error.hh>
+#include <nix/eval.hh>
+#include <nix/fmt.hh>
+#include <nix/logging.hh>
+#include <nix/nixexpr.hh>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <ostream>
+#include <sqlite3pp.hh>
+#include <tuple>
+
+#include "flox/core/exceptions.hh"
 #include "flox/pkgdb/input.hh"
+#include "flox/pkgdb/write.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+/* Forward declare */
+namespace nix {
+class Store;
+}
 
 
 /* -------------------------------------------------------------------------- */

--- a/src/pkgdb/params.cc
+++ b/src/pkgdb/params.cc
@@ -7,10 +7,16 @@
  *
  * -------------------------------------------------------------------------- */
 
+#include <map>
+#include <nix/config.hh>
 #include <nix/globals.hh>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
 
-#include "flox/core/util.hh"
-#include "flox/resolver/params.hh"
+#include "flox/pkgdb/params.hh"
+#include "flox/pkgdb/pkg-query.hh"
 
 
 /* -------------------------------------------------------------------------- */

--- a/src/pkgdb/pkg-query.cc
+++ b/src/pkgdb/pkg-query.cc
@@ -34,7 +34,7 @@ PkgDescriptorBase::clear()
 /* -------------------------------------------------------------------------- */
 
 void
-PkgQueryArgs::validate() const
+PkgQueryArgs::check() const
 {
 
   if ( this->name.has_value()
@@ -399,7 +399,7 @@ PkgQuery::init()
   this->clearBuilt();
 
   /* Validate parameters */
-  this->validate();
+  this->check();
 
   this->addSelection( "*" );
 

--- a/src/pkgdb/pkg-query.cc
+++ b/src/pkgdb/pkg-query.cc
@@ -43,15 +43,13 @@ PkgQueryArgs::validate() const
     {
       throw InvalidPkgQueryArg(
         "queries may not mix `name' parameter with any of `pname', "
-        "`version', or `semver' parameters."
-      );
+        "`version', or `semver' parameters." );
     }
 
   if ( this->version.has_value() && this->semver.has_value() )
     {
       throw InvalidPkgQueryArg(
-        "queries may not mix `version' and `semver' parameters."
-      );
+        "queries may not mix `version' and `semver' parameters." );
     }
 
   /* Check licenses don't contain the ' character */
@@ -62,8 +60,7 @@ PkgQueryArgs::validate() const
           if ( license.find( '\'' ) != std::string::npos )
             {
               throw InvalidPkgQueryArg(
-                "license contains illegal character \"'\": " + license
-              );
+                "license contains illegal character \"'\": " + license );
             }
         }
     }
@@ -77,8 +74,8 @@ PkgQueryArgs::validate() const
            == flox::getDefaultSystems().end() )
         {
 
-          throw InvalidPkgQueryArg(
-            "unrecognized or unsupported system: " + std::string( system ) );
+          throw InvalidPkgQueryArg( "unrecognized or unsupported system: "
+                                    + std::string( system ) );
         }
     }
 }

--- a/src/resolver/command.cc
+++ b/src/resolver/command.cc
@@ -88,10 +88,11 @@ LockCommand::run()
 
   // TODO: Handle multiple inputs
   // TODO: Handle multiple systems
-  auto [name, input] = * this->getPkgDbRegistry()->begin();
-  auto dbRO  = this->getPkgDbRegistry()->begin()->second->getDbReadOnly();
+  auto [name, input] = *this->getPkgDbRegistry()->begin();
+  auto dbRO = this->getPkgDbRegistry()->begin()->second->getDbReadOnly();
   nlohmann::json install = nlohmann::json::object();
-  for ( const auto & [id, desc] : this->getUnlockedManifest().getManifestRaw().install )
+  for ( const auto &[id, desc] :
+        this->getUnlockedManifest().getManifestRaw().install )
     {
       auto args = this->getBaseQueryArgs();
       desc.fillPkgQueryArgs( args );
@@ -109,10 +110,10 @@ LockCommand::run()
       else
         {
           auto info = dbRO->getPackage( rows.front() );
-          install.emplace( id, nlohmann::json {
-            { "input", name }
-          , { "abs-path", info.at( "absPath" ) }
-          } );
+          install.emplace(
+            id,
+            nlohmann::json { { "input", name },
+                             { "abs-path", info.at( "absPath" ) } } );
         }
     }
 

--- a/src/yamlToJSON.cc
+++ b/src/yamlToJSON.cc
@@ -22,7 +22,7 @@ namespace flox {
 /* -------------------------------------------------------------------------- */
 
 /**
- * @class YAMLToJSONException
+ * @class flox::YAMLToJSONException
  * @brief An exception thrown when converting YAML to JSON.
  */
 FLOX_DEFINE_EXCEPTION( YAMLToJSONException,


### PR DESCRIPTION
This document covers the various parameter parsers and structures that convert user input into SQL queries.

Largely it aims to be a guide for y'all to understand how those grew organically, and when some of them can be retired.

There's a few additions to inline docs as well in the related code.

You'll also notice some `#include` lines were modified - this was done programmatically by `include-what-you-use` ( which I don't have setup on my work machine ). It basically just drops `#include` lines that weren't in use, and explicitly adds ones that are used directly by a file but were supplied indirectly.
Finally I aligned the exceptions in `PkgQueryArgs` with the rest of the code-base.
I could split those into a separate PR but honestly it's just kind of a hassle to separate them and I'd prefer to leave them in.

There's some TODO spots in the doc, but there's more than enough here to help get @garbas started on a ticket he picked up.