### PR TITLE
fix: semver globs

### DIFF
--- a/src/search/params.cc
+++ b/src/search/params.cc
@@ -98,11 +98,15 @@ SearchQuery::fillPkgQueryArgs( pkgdb::PkgQueryArgs &pqa ) const
 
 /* Instantiate templates. */
 namespace flox::pkgdb {
+
 template struct QueryParams<search::SearchQuery>;
+
 template void
 from_json( const nlohmann::json &, QueryParams<search::SearchQuery> & );
+
 template void
 to_json( nlohmann::json &, const QueryParams<search::SearchQuery> & );
+
 }  // namespace flox::pkgdb
 
 

--- a/tests/search.bats
+++ b/tests/search.bats
@@ -118,6 +118,20 @@ genParamsNixpkgsFlox() {
 
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=search:semver, search:pname
+
+# Test `semver' by filtering to 18.*
+@test "'pkgdb search' 'pname=nodejs & semver=18.*'" {
+  run sh -c "$PKGDB search '$(
+    genParams '.query.pname|="nodejs"|.query.semver="18.*"';
+  )'|wc -l;";
+  assert_success;
+  assert_output 4;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
 # bats test_tags=search:name
 
 # Exact `name' match.


### PR DESCRIPTION
- Fixes handling of semantic version __glob ranges_ such as `18*`, `18.*`, `18.x`, and `18.X`.

- Adds a new test case to ensure glob handling works.
