### PR TITLE
feat: lock manifest descriptors ( no groups )

### DIFF
--- a/include/flox/core/types.hh
+++ b/include/flox/core/types.hh
@@ -33,6 +33,14 @@ namespace flox {
 using AttrPath = std::vector<std::string>;
 
 /**
+ * @brief An attribute path which may contain `null` members to
+ *        represent _globs_.
+ *
+ * Globs may only appear as the second element representing `system`.
+ */
+using AttrPathGlob = std::vector<std::optional<std::string>>;
+
+/**
  * @brief A `std::shared_ptr<nix::eval_cache::AttrCursor>` which may
  *        be `nullptr`.
  */

--- a/include/flox/registry.hh
+++ b/include/flox/registry.hh
@@ -77,6 +77,7 @@ struct InputPreferences
   pkgdb::PkgQueryArgs &
   fillPkgQueryArgs( pkgdb::PkgQueryArgs & pqa ) const;
 
+
 }; /* End struct `InputPreferences' */
 
 

--- a/include/flox/registry.hh
+++ b/include/flox/registry.hh
@@ -47,8 +47,7 @@ struct InputPreferences
   InputPreferences()                           = default;
   InputPreferences( const InputPreferences & ) = default;
   InputPreferences( InputPreferences && )      = default;
-  InputPreferences(
-    const std::optional<std::vector<Subtree>> &     subtrees)
+  InputPreferences( const std::optional<std::vector<Subtree>> & subtrees )
     : subtrees( subtrees )
   {}
 
@@ -91,8 +90,7 @@ struct InputPreferences
  * @brief Convert an @a flox::InputPreferences to a JSON object.
  */
 /* Generate to_json/from_json functions. */
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT( InputPreferences,
-                                                 subtrees );
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT( InputPreferences, subtrees );
 
 
 /* -------------------------------------------------------------------------- */
@@ -124,8 +122,8 @@ struct RegistryInput : public InputPreferences
 
   RegistryInput() = default;
 
-  RegistryInput( const std::optional<std::vector<Subtree>> &     subtrees,
-                 const nix::FlakeRef &                           from )
+  RegistryInput( const std::optional<std::vector<Subtree>> & subtrees,
+                 const nix::FlakeRef &                       from )
     : InputPreferences( subtrees )
     , from( std::make_shared<nix::FlakeRef>( from ) )
   {}

--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -78,15 +78,24 @@ public:
   /** Whether resoution is allowed to fail without producing errors. */
   std::optional<bool> optional;
 
+  // TODO: Not implemented.
   /** Named _group_ that the package is a member of. */
   std::optional<std::string> packageGroup;
 
-  /** Force resolution is a given input or _flake reference_. */
+  // TODO: Not implemented.
+  /** Force resolution is the named input or _flake reference_. */
   std::optional<std::variant<std::string, nix::fetchers::Attrs>>
     packageRepository;
 
-  /** Relative path to a `nix` expression file to be evaluated. */
-  std::optional<std::string> input;
+
+  /**
+   * Rank a package's priority for handling conflicting files.
+   * The default value is `5` ( set in @a flox::resolver::ManifestDescriptor ).
+   *
+   * Packages with higher @a priority values will take precendence over those
+   * with lower @a priority values.
+   */
+  std::optional<unsigned> priority;
 
 
 }; /* End struct `ManifestDescriptorRaw' */
@@ -94,6 +103,7 @@ public:
 
 /* -------------------------------------------------------------------------- */
 
+// TODO: support `packageRepository' field
 /**
  * @fn void from_json( const nlohmann::json        & jfrom
  *                   ,       ManifestDescriptorRaw & desc
@@ -112,8 +122,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT( ManifestDescriptorRaw,
                                                  systems,
                                                  optional,
                                                  packageGroup,
-                                                 packageRepository,
-                                                 input )
+                                                 priority )
 
 
 /* -------------------------------------------------------------------------- */
@@ -151,8 +160,17 @@ public:
   /** Match a relative attribute path. */
   std::optional<flox::AttrPath> path;
 
-  /** Force resolution is a given input, _flake reference_, or file. */
-  std::optional<std::variant<nix::FlakeRef, std::string>> input;
+  /** Force resolution is a given input, _flake reference_. */
+  std::optional<nix::FlakeRef> input;
+
+  /**
+   * Rank a package's priority for handling conflicting files.
+   * The default value is `5` ( set in @a flox::resolver::ManifestDescriptor ).
+   *
+   * Packages with higher @a priority values will take precendence over those
+   * with lower @a priority values.
+   */
+ unsigned priority = 5;
 
 
   ManifestDescriptor() = default;

--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -27,17 +27,6 @@ namespace flox::resolver {
 /* -------------------------------------------------------------------------- */
 
 /**
- * @brief An attribute path which may contain `null` members to
- *        represent _globs_.
- *
- * Globs may only appear as the second element representing `system`.
- */
-using AttrPathGlob = std::vector<std::optional<std::string>>;
-
-
-/* -------------------------------------------------------------------------- */
-
-/**
  * @brief Extend and remap fields from @a flox::resolver::PkgDescriptorRaw to
  *        those found in a `flox` _manifest_.
  *

--- a/include/flox/resolver/manifest.hh
+++ b/include/flox/resolver/manifest.hh
@@ -212,6 +212,31 @@ public:
   std::optional<RegistryRaw>           lockedRegistry;
   std::optional<pkgdb::PkgQueryArgs>   baseQueryArgs;
 
+  // TODO: Handle groups
+  // bool                                                   didGroups = false;
+  // std::unordered_set<std::string>                        ungroupedIds;
+  // std::unordered_map<std::string, std::string>           groupIds;
+
+  /**
+   * @brief A map of _locked_ descriptors organized by their _install ID_,
+   *        and then by `system`.
+   *        For optional packages, or those which are explicitly declared for
+   *        a subset of systems, the value may be `std::nullopt`.
+   */
+  std::unordered_map<std::string,                    /* _install ID_ */
+                     std::unordered_map<std::string, /* system */
+                                        std::optional<ManifestDescriptorRaw>>>
+    lockedDescriptors;
+
+
+private:
+
+  const std::unordered_map<std::string, std::optional<ManifestDescriptorRaw>> &
+  lockDescriptor( const std::string & iid, const ManifestDescriptor & desc );
+
+
+public:
+
   /**
    * @brief Returns the locked @a RegistryRaw from the manifest.
    *
@@ -260,34 +285,18 @@ public:
   addManifestFileArg( argparse::ArgumentParser & parser, bool required = true );
 
   const UnlockedManifest &
-  getUnlockedManifest()
-  {
-    if ( ! this->manifest.has_value() )
-      {
-        this->manifest = UnlockedManifest( this->getManifestPath() );
-      }
-    return *this->manifest;
-  }
+  getUnlockedManifest();
 
   const RegistryRaw &
-  getLockedRegistry()
-  {
-    if ( ! this->lockedRegistry.has_value() )
-      {
-        this->lockedRegistry
-          = this->getUnlockedManifest().getLockedRegistry( this->getStore() );
-      }
-    return *this->lockedRegistry;
-  }
+  getLockedRegistry();
 
   const pkgdb::PkgQueryArgs &
-  getBaseQueryArgs()
+  getBaseQueryArgs();
+
+  const std::unordered_map<std::string, ManifestDescriptor> &
+  getDescriptors()
   {
-    if ( ! this->baseQueryArgs.has_value() )
-      {
-        this->baseQueryArgs = this->getUnlockedManifest().getBaseQueryArgs();
-      }
-    return *this->baseQueryArgs;
+    return this->getUnlockedManifest().getManifestRaw().install;
   }
 
 

--- a/include/flox/resolver/manifest.hh
+++ b/include/flox/resolver/manifest.hh
@@ -19,6 +19,7 @@
 #include "flox/pkgdb/input.hh"
 #include "flox/registry.hh"
 #include "flox/resolver/descriptor.hh"
+#include "flox/resolver/resolve.hh"
 
 
 /* -------------------------------------------------------------------------- */
@@ -225,13 +226,13 @@ public:
    */
   std::unordered_map<std::string,                    /* _install ID_ */
                      std::unordered_map<std::string, /* system */
-                                        std::optional<ManifestDescriptorRaw>>>
+                                        std::optional<Resolved>>>
     lockedDescriptors;
 
 
 protected:
 
-  const std::unordered_map<std::string, std::optional<ManifestDescriptorRaw>> &
+  const std::unordered_map<std::string, std::optional<Resolved>> &
   lockDescriptor( const std::string & iid, const ManifestDescriptor & desc );
 
 

--- a/include/flox/resolver/manifest.hh
+++ b/include/flox/resolver/manifest.hh
@@ -229,7 +229,7 @@ public:
     lockedDescriptors;
 
 
-private:
+protected:
 
   const std::unordered_map<std::string, std::optional<ManifestDescriptorRaw>> &
   lockDescriptor( const std::string & iid, const ManifestDescriptor & desc );

--- a/include/flox/resolver/params.hh
+++ b/include/flox/resolver/params.hh
@@ -17,10 +17,10 @@
 #include <argparse/argparse.hpp>
 #include <nlohmann/json.hpp>
 
+#include "flox/core/types.hh"
 #include "flox/pkgdb/params.hh"
 #include "flox/pkgdb/pkg-query.hh"
 #include "flox/registry.hh"
-#include "flox/resolver/manifest.hh"
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/flox/resolver/resolve.hh
+++ b/include/flox/resolver/resolve.hh
@@ -15,6 +15,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "flox/registry.hh"
 #include "flox/resolver/state.hh"
 
 
@@ -32,9 +33,56 @@ struct Resolved
   /** @brief A registry input. */
   struct Input
   {
-    std::string    name;   /**< Registry input name/id. */
-    nlohmann::json locked; /**< Locked flake ref attributes. */
-  };                       /* End struct `Resolved::Input' */
+  private:
+
+    /**
+     * @brief Reduce @a locked fields to those needed to fetch the flake
+     *        in pure evaluation mode.
+     */
+    void
+    limitLocked();
+
+
+  public:
+
+    std::optional<std::string> name;   /**< Registry input name/id. */
+    nlohmann::json             locked; /**< Locked flake ref attributes. */
+
+    Input()                = default;
+    Input( const Input & ) = default;
+    Input( Input && )      = default;
+
+    Input( std::string name, nlohmann::json locked )
+      : name( std::move( name ) ), locked( std::move( locked ) )
+    {
+      this->limitLocked();
+    }
+
+    Input( std::string name, const nix::FlakeRef & locked )
+      : name( std::move( name ) ), locked( locked )
+    {
+      this->limitLocked();
+    }
+
+    explicit Input( nlohmann::json locked ) : locked( std::move( locked ) )
+    {
+      this->limitLocked();
+    }
+
+    explicit Input( const nix::FlakeRef & locked ) : locked( locked )
+    {
+      this->limitLocked();
+    }
+
+    ~Input() = default;
+    Input &
+    operator=( const Input & )
+      = default;
+    Input &
+    operator=( Input && )
+      = default;
+
+  }; /* End struct `Resolved::Input' */
 
   Input          input; /**< Registry input. */
   AttrPath       path;  /**< Attribute path to the package. */
@@ -44,19 +92,25 @@ struct Resolved
   void
   clear();
 
+
 }; /* End struct `Resolved' */
 
+
 /**
- * @fn void from_json( const nlohmann::json & j, Resolved::Input & pdb )
+ * @fn void flox::resolver::from_json( const nlohmann::json & j,
+ * flox::resolver::Resolved::Input & pdb )
  * @brief Convert a JSON object to a @a flox::resolver::Resolved::Input.
  *
- * @fn void to_json( nlohmann::json & j, const Resolved::Input & pdb )
+ * @fn void flox::resolver::to_json( nlohmann::json & j, const
+ * flox::resolver::Resolved::Input & pdb )
  * @brief Convert a @a flox::resolver::Resolved::Input to a JSON object.
  *
- * @fn void from_json( const nlohmann::json & j, Resolved & pdb )
+ * @fn void flox::resolver::from_json( const nlohmann::json & j,
+ * flox::resolver::Resolved & pdb )
  * @brief Convert a JSON object to a @a flox::resolver::Resolved.
  *
- * @fn void to_json( nlohmann::json & j, const Resolved & pdb )
+ * @fn void flox::resolver::to_json( nlohmann::json & j, const
+ * flox::resolver::Resolved & pdb )
  * @brief Convert a @a flox::resolver::Resolved to a JSON object.
  */
 /* Generate `to_json' and `from_json' functions. */
@@ -102,7 +156,7 @@ resolve_v0( ResolverState &    state,
  * @param descriptor The package descriptor.
  * @return The best resolved installable or `std:nullopt` if resolution failed.
  */
-[[nodiscard]] std::optional<Resolved>
+[[nodiscard]] inline std::optional<Resolved>
 resolveOne_v0( ResolverState & state, const Descriptor & descriptor )
 {
   auto resolved = resolve( state, descriptor, true );

--- a/src/pkgdb/input.cc
+++ b/src/pkgdb/input.cc
@@ -164,9 +164,7 @@ PkgDbInput::scrapeSystems( const std::vector<std::string> & systems )
       for ( const auto & system : systems )
         {
           prefix.emplace_back( system );
-          if ( subtree != ST_CATALOG ) {
-            this->scrapePrefix( prefix );
-          }
+          if ( subtree != ST_CATALOG ) { this->scrapePrefix( prefix ); }
           prefix.pop_back();
         }
     }

--- a/src/registry.cc
+++ b/src/registry.cc
@@ -23,7 +23,7 @@ namespace flox {
 void
 InputPreferences::clear()
 {
-  this->subtrees    = std::nullopt;
+  this->subtrees = std::nullopt;
 }
 
 
@@ -32,7 +32,7 @@ InputPreferences::clear()
 pkgdb::PkgQueryArgs &
 InputPreferences::fillPkgQueryArgs( pkgdb::PkgQueryArgs &pqa ) const
 {
-  pqa.subtrees    = this->subtrees;
+  pqa.subtrees = this->subtrees;
   return pqa;
 }
 
@@ -102,12 +102,12 @@ RegistryRaw::fillPkgQueryArgs( const std::string   &input,
   try
     {
       const RegistryInput &minput = this->inputs.at( input );
-      pqa.subtrees    = minput.subtrees.has_value() ? minput.subtrees
-                                                    : this->defaults.subtrees;
+      pqa.subtrees = minput.subtrees.has_value() ? minput.subtrees
+                                                 : this->defaults.subtrees;
     }
   catch ( ... )
     {
-      pqa.subtrees    = this->defaults.subtrees;
+      pqa.subtrees = this->defaults.subtrees;
     }
   return pqa;
 }
@@ -174,8 +174,7 @@ FloxFlakeInput::getSubtrees()
 RegistryInput
 FloxFlakeInput::getLockedInput()
 {
-  return { this->getSubtrees(),
-           this->getFlake()->lockedFlake.flake.lockedRef };
+  return { this->getSubtrees(), this->getFlake()->lockedFlake.flake.lockedRef };
 }
 
 

--- a/src/resolver/command.cc
+++ b/src/resolver/command.cc
@@ -86,42 +86,22 @@ LockCommand::run()
 {
   auto lockedRegistry = this->getLockedRegistry();
 
-  // TODO: Handle multiple inputs
-  // TODO: Handle multiple systems
-  auto [name, input] = *this->getPkgDbRegistry()->begin();
-  auto dbRO = this->getPkgDbRegistry()->begin()->second->getDbReadOnly();
-  nlohmann::json install = nlohmann::json::object();
-  for ( const auto &[id, desc] :
-        this->getUnlockedManifest().getManifestRaw().install )
+  std::unordered_map<
+    std::string,
+    std::unordered_map<std::string, std::optional<ManifestDescriptorRaw>>>
+    lockedDescriptors;
+
+  for ( const auto &[iid, desc] : this->getDescriptors() )
     {
-      auto args = this->getBaseQueryArgs();
-      desc.fillPkgQueryArgs( args );
-      auto query = flox::pkgdb::PkgQuery( args );
-      auto rows  = query.execute( dbRO->db );
-      if ( rows.empty() )
-        {
-          if ( desc.optional )
-            {
-              install.emplace( id, nullptr );
-              continue;
-            }
-          throw FloxException( "No packages found for `install." + id + "'!" );
-        }
-      else
-        {
-          auto info = dbRO->getPackage( rows.front() );
-          install.emplace(
-            id,
-            nlohmann::json { { "input", name },
-                             { "abs-path", info.at( "absPath" ) } } );
-        }
+      lockedDescriptors.emplace( iid, this->lockDescriptor( iid, desc ) );
     }
 
   // TODO: to_json( ManifestRaw )
+  // TODO: strip nulls from `packages' field.
   nlohmann::json lockfile
     = { { "manifest", readAndCoerceJSON( this->getManifestPath() ) },
         { "registry", std::move( lockedRegistry ) },
-        { "install", std::move( install ) },
+        { "packages", std::move( lockedDescriptors ) },
         { "lockfileVersion", 0 } };
   for ( const auto &[name, input] :
         lockfile.at( "registry" ).at( "inputs" ).items() )

--- a/src/resolver/descriptor.cc
+++ b/src/resolver/descriptor.cc
@@ -149,7 +149,7 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
           throw InvalidManifestDescriptorException(
             "`absPath' may only have a glob as its second element" );
         }
-      desc.path      = AttrPath {};
+      desc.path = AttrPath {};
       for ( auto itr = glob.begin() + 3; itr != glob.end(); ++itr )
         {
           const auto & elem = *itr;
@@ -266,15 +266,15 @@ ManifestDescriptor::ManifestDescriptor( const ManifestDescriptorRaw & raw )
 void
 ManifestDescriptor::clear()
 {
-  this->name      = std::nullopt;
-  this->optional  = false;
-  this->group     = std::nullopt;
-  this->version   = std::nullopt;
-  this->semver    = std::nullopt;
-  this->subtree   = std::nullopt;
-  this->systems   = std::nullopt;
-  this->path      = std::nullopt;
-  this->input     = std::nullopt;
+  this->name     = std::nullopt;
+  this->optional = false;
+  this->group    = std::nullopt;
+  this->version  = std::nullopt;
+  this->semver   = std::nullopt;
+  this->subtree  = std::nullopt;
+  this->systems  = std::nullopt;
+  this->path     = std::nullopt;
+  this->input    = std::nullopt;
 }
 
 

--- a/src/resolver/descriptor.cc
+++ b/src/resolver/descriptor.cc
@@ -239,12 +239,6 @@ ManifestDescriptor::ManifestDescriptor( const ManifestDescriptorRaw & raw )
 
   if ( raw.packageRepository.has_value() )
     {
-      if ( raw.input.has_value() )
-        {
-          throw InvalidManifestDescriptorException(
-            "`packageRepository' may not be used with `input'" );
-        }
-
       if ( std::holds_alternative<std::string>( *raw.packageRepository ) )
         {
           this->input
@@ -255,9 +249,9 @@ ManifestDescriptor::ManifestDescriptor( const ManifestDescriptorRaw & raw )
           this->input = nix::FlakeRef::fromAttrs(
             std::get<nix::fetchers::Attrs>( *raw.packageRepository ) );
         }
-      assert( std::holds_alternative<nix::FlakeRef>( *this->input ) );
     }
-  else if ( raw.input.has_value() ) { this->input = *raw.input; }
+
+  if ( raw.priority.has_value() ) { this->priority = *raw.priority; }
 }
 
 
@@ -275,6 +269,7 @@ ManifestDescriptor::clear()
   this->systems  = std::nullopt;
   this->path     = std::nullopt;
   this->input    = std::nullopt;
+  this->priority = 5;
 }
 
 

--- a/src/resolver/manifest.cc
+++ b/src/resolver/manifest.cc
@@ -117,6 +117,142 @@ ManifestFileMixin::getManifestPath()
 
 /* -------------------------------------------------------------------------- */
 
+const UnlockedManifest &
+ManifestFileMixin::getUnlockedManifest()
+{
+  if ( ! this->manifest.has_value() )
+    {
+      this->manifest = UnlockedManifest( this->getManifestPath() );
+    }
+  return *this->manifest;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+const RegistryRaw &
+ManifestFileMixin::getLockedRegistry()
+{
+  if ( ! this->lockedRegistry.has_value() )
+    {
+      this->lockedRegistry
+        = this->getUnlockedManifest().getLockedRegistry( this->getStore() );
+    }
+  return *this->lockedRegistry;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+const pkgdb::PkgQueryArgs &
+ManifestFileMixin::getBaseQueryArgs()
+{
+  if ( ! this->baseQueryArgs.has_value() )
+    {
+      this->baseQueryArgs = this->getUnlockedManifest().getBaseQueryArgs();
+    }
+  return *this->baseQueryArgs;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+const std::unordered_map<std::string, std::optional<ManifestDescriptorRaw>> &
+ManifestFileMixin::lockDescriptor( const std::string        &iid,
+                                   const ManifestDescriptor &desc )
+{
+  /* See if it was already locked. */
+  if ( auto locked = this->lockedDescriptors.find( iid );
+       locked != this->lockedDescriptors.end() )
+    {
+      return locked->second;
+    }
+
+  /* For each system we need to set `packageRepository' such that it has a `rev'
+   * field, and set `absPath` to the absolute attribute path the
+   * resolved package. */
+  std::unordered_map<std::string, std::optional<ManifestDescriptorRaw>> locked;
+
+  pkgdb::PkgQueryArgs baseArgs = this->getBaseQueryArgs();
+
+  /* Iterate over the systems. */
+  for ( const auto & system : this->getSystems() )
+    {
+      /* See if this system is skippable. */
+      if ( desc.systems.has_value()
+           && std::find( desc.systems->begin(), desc.systems->end(), system )
+                == desc.systems->end() )
+        {
+          /* This descriptor is not for this system. */
+          locked.emplace( system, std::nullopt );
+          continue;
+        }
+
+      /* Otherwise, try to lock it with an input. */
+      if ( desc.input.has_value() )
+        {
+          // TODO: Post-GA this is allowed!
+          throw InvalidManifestFileException(
+            "You cannot specify an input in manifest files." );
+        }
+
+      /* Prep our query. */
+      pkgdb::PkgQueryArgs args = baseArgs;
+      desc.fillPkgQueryArgs( args );
+      args.systems = { system };
+      pkgdb::PkgQuery query( args );
+
+      // TODO: handle groups.
+
+      /* Try each input. */
+      bool found = false;
+      for ( const auto &[name, input] : *this->getPkgDbRegistry() )
+        {
+          auto rows = query.execute( input->getDbReadOnly()->db );
+          if ( rows.empty() )
+            {
+              continue;
+            }
+
+          found = true;
+          ManifestDescriptorRaw lockedDescriptor;
+          // TODO: limit attrs to those which are actually required.
+          lockedDescriptor.packageRepository = input->getFlakeRef()->toAttrs();
+          AttrPathGlob absPath;
+          for ( auto &part :
+                input->getDbReadOnly()->getPackagePath( rows.front() ) )
+            {
+              absPath.emplace_back( part );
+            }
+          lockedDescriptor.absPath = std::move( absPath );
+
+          locked.emplace( system, std::move( lockedDescriptor ) );
+          break;
+        }
+
+      if ( ! found )
+        {
+          /* No match. */
+          if ( desc.optional )
+            {
+              locked.emplace( system, std::nullopt );
+              continue;
+            }
+          // TODO: make this a typed exception.
+          throw FloxException( "Failed to resolve descriptor for `install."
+                               + iid + "' on system `" + system + "'." );
+        }
+    }
+
+  /* Stash it in the collection. */
+  this->lockedDescriptors.emplace( iid, std::move( locked ) );
+
+  return this->lockedDescriptors.at( iid );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 }  // namespace flox::resolver
 
 

--- a/src/resolver/manifest.cc
+++ b/src/resolver/manifest.cc
@@ -220,6 +220,7 @@ ManifestFileMixin::lockDescriptor( const std::string        &iid,
                          { "pname", std::move( info.at( "pname" ) ) },
                          { "version", std::move( info.at( "version" ) ) },
                          { "license", std::move( info.at( "license" ) ) },
+                         { "priority", desc.priority }
                        } };
 
           locked.emplace( system, std::move( resolved ) );

--- a/src/resolver/manifest.cc
+++ b/src/resolver/manifest.cc
@@ -176,7 +176,7 @@ ManifestFileMixin::lockDescriptor( const std::string        &iid,
   pkgdb::PkgQueryArgs baseArgs = this->getBaseQueryArgs();
 
   /* Iterate over the systems. */
-  for ( const auto & system : this->getSystems() )
+  for ( const auto &system : this->getSystems() )
     {
       /* See if this system is skippable. */
       if ( desc.systems.has_value()
@@ -209,15 +209,14 @@ ManifestFileMixin::lockDescriptor( const std::string        &iid,
       for ( const auto &[name, input] : *this->getPkgDbRegistry() )
         {
           auto rows = query.execute( input->getDbReadOnly()->db );
-          if ( rows.empty() )
-            {
-              continue;
-            }
+          if ( rows.empty() ) { continue; }
 
           found = true;
           ManifestDescriptorRaw lockedDescriptor;
           // TODO: limit attrs to those which are actually required.
           lockedDescriptor.packageRepository = input->getFlakeRef()->toAttrs();
+
+          /* Convert absolute attribute path to `flox::AttrPathGlob'. */
           AttrPathGlob absPath;
           for ( auto &part :
                 input->getDbReadOnly()->getPackagePath( rows.front() ) )

--- a/tests/data/manifest/ga0.toml
+++ b/tests/data/manifest/ga0.toml
@@ -5,7 +5,7 @@ repo = "nixpkgs"
 rev = "e8039594435c68eb4f780f3e9bf3972a7399c4b1"
 
 [options]
-systems = ["x86_64-linux"]
+systems = ["x86_64-linux", "aarch64-darwin"]
 
 [install.charasay]
 version = "^2"

--- a/tests/data/manifest/ga0.yaml
+++ b/tests/data/manifest/ga0.yaml
@@ -8,7 +8,7 @@ registry:
         rev: e8039594435c68eb4f780f3e9bf3972a7399c4b1
 
 options:
-  systems: ["x86_64-linux"]
+  systems: ["x86_64-linux", "aarch64-darwin"]
 
 install:
   hello:

--- a/tests/manifest.cc
+++ b/tests/manifest.cc
@@ -70,7 +70,6 @@ test_parseManifestDescriptor0()
   , "version": "4.2.0"
   , "optional": true
   , "packageGroup": "blue"
-  , "packageRepository": "nixpkgs"
   } )"_json;
 
   flox::resolver::ManifestDescriptor descriptor( raw );
@@ -86,17 +85,6 @@ test_parseManifestDescriptor0()
   EXPECT( descriptor.group.has_value() );
   EXPECT_EQ( *descriptor.group, "blue" );
   EXPECT_EQ( descriptor.optional, true );
-
-  /* We expect this to be recognized as an _indirect flake reference_. */
-  EXPECT( descriptor.input.has_value() );
-  EXPECT( std::holds_alternative<nix::FlakeRef>( *descriptor.input ) );
-  auto flakeRef = std::get<nix::FlakeRef>( *descriptor.input );
-
-  EXPECT_EQ( flakeRef.input.getType(), "indirect" );
-
-  auto alias = flakeRef.input.attrs.at( "id" );
-  EXPECT( std::holds_alternative<std::string>( alias ) );
-  EXPECT_EQ( std::get<std::string>( alias ), "nixpkgs" );
 
   return true;
 }
@@ -197,6 +185,8 @@ test_parseManifestDescriptor_version3()
 
 /* -------------------------------------------------------------------------- */
 
+// TODO: Not supported yet
+#if 0
 /** @brief Test descriptor parsing inline inputs. */
 bool
 test_parseManifestDescriptor_input0()
@@ -214,31 +204,10 @@ test_parseManifestDescriptor_input0()
   flox::resolver::ManifestDescriptor descriptor( raw );
 
   EXPECT( descriptor.input.has_value() );
-  EXPECT( std::holds_alternative<nix::FlakeRef>( *descriptor.input ) );
 
   return true;
 }
-
-
-/* -------------------------------------------------------------------------- */
-
-/** @brief Test descriptor parsing inline inputs. */
-bool
-test_parseManifestDescriptor_input1()
-{
-
-  flox::resolver::ManifestDescriptorRaw raw = R"( {
-    "name": "foo"
-  , "input": "./pkgs/foo/default.nix"
-  } )"_json;
-
-  flox::resolver::ManifestDescriptor descriptor( raw );
-
-  EXPECT( descriptor.input.has_value() );
-  EXPECT( std::holds_alternative<std::string>( *descriptor.input ) );
-
-  return true;
-}
+#endif  /* if 0 */
 
 
 /* -------------------------------------------------------------------------- */
@@ -417,9 +386,6 @@ main()
   RUN_TEST( parseManifestDescriptor_version1 );
   RUN_TEST( parseManifestDescriptor_version2 );
   RUN_TEST( parseManifestDescriptor_version3 );
-
-  RUN_TEST( parseManifestDescriptor_input0 );
-  RUN_TEST( parseManifestDescriptor_input1 );
 
   RUN_TEST( parseManifestDescriptor_path0 );
   RUN_TEST( parseManifestDescriptor_path1 );

--- a/tests/registry.cc
+++ b/tests/registry.cc
@@ -14,6 +14,7 @@
 #include <nlohmann/json.hpp>
 
 #include "flox/registry.hh"
+#include "flox/resolver/manifest.hh"
 #include "flox/resolver/params.hh"
 #include "test.hh"
 

--- a/tests/resolver-params.cc
+++ b/tests/resolver-params.cc
@@ -99,15 +99,18 @@ main( int argc, char *argv[] )
 
   std::cout << std::endl;
 
+  auto input = flox::resolver::Resolved::Input( nlohmann::json {
+
+  } );
+
   auto resolved = flox::resolver::Resolved {
-    .input
-    = { .name = "nixpkgs",
-        .locked
-        = nlohmann::json { { "type", "github" },
-                           { "owner", "NixOS" },
-                           { "repo", "nixpkgs" },
-                           { "rev",
-                             "e8039594435c68eb4f780f3e9bf3972a7399c4b1" } } },
+    .input = flox::resolver::Resolved::Input(
+      "nixpkgs",
+      nlohmann::json {
+        { "type", "github" },
+        { "owner", "NixOS" },
+        { "repo", "nixpkgs" },
+        { "rev", "e8039594435c68eb4f780f3e9bf3972a7399c4b1" } } ),
     .path = flox::AttrPath { "legacyPackages", "x86_64-linux", "hello" },
     .info = nlohmann::json::object()
   };

--- a/tests/resolver.cc
+++ b/tests/resolver.cc
@@ -100,7 +100,7 @@ test_resolve0()
 
 /** @brief Limit resolution to a single input. */
 bool
-test_resolveInput()
+test_resolveInput0()
 {
   flox::RegistryRaw             registry    = commonRegistry;
   flox::pkgdb::QueryPreferences preferences = commonPreferences;
@@ -114,7 +114,8 @@ test_resolveInput()
   auto rsl = flox::resolver::resolve_v0( state, descriptor );
 
   EXPECT_EQ( rsl.size(), std::size_t( 1 ) );
-  EXPECT_EQ( rsl.front().input.name, "nixpkgs" );
+  EXPECT( rsl.front().input.name.has_value() );
+  EXPECT_EQ( *rsl.front().input.name, "nixpkgs" );
 
   return true;
 }
@@ -140,7 +141,7 @@ main( int argc, char * argv[] )
   setenv( "PKGDB_CACHEDIR", cacheDir.c_str(), 1 );
 
   RUN_TEST( resolve0 );
-  RUN_TEST( resolveInput );
+  RUN_TEST( resolveInput0 );
 
   /* Cleanup the temporary directory. */
   nix::deletePath( cacheDir );

--- a/tests/test.hh
+++ b/tests/test.hh
@@ -63,9 +63,6 @@ runTest( std::string_view name, F f, Args && ... args )
 
 /* -------------------------------------------------------------------------- */
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-
 /**
  * @brief Wrap a test routine which returns an exit code, and set a provided
  *        variable to the resulting code on failure.
@@ -85,8 +82,6 @@ runTest( std::string_view name, F f, Args && ... args )
                        );                                         \
     if ( _exitCode != EXIT_SUCCESS ) { _EXIT_CODE = _exitCode; }  \
   }
-
-#pragma clang diagnostic pop
 
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This implements the simplest manifest -> lockfile strategy for descriptors.
It does not support `packageGroup` , multiple inputs, or `update` operations at this time - these features will be added in later tickets/PRs.

Currently the manifest file must contain a `registry` field; but a later PR will hard code `github:NixOS/nixpkgs/release-23.05` as the only available input.