### PR TITLE
fix: buggy coercion to bool

### DIFF
--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -164,7 +164,7 @@ public:
   /** Match `name`, `pname`, or `attrName` */
   std::optional<std::string> name;
 
-  /** Whether resoution is allowed to fail without producing errors. */
+  /** Whether resolution is allowed to fail without producing errors. */
   bool optional = false;
 
   /** Named _group_ that the package is a member of. */

--- a/src/resolver/descriptor.cc
+++ b/src/resolver/descriptor.cc
@@ -461,7 +461,9 @@ to_json( nlohmann::json & jto, const ManifestDescriptorRaw & descriptor )
 /* -------------------------------------------------------------------------- */
 
 ManifestDescriptor::ManifestDescriptor( const ManifestDescriptorRaw & raw )
-  : name( raw.name ), optional( raw.optional ), group( raw.packageGroup )
+  : name( raw.name )
+  , optional( raw.optional.value_or( false ) )
+  , group( raw.packageGroup )
 {
   /* Determine if `version' was a range or not.
    * NOTE: The string "4.2.0" is not a range, but "4.2" is!


### PR DESCRIPTION
ManifestDescriptorRaw::optional is a std::optional<bool>, while ManifestDescriptor::optional is a bool, so constructing the bool from the std::optional<bool> incorrectly coerces an optional containing false to true. Instead, use value_or(false).