### PR TITLE
chore: update nix to 2.17

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698929167,
-        "narHash": "sha256-R+6T1131cIQdaHsvxxCdEESyWhM/HQxwufzRPsBWekM=",
+        "lastModified": 1698942558,
+        "narHash": "sha256-/UmnB+mEd6Eg3mJBrAgqRcyZX//RSjHphcCO7Ig9Bpk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2288ae0fa6ca56ca3ba777704de6cd3cbb70707",
+        "rev": "621f51253edffa1d6f08d5fce4f08614c852d17e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691024356,
-        "narHash": "sha256-uGLyhkwew6ORO6nAz0Y7KHdiQrDJVI2n6rl4gl7mWzk=",
+        "lastModified": 1694873346,
+        "narHash": "sha256-Uvh03bg0a6ZnNWiX1Gb8g+m343wSJ/wb8ryUASt0loc=",
         "owner": "aakropotkin",
         "repo": "floco",
-        "rev": "1e84b4b16bba5746e1195fa3a4d8addaaf2d9ef4",
+        "rev": "d16bd444ab9d29a6640f52ee4e43a66528e07515",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697828342,
-        "narHash": "sha256-DSaN5aa+Kyo84GoQL1dIg0H9AMLl8yU4q+uN2AjEi4s=",
+        "lastModified": 1698929167,
+        "narHash": "sha256-R+6T1131cIQdaHsvxxCdEESyWhM/HQxwufzRPsBWekM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96f7c64907ccdb53e36b3c02b5165dfd491ec0db",
+        "rev": "d2288ae0fa6ca56ca3ba777704de6cd3cbb70707",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -35,8 +35,13 @@
 
 # ---------------------------------------------------------------------------- #
 
-    /* Use nix@2.15 */
-    overlays.nix = final: prev: { nix = prev.nixVersions.nix_2_15; };
+    /* Use nix@2.17 */
+    overlays.nix = final: prev: { nix = prev.nixVersions.nix_2_17.overrideAttrs (old: {
+      patches = old.patches or [] ++ [
+        ./nix-patches/nix-9147.patch
+        ./nix-patches/multiple-github-tokens.2.13.2.patch
+      ];
+    }); };
     /* Aggregate dependency overlays. */
     overlays.deps = nixpkgs.lib.composeManyExtensions [
       overlays.nix
@@ -57,7 +62,7 @@
       pkgsFor = ( builtins.getAttr system nixpkgs.legacyPackages ).extend
                   overlays.default;
     in {
-      inherit (pkgsFor) flox-pkgdb;
+      inherit (pkgsFor) flox-pkgdb semver;
       default = pkgsFor.flox-pkgdb;
     } );
 
@@ -101,7 +106,7 @@
           if pkgsFor.stdenv.isLinux or false then [pkgsFor.valgrind] else []
         );
         inherit (pkgsFor.flox-pkgdb)
-          nix_INCDIR boost_CFLAGS toml_CFLAGS yaml_PREFIX libExt SEMVER_PATH
+          nix_INCDIR toml_CFLAGS yaml_PREFIX libExt SEMVER_PATH
         ;
         shellHook = ''
           shopt -s autocd;

--- a/flake.nix
+++ b/flake.nix
@@ -38,8 +38,8 @@
     /* Use nix@2.17 */
     overlays.nix = final: prev: { nix = prev.nixVersions.nix_2_17.overrideAttrs (old: {
       patches = old.patches or [] ++ [
-        ./nix-patches/nix-9147.patch
-        ./nix-patches/multiple-github-tokens.2.13.2.patch
+        (builtins.path {path = ./nix-patches/nix-9147.patch;})
+        (builtins.path {path = ./nix-patches/multiple-github-tokens.2.13.2.patch;})
       ];
     }); };
     /* Aggregate dependency overlays. */
@@ -106,7 +106,7 @@
           if pkgsFor.stdenv.isLinux or false then [pkgsFor.valgrind] else []
         );
         inherit (pkgsFor.flox-pkgdb)
-          nix_INCDIR toml_CFLAGS yaml_PREFIX libExt SEMVER_PATH
+          nix_INCDIR boost_CFLAGS toml_CFLAGS yaml_PREFIX libExt SEMVER_PATH
         ;
         shellHook = ''
           shopt -s autocd;

--- a/include/flox/core/nix-state.hh
+++ b/include/flox/core/nix-state.hh
@@ -12,6 +12,8 @@
 #include <nix/eval-cache.hh>
 #include <nix/logging.hh>
 #include <nix/store-api.hh>
+#include <nix/eval-cache.hh>
+#include <nix/search-path.hh>
 
 #include <nlohmann/json.hpp>
 
@@ -139,15 +141,16 @@ public:
    *
    * Evaluator remains open for lifetime of object.
    */
-  nix::ref<nix::EvalState>
+    nix::ref<nix::EvalState>
   getState()
   {
     if ( this->state == nullptr )
       {
-        this->state
-          = std::make_shared<nix::EvalState>( std::list<std::string> {},
-                                              this->getStore(),
-                                              this->getStore() );
+        this->state = std::make_shared<nix::EvalState>(
+          nix::SearchPath()
+        , this->getStore()
+        , this->getStore()
+        );
         this->state->repair = nix::NoRepair;
       }
     return static_cast<nix::ref<nix::EvalState>>( this->state );

--- a/include/flox/core/util.hh
+++ b/include/flox/core/util.hh
@@ -57,39 +57,49 @@ namespace nlohmann {
 
 /** @brief Variants ( Eithers ) of two elements to/from JSON. */
 template<typename A, typename B>
-struct adl_serializer<std::variant<A, B>> {
+struct adl_serializer<std::variant<A, B>>
+{
 
   /** @brief Convert a @a std::variant<A, B> to a JSON type. */
-    static void
-  to_json( json & jto, const std::variant<A, B> & var )
+  static void
+  to_json( json &jto, const std::variant<A, B> &var )
   {
-    if ( std::holds_alternative<A>( var ) )
-      {
-        jto = std::get<A>( var );
-      }
-    else
-      {
-        jto = std::get<B>( var );
-      }
+    if ( std::holds_alternative<A>( var ) ) { jto = std::get<A>( var ); }
+    else { jto = std::get<B>( var ); }
   }
 
   /** @brief Convert a JSON type to a @a std::variant<A, B>. */
-    static void
-  from_json( const json & jfrom, std::variant<A, B> & var )
+  static void
+  from_json( const json &jfrom, std::variant<A, B> &var )
   {
     try
       {
         var = jfrom.template get<A>();
       }
-    catch( ... )
+    catch ( ... )
       {
         var = jfrom.template get<B>();
       }
   }
 
-};  /* End struct `adl_serializer<std::variant<A, B>>' */
+}; /* End struct `adl_serializer<std::variant<A, B>>' */
+
 
 /* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Variants ( Eithers ) of any number of elements to/from JSON.
+ *
+ * The order of your types effects priority.
+ * Any valid parse or coercion from a type named _early_ in the variant list
+ * will succeed before attempting to parse alternatives.
+ *
+ * For example, always attempt `bool` first, then `int`, then `float`, and
+ * alway attempt `std::string` LAST.
+ *
+ * It's important to note that you must never nest multiple `std::optional`
+ * types in a variant, instead make `std::optional<std::variant<...>>`.
+ */
 template<typename A, typename... Types>
 struct adl_serializer<std::variant<A, Types...>>
 {
@@ -124,6 +134,7 @@ struct adl_serializer<std::variant<A, Types...>>
   }
 
 }; /* End struct `adl_serializer<std::variant<A, Types...>>' */
+
 
 /* -------------------------------------------------------------------------- */
 

--- a/include/flox/core/util.hh
+++ b/include/flox/core/util.hh
@@ -55,117 +55,84 @@ namespace nlohmann {
 
 /* -------------------------------------------------------------------------- */
 
-/** @brief Optional types to/from JSON. */
-template<typename T>
-struct adl_serializer<std::optional<T>>
-{
+  /** @brief Variants ( Eithers ) of two elements to/from JSON. */
+  template<typename A, typename B>
+  struct adl_serializer<std::variant<A, B>> {
 
-  /**
-   *  @brief Convert an optional type to a JSON type  treating `std::nullopt`
-   *         as `null`.
-   */
-  static void
-  to_json( json &jto, const std::optional<T> &opt )
-  {
-    if ( opt.has_value() ) { jto = *opt; }
-    else { jto = nullptr; }
-  }
+    /** @brief Convert a @a std::variant<A, B> to a JSON type. */
+      static void
+    to_json( json & jto, const std::variant<A, B> & var )
+    {
+      if ( std::holds_alternative<A>( var ) )
+        {
+          jto = std::get<A>( var );
+        }
+      else
+        {
+          jto = std::get<B>( var );
+        }
+    }
 
-  /**
-   * @brief Convert a JSON type to an `optional<T>` treating
-   *        `null` as `std::nullopt`.
-   */
-  static void
-  from_json( const json &jfrom, std::optional<T> &opt )
-  {
-    if ( jfrom.is_null() ) { opt = std::nullopt; }
-    else { opt = std::make_optional( jfrom.template get<T>() ); }
-  }
+    /** @brief Convert a JSON type to a @a std::variant<A, B>. */
+      static void
+    from_json( const json & jfrom, std::variant<A, B> & var )
+    {
+      try
+        {
+          var = jfrom.template get<A>();
+        }
+      catch( ... )
+        {
+          var = jfrom.template get<B>();
+        }
+    }
 
-}; /* End struct `adl_serializer<std::optional<T>>' */
-
-
-/* -------------------------------------------------------------------------- */
-
-/** @brief Variants ( Eithers ) of two elements to/from JSON. */
-template<typename A, typename B>
-struct adl_serializer<std::variant<A, B>>
-{
-
-  /** @brief Convert a @a std::variant<A, B> to a JSON type. */
-  static void
-  to_json( json &jto, const std::variant<A, B> &var )
-  {
-    if ( std::holds_alternative<A>( var ) ) { jto = std::get<A>( var ); }
-    else { jto = std::get<B>( var ); }
-  }
-
-  /** @brief Convert a JSON type to a @a std::variant<A, B>. */
-  static void
-  from_json( const json &jfrom, std::variant<A, B> &var )
-  {
-    try
-      {
-        var = jfrom.template get<A>();
-      }
-    catch ( ... )
-      {
-        var = jfrom.template get<B>();
-      }
-  }
-
-}; /* End struct `adl_serializer<std::variant<A, B>>' */
-
+  };  /* End struct `adl_serializer<std::variant<A, B>>' */
 
 /* -------------------------------------------------------------------------- */
 
-/**
- * @brief Variants ( Eithers ) of any number of elements to/from JSON.
- *
- * The order of your types effects priority.
- * Any valid parse or coercion from a type named _early_ in the variant list
- * will succeed before attempting to parse alternatives.
- *
- * For example, always attempt `bool` first, then `int`, then `float`, and
- * alway attempt `std::string` LAST.
- *
- * It's important to note that you must never nest multiple `std::optional`
- * types in a variant, instead make `std::optional<std::variant<...>>`.
- */
-template<typename A, typename... Types>
-struct adl_serializer<std::variant<A, Types...>>
-{
+  /** @brief Variants ( Eithers ) of three elements to/from JSON. */
+  template<typename A, typename B, typename C>
+  struct adl_serializer<std::variant<A, B, C>> {
 
-  /** @brief Convert a @a std::variant<A, Types...> to a JSON type. */
-  static void
-  to_json( json &jto, const std::variant<A, Types...> &var )
-  {
-    /* This _unwraps_ the inner type and calls the proper `to_json'.
-     * The compiler does the heavy lifting for us here <3. */
-    std::visit( [&]( auto unwrapped ) -> void { jto = unwrapped; }, var );
-  }
+    /** @brief Convert a @a std::variant<A, B, C> to a JSON type. */
+      static void
+    to_json( json & jto, const std::variant<A, B, C> & var )
+    {
+      if ( std::holds_alternative<A>( var ) )
+        {
+          jto = std::get<A>( var );
+        }
+      else if ( std::holds_alternative<B>( var ) )
+        {
+          jto = std::get<B>( var );
+        }
+      else
+        {
+          jto = std::get<C>( var );
+        }
+    }
 
-  /** @brief Convert a JSON type to a @a std::variant<Types...>. */
-  static void
-  from_json( const json &jfrom, std::variant<A, Types...> &var )
-  {
-    /* Try getting typename `A', or recur. */
-    try
-      {
-        var = jfrom.template get<A>();
-      }
-    catch ( ... )
-      {
-        /* Strip typename `A' from variant, and call recursively. */
-        using next_variant = std::variant<Types...>;
+    /** @brief Convert a JSON type to a @a std::variant<A, B, C>. */
+      static void
+    from_json( const json & jfrom, std::variant<A, B, C> & var )
+    {
+      try
+        {
+          var = jfrom.template get<A>();
+        }
+      catch( ... )
+        {
+          try {
+              var = jfrom.template get<B>();
+          }
+          catch (...) {
+              var = jfrom.template get<C>();
+          }
+        }
+    }
 
-        /* Coerce to `next_variant' type. */
-        next_variant next = jfrom.template get<next_variant>();
-        std::visit( [&]( auto unwrapped ) -> void { var = unwrapped; }, next );
-      }
-  }
-
-}; /* End struct `adl_serializer<std::variant<A, Types...>>' */
+  };  /* End struct `adl_serializer<std::variant<A, B, C>>' */
 
 
 /* -------------------------------------------------------------------------- */

--- a/nix-patches/multiple-github-tokens.2.13.2.patch
+++ b/nix-patches/multiple-github-tokens.2.13.2.patch
@@ -1,0 +1,99 @@
+diff --git a/src/libfetchers/github.cc b/src/libfetchers/github.cc
+index 1ed09d30d..9f44bdb67 100644
+--- a/src/libfetchers/github.cc
++++ b/src/libfetchers/github.cc
+@@ -157,18 +157,37 @@ struct GitArchiveInputScheme : InputScheme
+         return input;
+     }
+ 
+-    std::optional<std::string> getAccessToken(const std::string & host) const
++    std::optional<std::string> getAccessToken(const std::string & host, const std::string & url) const
+     {
+         auto tokens = fetchSettings.accessTokens.get();
++        std::string answer;
++        size_t answer_match_len = 0;
++        if(! url.empty()) {
++            for (auto & token : tokens) {
++                auto match_len = url.find(token.first);
++                if (match_len != std::string::npos && token.first.length() > answer_match_len) {
++                    answer = token.second;
++                    answer_match_len = token.first.length();
++                }
++            }
++            if (!answer.empty())
++                return answer;
++        }
+         if (auto token = get(tokens, host))
+             return *token;
+         return {};
+     }
+ 
+-    Headers makeHeadersWithAuthTokens(const std::string & host) const
++    Headers makeHeadersWithAuthTokens(const std::string & host, const Input & input) const {
++        auto owner = getStrAttr(input.attrs, "owner");
++        auto repo = getStrAttr(input.attrs, "repo");
++        auto urlGen = fmt( "%s/%s/%s", host, owner, repo);
++        return makeHeadersWithAuthTokens(host, urlGen);
++    }
++    Headers makeHeadersWithAuthTokens(const std::string & host,const std::string & url) const
+     {
+         Headers headers;
+-        auto accessToken = getAccessToken(host);
++        auto accessToken = getAccessToken(host, url);
+         if (accessToken) {
+             auto hdr = accessHeaderFromToken(*accessToken);
+             if (hdr)
+@@ -264,7 +283,7 @@ struct GitHubInputScheme : GitArchiveInputScheme
+             : "https://%s/api/v3/repos/%s/%s/commits/%s",
+             host, getOwner(input), getRepo(input), *input.getRef());
+ 
+-        Headers headers = makeHeadersWithAuthTokens(host);
++        Headers headers = makeHeadersWithAuthTokens(host, input);
+ 
+         auto json = nlohmann::json::parse(
+             readFile(
+@@ -279,7 +298,7 @@ struct GitHubInputScheme : GitArchiveInputScheme
+     {
+         auto host = getHost(input);
+ 
+-        Headers headers = makeHeadersWithAuthTokens(host);
++        Headers headers = makeHeadersWithAuthTokens(host, input);
+ 
+         // If we have no auth headers then we default to the public archive
+         // urls so we do not run into rate limits.
+@@ -336,7 +355,7 @@ struct GitLabInputScheme : GitArchiveInputScheme
+         auto url = fmt("https://%s/api/v4/projects/%s%%2F%s/repository/commits?ref_name=%s",
+             host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo"), *input.getRef());
+ 
+-        Headers headers = makeHeadersWithAuthTokens(host);
++        Headers headers = makeHeadersWithAuthTokens(host, input);
+ 
+         auto json = nlohmann::json::parse(
+             readFile(
+@@ -359,7 +378,7 @@ struct GitLabInputScheme : GitArchiveInputScheme
+             host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo"),
+             input.getRev()->to_string(Base16, false));
+ 
+-        Headers headers = makeHeadersWithAuthTokens(host);
++        Headers headers = makeHeadersWithAuthTokens(host, input);
+         return DownloadUrl { url, headers };
+     }
+ 
+@@ -399,7 +418,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
+         auto base_url = fmt("https://%s/%s/%s",
+             host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo"));
+ 
+-        Headers headers = makeHeadersWithAuthTokens(host);
++        Headers headers = makeHeadersWithAuthTokens(host, input);
+ 
+         std::string refUri;
+         if (ref == "HEAD") {
+@@ -446,7 +465,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
+             host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo"),
+             input.getRev()->to_string(Base16, false));
+ 
+-        Headers headers = makeHeadersWithAuthTokens(host);
++        Headers headers = makeHeadersWithAuthTokens(host, input);
+         return DownloadUrl { url, headers };
+     }
+ 

--- a/nix-patches/nix-9147.patch
+++ b/nix-patches/nix-9147.patch
@@ -1,0 +1,52 @@
+diff --git a/src/libutil/json-utils.hh b/src/libutil/json-utils.hh
+index 77c63595c..740168f8f 100644
+--- a/src/libutil/json-utils.hh
++++ b/src/libutil/json-utils.hh
+@@ -77,24 +77,30 @@ namespace nlohmann {
+  * round trip. We do that with a static assert.
+  */
+ template<typename T>
+-struct adl_serializer<std::optional<T>> {
+-    static std::optional<T> from_json(const json & json) {
+-        static_assert(
+-            nix::json_avoids_null<T>::value,
+-            "null is already in use for underlying type's JSON");
+-        return json.is_null()
+-            ? std::nullopt
+-            : std::optional { adl_serializer<T>::from_json(json) };
++      /** @brief Optional types to/from JSON. */
++  struct adl_serializer<std::optional<T>> {
++
++    /**
++     *  @brief Convert an optional type to a JSON type  treating `std::nullopt`
++     *         as `null`.
++     */
++      static void
++    to_json( json & jto, const std::optional<T> & opt )
++    {
++      if ( opt.has_value() ) { jto = * opt; }
++      else                   { jto = nullptr; }
+     }
+-    static void to_json(json & json, std::optional<T> t) {
+-        static_assert(
+-            nix::json_avoids_null<T>::value,
+-            "null is already in use for underlying type's JSON");
+-        if (t)
+-            adl_serializer<T>::to_json(json, *t);
+-        else
+-            json = nullptr;
++
++    /**
++     * @brief Convert a JSON type to an `optional<T>` treating
++     *        `null` as `std::nullopt`.
++     */
++      static void
++    from_json( const json & jfrom, std::optional<T> & opt )
++    {
++      if ( jfrom.is_null() ) { opt = std::nullopt; }
++      else { opt = std::make_optional( jfrom.template get<T>() ); }
+     }
+-};
+ 
++  };  /* End struct `adl_serializer<std::optional<T>>' */
+ }

--- a/pkg-fun.nix
+++ b/pkg-fun.nix
@@ -8,16 +8,14 @@
 , sqlite
 , pkg-config
 , nlohmann_json
-, nixVersions
+, nix
 , boost
 , argparse
 , semver
 , sqlite3pp
 , toml11
 , yaml-cpp
-}: let
-  nix = nixVersions.nix_2_15;
-in
+}:
   stdenv.mkDerivation {
   pname   = "flox-pkgdb";
   version = builtins.replaceStrings ["\n"] [""] ( builtins.readFile ./version );

--- a/pkg-fun.nix
+++ b/pkg-fun.nix
@@ -15,8 +15,7 @@
 , sqlite3pp
 , toml11
 , yaml-cpp
-}:
-  stdenv.mkDerivation {
+}: stdenv.mkDerivation {
   pname   = "flox-pkgdb";
   version = builtins.replaceStrings ["\n"] [""] ( builtins.readFile ./version );
   src     = builtins.path {

--- a/pkg-fun.nix
+++ b/pkg-fun.nix
@@ -8,14 +8,17 @@
 , sqlite
 , pkg-config
 , nlohmann_json
-, nix
+, nixVersions
 , boost
 , argparse
 , semver
 , sqlite3pp
 , toml11
 , yaml-cpp
-}: stdenv.mkDerivation {
+}: let
+  nix = nixVersions.nix_2_15;
+in
+  stdenv.mkDerivation {
   pname   = "flox-pkgdb";
   version = builtins.replaceStrings ["\n"] [""] ( builtins.readFile ./version );
   src     = builtins.path {


### PR DESCRIPTION
brings Nix to 2.17

- brought in some patches to make nlohmann machinery work, ~~notably adding a variant<A,B,C> handler which is a bit ugly, but generic handling of arbitrary sum types in C++ is....... an exercise for the reader.~~ restored support for sum types
- included the multiple-github-tokens patch
- use overlays to make `nix` the patched version for all downstream users of the pkgdb overlays. 