### PR TITLE
fix: database views schema migration

### DIFF
--- a/src/pkgdb/schemas.hh
+++ b/src/pkgdb/schemas.hh
@@ -105,7 +105,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_Packages
 
 /* -------------------------------------------------------------------------- */
 
-/* XXX: Keep in sync with `<pkgdb>/src/pkgdb/write.cc:PkgDb::initTables()' */
 static const char * sql_views = R"SQL(
 
 -- A JSON list form of the _attribute path_ to an `AttrSets` row.

--- a/src/pkgdb/write.cc
+++ b/src/pkgdb/write.cc
@@ -46,7 +46,7 @@ PkgDb::updateViews()
                           " ( type = 'view' )" );
     for ( auto row : qry )
       {
-        std::string        name = row.get<std::string>( 0 );
+        auto               name = row.get<std::string>( 0 );
         std::string        cmd  = "DROP VIEW IF EXISTS '" + name + '\'';
         sqlite3pp::command dropView( this->db, cmd.c_str() );
         if ( sql_rc rcode = dropView.execute(); isSQLError( rcode ) )

--- a/src/pkgdb/write.cc
+++ b/src/pkgdb/write.cc
@@ -41,12 +41,13 @@ PkgDb::updateViews()
 {
   /* Drop all existing views. */
   {
-    sqlite3pp::query qry( this->db, "SELECT name FROM sqlite_master WHERE"
-                                    " ( type = 'view' )" );
+    sqlite3pp::query qry( this->db,
+                          "SELECT name FROM sqlite_master WHERE"
+                          " ( type = 'view' )" );
     for ( auto row : qry )
       {
-        std::string name = row.get<std::string>( 0 );
-        std::string cmd = "DROP VIEW IF EXISTS '" + name + '\'';
+        std::string        name = row.get<std::string>( 0 );
+        std::string        cmd  = "DROP VIEW IF EXISTS '" + name + '\'';
         sqlite3pp::command dropView( this->db, cmd.c_str() );
         if ( sql_rc rcode = dropView.execute(); isSQLError( rcode ) )
           {

--- a/src/pkgdb/write.cc
+++ b/src/pkgdb/write.cc
@@ -27,7 +27,7 @@ PkgDb::initViews()
 {
   if ( sql_rc rcode = this->execute_all( sql_views ); isSQLError( rcode ) )
     {
-      throw PkgDbException( nix::fmt( "Failed to initialize views:(%d) %s",
+      throw PkgDbException( nix::fmt( "failed to initialize views:(%d) %s",
                                       rcode,
                                       this->db.error_msg() ) );
     }
@@ -39,23 +39,39 @@ PkgDb::initViews()
 void
 PkgDb::updateViews()
 {
-  /* XXX: Keep in sync with `<pkgdb>/src/pkgdb/schemas.hh' */
-  sqlite3pp::command updateViews(
-    this->db,
-    "DROP VIEW IF EXISTS v_AttrPaths;"
-    "DROP VIEW IF EXISTS v_Semvers;"
-    "DROP VIEW IF EXISTS v_PackagesSearch;"
-    "UPDATE DbVersions SET version = ? WHERE name = 'pkgdb_views_schema'" );
-  updateViews.bind( 1, static_cast<int>( sqlVersions.views ) );
+  /* Drop all existing views. */
+  {
+    sqlite3pp::query qry( this->db, "SELECT name FROM sqlite_master WHERE"
+                                    " ( type = 'view' )" );
+    for ( auto row : qry )
+      {
+        std::string name = row.get<std::string>( 0 );
+        std::string cmd = "DROP VIEW IF EXISTS '" + name + '\'';
+        sqlite3pp::command dropView( this->db, cmd.c_str() );
+        if ( sql_rc rcode = dropView.execute(); isSQLError( rcode ) )
+          {
+            throw PkgDbException( nix::fmt( "failed to drop view '%s':(%d) %s",
+                                            name,
+                                            rcode,
+                                            this->db.error_msg() ) );
+          }
+      }
+  }
 
-  if ( sql_rc rcode = updateViews.execute_all(); isSQLError( rcode ) )
+  /* Update the `pkgdb_views_schema' version. */
+  sqlite3pp::command updateVersion(
+    this->db,
+    "UPDATE DbVersions SET version = ? WHERE name = 'pkgdb_views_schema'" );
+  updateVersion.bind( 1, static_cast<int>( sqlVersions.views ) );
+
+  if ( sql_rc rcode = updateVersion.execute_all(); isSQLError( rcode ) )
     {
-      throw PkgDbException( nix::fmt( "Failed to update PkgDb Views:(%d) %s",
+      throw PkgDbException( nix::fmt( "failed to update PkgDb Views:(%d) %s",
                                       rcode,
                                       this->db.error_msg() ) );
     }
 
-  /* Redefine the `VIEW`s */
+  /* Redefine the `VIEW's */
   this->initViews();
 }
 
@@ -68,7 +84,7 @@ PkgDb::initTables()
   if ( sql_rc rcode = this->execute( sql_versions ); isSQLError( rcode ) )
     {
       throw PkgDbException(
-        nix::fmt( "Failed to initialize DbVersions table:(%d) %s",
+        nix::fmt( "failed to initialize DbVersions table:(%d) %s",
                   rcode,
                   this->db.error_msg() ) );
     }
@@ -76,7 +92,7 @@ PkgDb::initTables()
   if ( sql_rc rcode = this->execute_all( sql_input ); isSQLError( rcode ) )
     {
       throw PkgDbException(
-        nix::fmt( "Failed to initialize LockedFlake table:(%d) %s",
+        nix::fmt( "failed to initialize LockedFlake table:(%d) %s",
                   rcode,
                   this->db.error_msg() ) );
     }
@@ -84,7 +100,7 @@ PkgDb::initTables()
   if ( sql_rc rcode = this->execute_all( sql_attrSets ); isSQLError( rcode ) )
     {
       throw PkgDbException(
-        nix::fmt( "Failed to initialize AttrSets table:(%d) %s",
+        nix::fmt( "failed to initialize AttrSets table:(%d) %s",
                   rcode,
                   this->db.error_msg() ) );
     }
@@ -92,7 +108,7 @@ PkgDb::initTables()
   if ( sql_rc rcode = this->execute_all( sql_packages ); isSQLError( rcode ) )
     {
       throw PkgDbException(
-        nix::fmt( "Failed to initialize Packages table:(%d) %s",
+        nix::fmt( "failed to initialize Packages table:(%d) %s",
                   rcode,
                   this->db.error_msg() ) );
     }
@@ -114,7 +130,7 @@ PkgDb::initVersions()
   defineVersions.bind( 2, static_cast<int>( sqlVersions.views ) );
   if ( sql_rc rcode = defineVersions.execute(); isSQLError( rcode ) )
     {
-      throw PkgDbException( nix::fmt( "Failed to write DbVersions info:(%d) %s",
+      throw PkgDbException( nix::fmt( "failed to write DbVersions info:(%d) %s",
                                       rcode,
                                       this->db.error_msg() ) );
     }
@@ -152,7 +168,7 @@ PkgDb::writeInput()
   if ( sql_rc rcode = cmd.execute(); isSQLError( rcode ) )
     {
       throw PkgDbException(
-        nix::fmt( "Failed to write LockedFlaked info:(%d) %s",
+        nix::fmt( "failed to write LockedFlaked info:(%d) %s",
                   rcode,
                   this->db.error_msg() ) );
     }
@@ -180,7 +196,7 @@ PkgDb::addOrGetAttrSetId( const std::string & attrName, row_id parent )
       if ( row == qryId.end() )
         {
           throw PkgDbException(
-            nix::fmt( "Failed to add AttrSet.id 'AttrSets[%ull].%s':(%d) %s",
+            nix::fmt( "failed to add AttrSet.id `AttrSets[%ull].%s':(%d) %s",
                       parent,
                       attrName,
                       rcode,
@@ -235,7 +251,7 @@ PkgDb::addOrGetDescriptionId( const std::string & description )
     nix::fmt( "Adding new description to database: %s.", description ) );
   if ( sql_rc rcode = cmd.execute(); isSQLError( rcode ) )
     {
-      throw PkgDbException( nix::fmt( "Failed to add Description '%s':(%d) %s",
+      throw PkgDbException( nix::fmt( "failed to add Description '%s':(%d) %s",
                                       description,
                                       rcode,
                                       this->db.error_msg() ) );
@@ -333,7 +349,7 @@ PkgDb::addPackage( row_id               parentId,
     }
   if ( sql_rc rcode = cmd.execute(); isSQLError( rcode ) )
     {
-      throw PkgDbException( nix::fmt( "Failed to write Package '%s':(%d) %s",
+      throw PkgDbException( nix::fmt( "failed to write Package '%s':(%d) %s",
                                       pkg._fullName,
                                       rcode,
                                       this->db.error_msg() ) );
@@ -364,7 +380,7 @@ PkgDb::setPrefixDone( row_id prefixId, bool done )
   if ( sql_rc rcode = cmd.execute(); isSQLError( rcode ) )
     {
       throw PkgDbException( nix::fmt(
-        "Failed to set AttrSets.done for subtree '%s':(%d) %s",
+        "failed to set AttrSets.done for subtree '%s':(%d) %s",
         nix::concatStringsSep( ".", this->getAttrSetPath( prefixId ) ),
         rcode,
         this->db.error_msg() ) );

--- a/tests/migrate.bats
+++ b/tests/migrate.bats
@@ -1,0 +1,80 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Ensure schema migrations work as expected.
+#
+# TODO:
+#   - `pkgdb_tables_schema' tests.
+#
+# ---------------------------------------------------------------------------- #
+
+load setup_suite.bash;
+
+# bats file_tags=sqlite3
+
+
+# ---------------------------------------------------------------------------- #
+
+setup_file() {
+  # We don't parallelize these to avoid DB sync headaches and to recycle the
+  # cache between tests.
+  # Nonetheless this file makes an effort to avoid depending on past state in
+  # such a way that would make it difficult to eventually parallelize in
+  # the future.
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true;
+  export TEST_HARNESS_FLAKE="$TESTS_DIR/harnesses/proj0";
+
+  export DBPATH="$BATS_FILE_TMPDIR/test.sqlite";
+
+  # Create a new DB.
+  $PKGDB scrape --database "$DBPATH" "$TEST_HARNESS_FLAKE"  \
+                packages "$NIX_SYSTEM";
+
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# get_version ROW-NAME
+# --------------------
+# Get the version of a row in the DbVersions table.
+# Row names:
+#   pkgdb
+#   pkgdb_tables_schema
+#   pkgdb_views_schema
+get_version() {
+  sqlite3 "$DBPATH" "SELECT version FROM DbVersions WHERE name = '${1?}'";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "migrate views schema" {
+  # Set the version of the views schema to 0, which will always force
+  # a migration.
+  run sqlite3 "$DBPATH"                                                     \
+    "UPDATE DbVersions SET version = 0 WHERE name = 'pkgdb_views_schema'";
+  assert_success;
+
+  run get_version pkgdb_views_schema;
+  assert_success;
+  assert_output 0;
+
+  # Trigger a scrape which should migrate the views schema.
+  run $PKGDB scrape --database "$DBPATH" "$TEST_HARNESS_FLAKE"  \
+                    packages "$NIX_SYSTEM";
+  assert_success;
+
+  # Assert that the views schema was updated.
+  run get_version pkgdb_views_schema;
+  assert_success;
+  refute_output 0;
+}
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #


### PR DESCRIPTION
When migrating _views schema_ all previously defined `VIEW`s are deleted and recreated.

Previously `VIEW`s were explicitly deleted by name, but if new `VIEW` definitions were added to the DB it was easy to forget to update the `PkgDb::updateViews()` routine.
