### PR TITLE
fix: invalid optional dereference

### DIFF
--- a/include/flox/resolver/manifest.hh
+++ b/include/flox/resolver/manifest.hh
@@ -395,8 +395,12 @@ public:
   [[nodiscard]] std::vector<System>
   getSystems() const
   {
-    return this->getManifestRaw().options->systems.value_or(
-      std::vector<System> { nix::settings.thisSystem.get() } );
+    auto manifest = this->getManifestRaw();
+    if ( manifest.options.has_value() && manifest.options->systems.has_value() )
+      {
+        return *manifest.options->systems;
+      }
+    else { return std::vector<System> { nix::settings.thisSystem.get() }; }
   }
 
   [[nodiscard]] pkgdb::PkgQueryArgs

--- a/include/flox/resolver/manifest.hh
+++ b/include/flox/resolver/manifest.hh
@@ -395,7 +395,7 @@ public:
   [[nodiscard]] std::vector<System>
   getSystems() const
   {
-    auto manifest = this->getManifestRaw();
+    const auto & manifest = this->getManifestRaw();
     if ( manifest.options.has_value() && manifest.options->systems.has_value() )
       {
         return *manifest.options->systems;


### PR DESCRIPTION
An optional is being dereferenced even when it doesn't have a value. This appears to be causing the following behavior:

$ pkgdb manifest lock manifest.toml
vector

After this change, correct JSON is output.