### PR TITLE
docs: fixup docstrings and some comments

### DIFF
--- a/include/flox/resolver/manifest.hh
+++ b/include/flox/resolver/manifest.hh
@@ -481,8 +481,11 @@ public:
     return this->descriptors;
   }
 
-  /** @brief Returns all descriptors, grouping those with a _group_ field, and
-   * returning those without a group field as a map with a single element */
+  /**
+   * @brief Returns all descriptors, grouping those with a _group_ field, and
+   *        returning those without a group field as a map with a
+   *        single element.
+   */
   [[nodiscard]] std::vector<InstallDescriptors>
   getGroupedDescriptors() const;
 

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -96,8 +96,11 @@ Environment::getOldManifestRaw() const
 
 /* -------------------------------------------------------------------------- */
 
-// Helper function for groupIsLocked.
-// A system is skipped if systems is specified but that system is not.
+/**
+ * @brief Helper function for @a flox::resolver::Environment::groupIsLocked.
+ *
+ * A system is skipped if systems is specified but that system is not.
+ */
 bool
 systemSkipped( const System &                             system,
                const std::optional<std::vector<System>> & systems )
@@ -120,8 +123,8 @@ Environment::groupIsLocked( const InstallDescriptors & group,
 
   for ( auto & [iid, descriptor] : group )
     {
-      // If the descriptor has changed compared to the one in the lockfile
-      // manifest, it needs to be locked again.
+      /* If the descriptor has changed compared to the one in the lockfile
+       * manifest, it needs to be locked again. */
       if ( auto oldDescriptorPair = oldDescriptors.find( iid );
            oldDescriptorPair != oldDescriptors.end() )
         {
@@ -138,7 +141,7 @@ Environment::groupIsLocked( const InstallDescriptors & group,
             {
               return false;
             }
-          // Ignore changes to systems other than the one we're locking
+          /* Ignore changes to systems other than the one we're locking. */
           if ( systemSkipped( system, descriptor.systems )
                != systemSkipped( system, oldDescriptor.systems ) )
             {
@@ -152,15 +155,15 @@ Environment::groupIsLocked( const InstallDescriptors & group,
       if ( auto oldLockedPackagePair = oldSystemPackages.find( iid );
            oldLockedPackagePair != oldSystemPackages.end() )
         {
-          // Note: we could relock if the prior locking attempt was null
+          /* NOTE: we could relock if the prior locking attempt was null */
           // auto & [_, oldLockedPackage] = *oldLockedPackagePair;
           // if ( !oldLockedPackage.has_value()) { return false; }
         }
-      // If the descriptor doesn't even exist in the lockfile lock, it needs to
-      // be locked again.
+      /* If the descriptor doesn't even exist in the lockfile lock, it needs to
+       * be locked again. */
       else { return false; }
     }
-  // We haven't found something unlocked, so everything must be locked.
+  /* We haven't found something unlocked, so everything must be locked. */
   return true;
 }
 
@@ -196,7 +199,7 @@ Environment::getLockedGroups( const System & system )
 
   auto groupedDescriptors = this->getManifest().getGroupedDescriptors();
 
-  // remove all groups that are ~not~ already locked
+  /* Remove all groups that are ~not~ already locked. */
   for ( auto group = groupedDescriptors.begin();
         group != groupedDescriptors.end(); )
     {
@@ -397,8 +400,8 @@ Environment::lockSystem( const System & system )
       msg << "failed to resolve some packages(s):";
       for ( const auto & group : groups )
         {
-          // TODO tryResolveGroupIn should report which packages failed to
-          // resolve
+          // TODO tryResolveGroupIn should report which packages failed
+          //      to resolve.
           if ( auto descriptor = group.begin();
                descriptor != group.end()
                && descriptor->second.group.has_value() )
@@ -424,7 +427,7 @@ Environment::lockSystem( const System & system )
     }
 
 
-  // Copy over old lockfile entries we want to keep
+  /* Copy over old lockfile entries we want to keep. */
   if ( auto oldLockfile = this->getOldLockfile() )
     {
       SystemPackages systemPackages

--- a/src/resolver/manifest.cc
+++ b/src/resolver/manifest.cc
@@ -189,14 +189,14 @@ Manifest::Manifest( std::filesystem::path manifestPath )
 std::vector<InstallDescriptors>
 Manifest::getGroupedDescriptors() const
 {
-  // Group all packages into a map with group name as key.
+  /* Group all packages into a map with group name as key. */
   std::unordered_map<GroupName, InstallDescriptors> grouped;
   InstallDescriptors                                defaultGroup;
   for ( const auto & [iid, desc] : this->descriptors )
     {
-      // For now add all descriptors without a group to `defaultGroup`.
-      // TODO: use manifest options to decide how ungrouped descriptors are
-      // grouped.
+      // TODO: Use manifest options to decide how ungrouped descriptors
+      //       are grouped.
+      /* For now add all descriptors without a group to `defaultGroup`. */
       if ( ! desc.group.has_value() ) { defaultGroup.emplace( iid, desc ); }
       else
         {
@@ -205,8 +205,9 @@ Manifest::getGroupedDescriptors() const
         }
     }
 
-  // Add all groups to a vector. Don't use a map with group name because the
-  // defaultGroup doesn't have a name.
+  /* Add all groups to a vector.
+   * Don't use a map with group name because the defaultGroup doesn't have
+   * a name. */
   std::vector<InstallDescriptors> allDescriptors;
   allDescriptors.emplace_back( defaultGroup );
   for ( const auto & [_, group] : grouped )


### PR DESCRIPTION
- docs: docstring and comment tweaks

Underlying code looks great.

For Doxygen docstrings `@brief` continuations have to be indendent, and for whatever reason if your block is multiple lines `/**` has to be _on its own_:

```c++
// Renders improperly:

/** @brief It doesn't
    like this. */
    
    
// Renders properly:

/**
 * @brief It does
 *        like this.
 */
```


The other tweaks are just me preferring `/* Comment. */` for _inline comments_
and `// TODO: Something` for TODOs and `// someCode( 1 );` for _blocking out temporary code_.
That's just personal preference, you can use whichever you like.
