### PR TITLE
feat: `flox search --ga-manifest` and other arg parser improvements

### DIFF
--- a/include/flox/resolver/command.hh
+++ b/include/flox/resolver/command.hh
@@ -9,8 +9,11 @@
 
 #pragma once
 
-#include "flox/resolver/environment.hh"
-#include "flox/resolver/manifest.hh"
+#include <filesystem>
+#include <optional>
+
+#include "flox/resolver/manifest-raw.hh"
+#include "flox/resolver/mixins.hh"
 #include "flox/search/command.hh"
 
 

--- a/include/flox/resolver/environment.hh
+++ b/include/flox/resolver/environment.hh
@@ -36,11 +36,11 @@ namespace flox {
 
 namespace pkgdb {
 class PkgDbReadOnly;
-} // namespace flox::pkgdb
+}  // namespace pkgdb
 
 namespace resolver {
 struct ManifestDescriptor;
-}  // namespace flox::resolver
+}  // namespace resolver
 
 
 }  // namespace flox

--- a/include/flox/resolver/environment.hh
+++ b/include/flox/resolver/environment.hh
@@ -9,11 +9,9 @@
 
 #pragma once
 
-#include <filesystem>
 #include <memory>
 #include <optional>
 #include <string_view>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -26,24 +24,25 @@
 #include "flox/pkgdb/pkg-query.hh"
 #include "flox/registry.hh"
 #include "flox/resolver/lockfile.hh"
+#include "flox/resolver/manifest-raw.hh"
+#include "flox/resolver/manifest.hh"
 
 
 /* -------------------------------------------------------------------------- */
 
 /* Forward Declarations */
 
-namespace argparse {
-class Argument;
-class ArgumentParser;
-}  // namespace argparse
-
 namespace flox {
+
 namespace pkgdb {
 class PkgDbReadOnly;
-}
+} // namespace flox::pkgdb
+
 namespace resolver {
 struct ManifestDescriptor;
-}
+}  // namespace flox::resolver
+
+
 }  // namespace flox
 
 
@@ -283,228 +282,6 @@ public:
 
 
 }; /* End class `Environment' */
-
-
-/* -------------------------------------------------------------------------- */
-
-/**
- * @a class flox::resolver::EnvironmentMixinException
- * @brief An exception thrown by @a flox::resolver::EnvironmentMixin during
- *        its initialization.
- * @{
- */
-FLOX_DEFINE_EXCEPTION( EnvironmentMixinException,
-                       EC_ENVIRONMENT_MIXIN,
-                       "EnvironmentMixin" )
-/** @} */
-
-
-/* -------------------------------------------------------------------------- */
-
-/**
- * @brief A state blob with files associated with an environment.
- *
- * This structure stashes several fields to avoid repeatedly calculating them.
- */
-class EnvironmentMixin
-{
-
-private:
-
-  /* All member variables are calculated lazily using `std::optional' and
-   * `get<MEMBER>' accessors.
-   * Even for internal access you should use the `get<MEMBER>' accessors to
-   * lazily initialize. */
-
-  /** Path to user level manifest ( if any ). */
-  std::optional<std::filesystem::path> globalManifestPath;
-  /**
-   * Contents of user level manifest with global registry and settings
-   * ( if any ).
-   */
-  std::optional<GlobalManifest> globalManifest;
-
-  /** Path to project level manifest. ( required ) */
-  std::optional<std::filesystem::path> manifestPath;
-  /**
-   * Contents of project level manifest with registry, settings,
-   * activation hook, and list of packages. ( required )
-   */
-  std::optional<Manifest> manifest;
-
-  /** Path to project's lockfile ( if any ). */
-  std::optional<std::filesystem::path> lockfilePath;
-  /** Contents of project's lockfile ( if any ). */
-  std::optional<Lockfile> lockfile;
-
-  /** Lazily initialized environment wrapper. */
-  std::optional<Environment> environment;
-
-
-protected:
-
-  /**
-   * @brief Initialize the @a globalManifestPath member variable.
-   *
-   * This may only be called once and must be called before
-   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
-   *
-   * This function exists so that child classes can initialize their
-   * @a flox::resolver::EnvirontMixin base at runtime without accessing
-   * private member variables.
-   */
-  void
-  initGlobalManifestPath( std::filesystem::path path );
-
-  /**
-   * @brief Initialize the @a globalManifest member variable.
-   *
-   * This may only be called once and must be called before
-   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
-   *
-   * This function exists so that child classes can initialize their
-   * @a flox::resolver::EnvirontMixin base at runtime without accessing
-   * private member variables.
-   */
-  void
-  initGlobalManifest( GlobalManifest manifest );
-
-  /**
-   * @brief Initialize the @a manifestPath member variable.
-   *
-   * This may only be called once and must be called before
-   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
-   *
-   * This function exists so that child classes can initialize their
-   * @a flox::resolver::EnvirontMixin base at runtime without accessing
-   * private member variables.
-   */
-  void
-  initManifestPath( std::filesystem::path path );
-
-  /**
-   * @brief Initialize the @a manifest member variable.
-   *
-   * This may only be called once and must be called before
-   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
-   *
-   * This function exists so that child classes can initialize their
-   * @a flox::resolver::EnvirontMixin base at runtime without accessing
-   * private member variables.
-   */
-  void
-  initManifest( Manifest manifest );
-
-  /**
-   * @brief Initialize the @a lockfilePath member variable.
-   *
-   * This may only be called once and must be called before
-   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
-   *
-   * This function exists so that child classes can initialize their
-   * @a flox::resolver::EnvirontMixin base at runtime without accessing
-   * private member variables.
-   */
-  void
-  initLockfilePath( std::filesystem::path path );
-
-  /**
-   * @brief Initialize the @a lockfile member variable.
-   *
-   * This may only be called once and must be called before
-   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
-   *
-   * This function exists so that child classes can initialize their
-   * @a flox::resolver::EnvirontMixin base at runtime without accessing
-   * private member variables.
-   */
-  void
-  initLockfile( Lockfile lockfile );
-
-
-public:
-
-  /**
-   * @brief Lazily initialize and return the @a globalManifest.
-   *
-   * If @a globalManifest is set simply return it.
-   * If @a globalManifest is unset, but @a globalManifestPath is set then
-   * load from the file.
-   */
-  [[nodiscard]] const std::optional<GlobalManifest> &
-  getGlobalManifest();
-
-  /**
-   * @brief Lazily initialize and return the @a manifest.
-   *
-   * If @a manifest is set simply return it.
-   * If @a manifest is unset, but @a manifestPath is set then
-   * load from the file.
-   */
-  [[nodiscard]] const Manifest &
-  getManifest();
-
-  /**
-   * @brief Lazily initialize and return the @a lockfile.
-   *
-   * If @a lockfile is set simply return it.
-   * If @a lockfile is unset, but @a lockfilePath is set then
-   * load from the file.
-   */
-  [[nodiscard]] const std::optional<Lockfile> &
-  getLockfile();
-
-  /**
-   * @brief Laziliy initialize and return the @a environment.
-   *
-   * The member variable @a manifest or @a manifestPath must be set for
-   * initialization to succeed.
-   * Member variables associated with the _global manifest_ and _lockfile_
-   * are optional.
-   *
-   * After @a getEnvironment() has been called once, it is no longer possible
-   * to use any `init*( MEMBER )` functions.
-   */
-  [[nodiscard]] Environment &
-  getEnvironment();
-
-  /**
-   * @brief Sets the path to the global manifest file to load
-   *        with `--global-manifest`.
-   * @param parser The parser to add the argument to.
-   * @return The argument added to the parser.
-   */
-  argparse::Argument &
-  addGlobalManifestFileOption( argparse::ArgumentParser & parser );
-
-  /**
-   * @brief Sets the path to the manifest file to load with `--manifest`.
-   * @param parser The parser to add the argument to.
-   * @param required Whether the argument is required.
-   * @return The argument added to the parser.
-   */
-  argparse::Argument &
-  addManifestFileOption( argparse::ArgumentParser & parser );
-
-  /**
-   * @brief Sets the path to the manifest file to load with a positional arg.
-   * @param parser The parser to add the argument to.
-   * @param required Whether the argument is required.
-   * @return The argument added to the parser.
-   */
-  argparse::Argument &
-  addManifestFileArg( argparse::ArgumentParser & parser, bool required = true );
-
-  /**
-   * @brief Sets the path to the old lockfile to load with `--lockfile`.
-   * @param parser The parser to add the argument to.
-   * @return The argument added to the parser.
-   */
-  argparse::Argument &
-  addLockfileOption( argparse::ArgumentParser & parser );
-
-
-}; /* End class `EnvironmentMixin' */
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/flox/resolver/lockfile.hh
+++ b/include/flox/resolver/lockfile.hh
@@ -17,10 +17,10 @@
 
 #include "flox/core/exceptions.hh"
 #include "flox/core/types.hh"
+#include "flox/pkgdb/input.hh"
 #include "flox/pkgdb/read.hh"
 #include "flox/registry.hh"
 #include "flox/resolver/manifest.hh"
-#include "flox/pkgdb/input.hh"
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/flox/resolver/lockfile.hh
+++ b/include/flox/resolver/lockfile.hh
@@ -20,6 +20,7 @@
 #include "flox/pkgdb/read.hh"
 #include "flox/registry.hh"
 #include "flox/resolver/manifest.hh"
+#include "flox/pkgdb/input.hh"
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/flox/resolver/manifest-raw.hh
+++ b/include/flox/resolver/manifest-raw.hh
@@ -1,0 +1,331 @@
+/* ========================================================================== *
+ *
+ * @file flox/resolver/manifest-raw.hh
+ *
+ * @brief An abstract description of an environment in its unresolved state.
+ *        This representation is intended for serialization and deserialization.
+ *        For the _real_ representation, see
+ *        [flox/resolver/manifest.hh](./manifest.hh).
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "flox/core/exceptions.hh"
+#include "flox/core/types.hh"
+#include "flox/pkgdb/pkg-query.hh"
+#include "flox/registry.hh"
+#include "flox/resolver/descriptor.hh"  // IWYU pragma: keep
+
+
+/* -------------------------------------------------------------------------- */
+
+namespace flox::resolver {
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @class flox::resolver::InvalidManifestFileException
+ * @brief An exception thrown when a manifest file is invalid.
+ * @{
+ */
+FLOX_DEFINE_EXCEPTION( InvalidManifestFileException,
+                       EC_INVALID_MANIFEST_FILE,
+                       "invalid manifest file" )
+/** @} */
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief The `install.<INSTALL-ID>` field name associated with a package
+ *        or descriptor.
+ */
+using InstallID = std::string;
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief A set of options that apply to an entire environment. */
+struct Options
+{
+
+  std::optional<std::vector<System>> systems;
+
+  struct Allows
+  {
+    std::optional<bool>                     unfree;
+    std::optional<bool>                     broken;
+    std::optional<std::vector<std::string>> licenses;
+  }; /* End struct `Allows' */
+  std::optional<Allows> allow;
+
+  struct Semver
+  {
+    std::optional<bool> preferPreReleases;
+  }; /* End struct `Semver' */
+  std::optional<Semver> semver;
+
+  std::optional<std::string> packageGroupingStrategy;
+  std::optional<std::string> activationStrategy;
+  // TODO: Other options
+
+
+  /**
+   * @brief Apply options from @a overrides, but retain other existing options.
+   */
+  void
+  merge( const Options & overrides );
+
+  /** @brief Convert to a _base_ set of @a flox::pkgdb::PkgQueryArgs. */
+  explicit operator pkgdb::PkgQueryArgs() const;
+
+
+}; /* End struct `Options' */
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Convert a JSON object to a @a flox::resolver::Options. */
+void
+from_json( const nlohmann::json & jfrom, Options & opts );
+
+/** @brief Convert a @a flox::resolver::Options to a JSON Object. */
+void
+to_json( nlohmann::json & jto, const Options & opts );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief A _global_ manifest containing only `registry` and `options` fields
+ *        in its _raw_ form.
+ *
+ * This _raw_ struct is defined to generate parsers, and its declarations simply
+ * represent what is considered _valid_.
+ * On its own, it performs no real work, other than to validate the input.
+ *
+ * @see flox::resolver::GlobalManifest
+ */
+struct GlobalManifestRaw
+{
+  std::optional<RegistryRaw> registry;
+  std::optional<Options>     options;
+
+  virtual ~GlobalManifestRaw()                   = default;
+  GlobalManifestRaw()                            = default;
+  GlobalManifestRaw( const GlobalManifestRaw & ) = default;
+  GlobalManifestRaw( GlobalManifestRaw && )      = default;
+
+  explicit GlobalManifestRaw( std::optional<RegistryRaw> registry,
+                              std::optional<Options> options = std::nullopt )
+    : registry( std::move( registry ) ), options( std::move( options ) )
+  {}
+
+  explicit GlobalManifestRaw( std::optional<Options> options )
+    : options( std::move( options ) )
+  {}
+
+  GlobalManifestRaw &
+  operator=( const GlobalManifestRaw & )
+    = default;
+  GlobalManifestRaw &
+  operator=( GlobalManifestRaw && )
+    = default;
+
+
+  /**
+   * @brief Validate manifest fields, throwing an exception if its contents
+   *        are invalid.
+   */
+  virtual void
+  check() const
+  {}
+
+  virtual void
+  clear()
+  {
+    this->registry = std::nullopt;
+    this->options  = std::nullopt;
+  }
+
+
+}; /* End struct `GlobalManifestRaw' */
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Convert a JSON object to a @a flox::resolver::GlobalManifest. */
+void
+from_json( const nlohmann::json & jfrom, GlobalManifestRaw & manifest );
+
+/** @brief Convert a @a flox::resolver::GlobalManifest to a JSON object. */
+void
+to_json( nlohmann::json & jto, const GlobalManifestRaw & manifest );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief A _raw_ description of an environment to be read from a file.
+ *
+ * This _raw_ struct is defined to generate parsers, and its declarations simply
+ * represent what is considered _valid_.
+ * On its own, it performs no real work, other than to validate the input.
+ *
+ * @see flox::resolver::Manifest
+ */
+struct ManifestRaw : public GlobalManifestRaw
+{
+
+  struct EnvBase
+  {
+    std::optional<std::string> floxhub;
+    std::optional<std::string> dir;
+
+    /**
+     * @brief Validate the `env-base` field, throwing an exception if invalid
+     *        information is found.
+     *
+     * This asserts:
+     * - Only one of `floxhub` or `dir` is set.
+     */
+    void
+    check() const;
+
+    void
+    clear()
+    {
+      this->floxhub = std::nullopt;
+      this->dir     = std::nullopt;
+    }
+
+  }; /* End struct `EnvBase' */
+  std::optional<EnvBase> envBase;
+
+  std::optional<
+    std::unordered_map<InstallID, std::optional<ManifestDescriptorRaw>>>
+    install;
+
+  std::optional<std::unordered_map<std::string, std::string>> vars;
+
+  struct Hook
+  {
+    std::optional<std::string> script;
+    std::optional<std::string> file;
+
+    /**
+     * @brief Validate `Hook` fields, throwing an exception if its contents
+     *        are invalid.
+     */
+    void
+    check() const;
+
+  }; /* End struct `ManifestRaw::Hook' */
+  std::optional<Hook> hook;
+
+  ~ManifestRaw() override            = default;
+  ManifestRaw()                      = default;
+  ManifestRaw( const ManifestRaw & ) = default;
+  ManifestRaw( ManifestRaw && )      = default;
+
+  explicit ManifestRaw( const GlobalManifestRaw & globalManifestRaw )
+    : GlobalManifestRaw( globalManifestRaw )
+  {}
+
+  explicit ManifestRaw( GlobalManifestRaw && globalManifestRaw )
+    : GlobalManifestRaw( globalManifestRaw )
+  {}
+
+  ManifestRaw &
+  operator=( const ManifestRaw & )
+    = default;
+
+  ManifestRaw &
+  operator=( ManifestRaw && )
+    = default;
+
+  ManifestRaw &
+  operator=( const GlobalManifestRaw & globalManifestRaw )
+  {
+    GlobalManifestRaw::operator=( globalManifestRaw );
+    return *this;
+  }
+
+  ManifestRaw &
+  operator=( GlobalManifestRaw && globalManifestRaw )
+  {
+    GlobalManifestRaw::operator=( globalManifestRaw );
+    return *this;
+  }
+
+  /**
+   * @brief Validate manifest fields, throwing an exception if its contents
+   *        are invalid.
+   *
+   * This asserts:
+   * - @a envBase is valid.
+   * - @a registry does not contain indirect flake references.
+   * - All members of @a install are valid.
+   * - @a hook is valid.
+   */
+  void
+  check() const override;
+
+  void
+  clear() override
+  {
+    /* From `GlobalManifestRaw' */
+    this->options  = std::nullopt;
+    this->registry = std::nullopt;
+    /* From `ManifestRaw' */
+    this->envBase = std::nullopt;
+    this->install = std::nullopt;
+    this->vars    = std::nullopt;
+    this->hook    = std::nullopt;
+  }
+
+  /**
+   * @brief Generate a JSON _diff_ between @a this manifest an @a old manifest.
+   *
+   * The _diff_ is represented as an [JSON patch](https://jsonpatch.com) object.
+   */
+  nlohmann::json
+  diff( const ManifestRaw & old ) const;
+
+
+}; /* End struct `ManifestRaw' */
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Convert a JSON object to a @a flox::resolver::ManifestRaw. */
+void
+from_json( const nlohmann::json & jfrom, ManifestRaw & manifest );
+
+/** @brief Convert a @a flox::resolver::ManifestRaw to a JSON object. */
+void
+to_json( nlohmann::json & jto, const ManifestRaw & manifest );
+
+
+/* -------------------------------------------------------------------------- */
+
+}  // namespace flox::resolver
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/include/flox/resolver/manifest.hh
+++ b/include/flox/resolver/manifest.hh
@@ -9,309 +9,39 @@
 
 #pragma once
 
+#include <filesystem>
 #include <optional>
+#include <string>
 #include <unordered_map>
-#include <unordered_set>
+#include <utility>
+#include <vector>
 
-#include <argparse/argparse.hpp>
-#include <nlohmann/json.hpp>
+#include <nix/config.hh>
+#include <nix/globals.hh>
+#include <nix/ref.hh>
 
-#include "flox/core/exceptions.hh"
+#include "flox/core/nix-state.hh"
 #include "flox/core/types.hh"
-#include "flox/pkgdb/input.hh"
+#include "flox/pkgdb/pkg-query.hh"
 #include "flox/registry.hh"
-#include "flox/resolver/descriptor.hh"
+#include "flox/resolver/manifest-raw.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+/* Forward Declarations. */
+
+namespace flox { namespace resolver {
+struct ManifestDescriptor;
+}}  // namespace flox::resolver
+namespace nix {
+class Store;
+}
 
 
 /* -------------------------------------------------------------------------- */
 
 namespace flox::resolver {
-
-/* -------------------------------------------------------------------------- */
-
-/**
- * @class flox::resolver::InvalidManifestFileException
- * @brief An exception thrown when a manifest file is invalid.
- * @{
- */
-FLOX_DEFINE_EXCEPTION( InvalidManifestFileException,
-                       EC_INVALID_MANIFEST_FILE,
-                       "invalid manifest file" )
-/** @} */
-
-
-/* -------------------------------------------------------------------------- */
-
-/**
- * @brief The `install.<INSTALL-ID>` field name associated with a package
- *        or descriptor.
- */
-using InstallID = std::string;
-
-
-/* -------------------------------------------------------------------------- */
-
-/** @brief A set of options that apply to an entire environment. */
-struct Options
-{
-
-  std::optional<std::vector<System>> systems;
-
-  struct Allows
-  {
-    std::optional<bool>                     unfree;
-    std::optional<bool>                     broken;
-    std::optional<std::vector<std::string>> licenses;
-  }; /* End struct `Allows' */
-  std::optional<Allows> allow;
-
-  struct Semver
-  {
-    std::optional<bool> preferPreReleases;
-  }; /* End struct `Semver' */
-  std::optional<Semver> semver;
-
-  std::optional<std::string> packageGroupingStrategy;
-  std::optional<std::string> activationStrategy;
-  // TODO: Other options
-
-
-  /**
-   * @brief Apply options from @a overrides, but retain other existing options.
-   */
-  void
-  merge( const Options & overrides );
-
-  /** @brief Convert to a _base_ set of @a flox::pkgdb::PkgQueryArgs. */
-  explicit operator pkgdb::PkgQueryArgs() const;
-
-
-}; /* End struct `Options' */
-
-
-/* -------------------------------------------------------------------------- */
-
-/** @brief Convert a JSON object to a @a flox::resolver::Options. */
-void
-from_json( const nlohmann::json & jfrom, Options & opts );
-
-/** @brief Convert a @a flox::resolver::Options to a JSON Object. */
-void
-to_json( nlohmann::json & jto, const Options & opts );
-
-
-/* -------------------------------------------------------------------------- */
-
-/**
- * @brief A _global_ manifest containing only `registry` and `options` fields
- *        in its _raw_ form.
- *
- * This _raw_ struct is defined to generate parsers, and its declarations simply
- * represent what is considered _valid_.
- * On its own, it performs no real work, other than to validate the input.
- *
- * @see flox::resolver::GlobalManifest
- */
-struct GlobalManifestRaw
-{
-  std::optional<RegistryRaw> registry;
-  std::optional<Options>     options;
-
-  virtual ~GlobalManifestRaw()                   = default;
-  GlobalManifestRaw()                            = default;
-  GlobalManifestRaw( const GlobalManifestRaw & ) = default;
-  GlobalManifestRaw( GlobalManifestRaw && )      = default;
-
-  explicit GlobalManifestRaw( std::optional<RegistryRaw> registry,
-                              std::optional<Options> options = std::nullopt )
-    : registry( std::move( registry ) ), options( std::move( options ) )
-  {}
-
-  explicit GlobalManifestRaw( std::optional<Options> options )
-    : options( std::move( options ) )
-  {}
-
-  GlobalManifestRaw &
-  operator=( const GlobalManifestRaw & )
-    = default;
-  GlobalManifestRaw &
-  operator=( GlobalManifestRaw && )
-    = default;
-
-
-  /**
-   * @brief Validate manifest fields, throwing an exception if its contents
-   *        are invalid.
-   */
-  virtual void
-  check() const
-  {}
-
-  virtual void
-  clear()
-  {
-    this->registry = std::nullopt;
-    this->options  = std::nullopt;
-  }
-
-
-}; /* End struct `GlobalManifestRaw' */
-
-
-/* -------------------------------------------------------------------------- */
-
-/** @brief Convert a JSON object to a @a flox::resolver::GlobalManifest. */
-void
-from_json( const nlohmann::json & jfrom, GlobalManifestRaw & manifest );
-
-/** @brief Convert a @a flox::resolver::GlobalManifest to a JSON object. */
-void
-to_json( nlohmann::json & jto, const GlobalManifestRaw & manifest );
-
-
-/* -------------------------------------------------------------------------- */
-
-/**
- * @brief A _raw_ description of an environment to be read from a file.
- *
- * This _raw_ struct is defined to generate parsers, and its declarations simply
- * represent what is considered _valid_.
- * On its own, it performs no real work, other than to validate the input.
- *
- * @see flox::resolver::Manifest
- */
-struct ManifestRaw : public GlobalManifestRaw
-{
-
-  struct EnvBase
-  {
-    std::optional<std::string> floxhub;
-    std::optional<std::string> dir;
-
-    /**
-     * @brief Validate the `env-base` field, throwing an exception if invalid
-     *        information is found.
-     *
-     * This asserts:
-     * - Only one of `floxhub` or `dir` is set.
-     */
-    void
-    check() const;
-
-    void
-    clear()
-    {
-      this->floxhub = std::nullopt;
-      this->dir     = std::nullopt;
-    }
-
-  }; /* End struct `EnvBase' */
-  std::optional<EnvBase> envBase;
-
-  std::optional<
-    std::unordered_map<InstallID, std::optional<ManifestDescriptorRaw>>>
-    install;
-
-  std::optional<std::unordered_map<std::string, std::string>> vars;
-
-  struct Hook
-  {
-    std::optional<std::string> script;
-    std::optional<std::string> file;
-
-    /**
-     * @brief Validate `Hook` fields, throwing an exception if its contents
-     *        are invalid.
-     */
-    void
-    check() const;
-
-  }; /* End struct `ManifestRaw::Hook' */
-  std::optional<Hook> hook;
-
-  ~ManifestRaw() override            = default;
-  ManifestRaw()                      = default;
-  ManifestRaw( const ManifestRaw & ) = default;
-  ManifestRaw( ManifestRaw && )      = default;
-
-  explicit ManifestRaw( const GlobalManifestRaw & globalManifestRaw )
-    : GlobalManifestRaw( globalManifestRaw )
-  {}
-
-  explicit ManifestRaw( GlobalManifestRaw && globalManifestRaw )
-    : GlobalManifestRaw( globalManifestRaw )
-  {}
-
-  ManifestRaw &
-  operator=( const ManifestRaw & )
-    = default;
-
-  ManifestRaw &
-  operator=( ManifestRaw && )
-    = default;
-
-  ManifestRaw &
-  operator=( const GlobalManifestRaw & globalManifestRaw )
-  {
-    GlobalManifestRaw::operator=( globalManifestRaw );
-    return *this;
-  }
-
-  ManifestRaw &
-  operator=( GlobalManifestRaw && globalManifestRaw )
-  {
-    GlobalManifestRaw::operator=( globalManifestRaw );
-    return *this;
-  }
-
-  /**
-   * @brief Validate manifest fields, throwing an exception if its contents
-   *        are invalid.
-   *
-   * This asserts:
-   * - @a envBase is valid.
-   * - @a registry does not contain indirect flake references.
-   * - All members of @a install are valid.
-   * - @a hook is valid.
-   */
-  void
-  check() const override;
-
-  void
-  clear() override
-  {
-    /* From `GlobalManifestRaw' */
-    this->options  = std::nullopt;
-    this->registry = std::nullopt;
-    /* From `ManifestRaw' */
-    this->envBase = std::nullopt;
-    this->install = std::nullopt;
-    this->vars    = std::nullopt;
-    this->hook    = std::nullopt;
-  }
-
-  /**
-   * @brief Generate a JSON _diff_ between @a this manifest an @a old manifest.
-   *
-   * The _diff_ is represented as an [JSON patch](https://jsonpatch.com) object.
-   */
-  nlohmann::json
-  diff( const ManifestRaw & old ) const;
-
-
-}; /* End struct `ManifestRaw' */
-
-
-/* -------------------------------------------------------------------------- */
-
-/** @brief Convert a JSON object to a @a flox::resolver::ManifestRaw. */
-void
-from_json( const nlohmann::json & jfrom, ManifestRaw & manifest );
-
-/** @brief Convert a @a flox::resolver::ManifestRaw to a JSON object. */
-void
-to_json( nlohmann::json & jto, const ManifestRaw & manifest );
-
 
 /* -------------------------------------------------------------------------- */
 

--- a/include/flox/resolver/manifest.hh
+++ b/include/flox/resolver/manifest.hh
@@ -63,6 +63,7 @@ protected:
 
   /* We need these `protected' so they can be set by `Manifest'. */
   // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
+  // TODO: remove `manifestPath'
   std::filesystem::path manifestPath;
   ManifestRaw           manifestRaw;
   RegistryRaw           registryRaw;
@@ -82,6 +83,7 @@ public:
   GlobalManifest( const GlobalManifest & ) = default;
   GlobalManifest( GlobalManifest && )      = default;
 
+  // TODO: remove `manifestPath'
   GlobalManifest( std::filesystem::path manifestPath, GlobalManifestRaw raw )
     : manifestPath( std::move( manifestPath ) ), manifestRaw( std::move( raw ) )
   {
@@ -91,6 +93,11 @@ public:
         this->registryRaw = *this->manifestRaw.registry;
       }
   }
+
+  // TODO: remove `manifestPath'
+  explicit GlobalManifest( GlobalManifestRaw raw )
+    : GlobalManifest( "manifest.json", std::move( raw ) )
+  {}
 
   explicit GlobalManifest( std::filesystem::path manifestPath );
 
@@ -102,7 +109,7 @@ public:
   operator=( GlobalManifest && )
     = default;
 
-
+  // TODO: remove `manifestPath'
   [[nodiscard]] std::filesystem::path
   getManifestPath() const
   {
@@ -196,7 +203,14 @@ public:
   Manifest( const Manifest & ) = default;
   Manifest( Manifest && )      = default;
 
+  // TODO: remove `manifestPath'
   Manifest( std::filesystem::path manifestPath, ManifestRaw raw );
+
+  // TODO: remove `manifestPath'
+  explicit Manifest( ManifestRaw raw )
+    : Manifest( "manifest.json", std::move( raw ) )
+  {}
+
   explicit Manifest( std::filesystem::path manifestPath );
 
 

--- a/include/flox/resolver/manifest.hh
+++ b/include/flox/resolver/manifest.hh
@@ -97,7 +97,7 @@ from_json( const nlohmann::json & jfrom, Options & opts );
 
 /** @brief Convert a @a flox::resolver::Options to a JSON Object. */
 void
-to_json( nlohmann::json & jfrom, const Options & opts );
+to_json( nlohmann::json & jto, const Options & opts );
 
 
 /* -------------------------------------------------------------------------- */
@@ -162,11 +162,11 @@ struct GlobalManifestRaw
 
 /** @brief Convert a JSON object to a @a flox::resolver::GlobalManifest. */
 void
-from_json( const nlohmann::json & jfrom, GlobalManifestRaw & raw );
+from_json( const nlohmann::json & jfrom, GlobalManifestRaw & manifest );
 
 /** @brief Convert a @a flox::resolver::GlobalManifest to a JSON object. */
 void
-to_json( nlohmann::json & jto, const GlobalManifestRaw & raw );
+to_json( nlohmann::json & jto, const GlobalManifestRaw & manifest );
 
 
 /* -------------------------------------------------------------------------- */
@@ -204,6 +204,7 @@ struct ManifestRaw : public GlobalManifestRaw
       this->floxhub = std::nullopt;
       this->dir     = std::nullopt;
     }
+
   }; /* End struct `EnvBase' */
   std::optional<EnvBase> envBase;
 
@@ -224,6 +225,7 @@ struct ManifestRaw : public GlobalManifestRaw
      */
     void
     check() const;
+
   }; /* End struct `ManifestRaw::Hook' */
   std::optional<Hook> hook;
 
@@ -243,6 +245,7 @@ struct ManifestRaw : public GlobalManifestRaw
   ManifestRaw &
   operator=( const ManifestRaw & )
     = default;
+
   ManifestRaw &
   operator=( ManifestRaw && )
     = default;
@@ -253,6 +256,7 @@ struct ManifestRaw : public GlobalManifestRaw
     GlobalManifestRaw::operator=( globalManifestRaw );
     return *this;
   }
+
   ManifestRaw &
   operator=( GlobalManifestRaw && globalManifestRaw )
   {

--- a/include/flox/resolver/mixins.hh
+++ b/include/flox/resolver/mixins.hh
@@ -313,6 +313,15 @@ public:
   argparse::Argument &
   addLockfileOption( argparse::ArgumentParser & parser );
 
+  /**
+   * @brief Uses a `--dir PATH` to locate `manifest.{toml,yaml,json}' file and
+   *        `manifest.lock` if it is present.`.
+   * @param parser The parser to add the argument to.
+   * @return The argument added to the parser.
+   */
+  argparse::Argument &
+  addFloxDirectoryOption( argparse::ArgumentParser & parser );
+
 
 }; /* End class `EnvironmentMixin' */
 

--- a/include/flox/resolver/mixins.hh
+++ b/include/flox/resolver/mixins.hh
@@ -279,6 +279,15 @@ public:
   addGlobalManifestFileOption( argparse::ArgumentParser & parser );
 
   /**
+   * @brief Hard codes a manifest with only `github:NixOS/nixpkgs/release-23.05`
+   * with `--ga-manifest`.
+   * @param parser The parser to add the argument to.
+   * @return The argument added to the parser.
+   */
+  argparse::Argument &
+  addGAManifestOption( argparse::ArgumentParser & parser );
+
+  /**
    * @brief Sets the path to the manifest file to load with `--manifest`.
    * @param parser The parser to add the argument to.
    * @param required Whether the argument is required.

--- a/include/flox/resolver/mixins.hh
+++ b/include/flox/resolver/mixins.hh
@@ -174,6 +174,10 @@ protected:
 
 public:
 
+  /** @brief Get the filesystem path to the global manifest ( if any ). */
+  [[nodiscard]] const std::optional<std::filesystem::path> &
+  getGlobalManifestPath() const;
+
   /**
    * @brief Lazily initialize and return the @a globalManifest.
    *
@@ -184,6 +188,10 @@ public:
   [[nodiscard]] const std::optional<GlobalManifest> &
   getGlobalManifest();
 
+  /** @brief Get the filesystem path to the manifest ( if any ). */
+  [[nodiscard]] const std::optional<std::filesystem::path> &
+  getManifestPath() const;
+
   /**
    * @brief Lazily initialize and return the @a manifest.
    *
@@ -193,6 +201,10 @@ public:
    */
   [[nodiscard]] const Manifest &
   getManifest();
+
+  /** @brief Get the filesystem path to the lockfile ( if any ). */
+  [[nodiscard]] const std::optional<std::filesystem::path> &
+  getLockfilePath() const;
 
   /**
    * @brief Lazily initialize and return the @a lockfile.

--- a/include/flox/resolver/mixins.hh
+++ b/include/flox/resolver/mixins.hh
@@ -117,6 +117,19 @@ protected:
    * private member variables.
    */
   void
+  initGlobalManifest( GlobalManifestRaw manifestRaw );
+
+  /**
+   * @brief Initialize the @a globalManifest member variable.
+   *
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
+   */
+  void
   initGlobalManifest( GlobalManifest manifest );
 
   /**
@@ -143,6 +156,19 @@ protected:
    * private member variables.
    */
   void
+  initManifest( ManifestRaw manifestRaw );
+
+  /**
+   * @brief Initialize the @a manifest member variable.
+   *
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
+   */
+  void
   initManifest( Manifest manifest );
 
   /**
@@ -157,6 +183,19 @@ protected:
    */
   void
   initLockfilePath( std::filesystem::path path );
+
+  /**
+   * @brief Initialize the @a lockfile member variable.
+   *
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
+   */
+  void
+  initLockfile( LockfileRaw lockfileRaw );
 
   /**
    * @brief Initialize the @a lockfile member variable.

--- a/include/flox/resolver/mixins.hh
+++ b/include/flox/resolver/mixins.hh
@@ -1,0 +1,269 @@
+/* ========================================================================== *
+ *
+ * @file flox/resolver/mixins.hh
+ *
+ * @brief State blobs for flox commands.
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string_view>
+
+#include "flox/core/exceptions.hh"
+#include "flox/resolver/environment.hh"
+#include "flox/resolver/lockfile.hh"
+#include "flox/resolver/manifest.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+/* Forward Declarations */
+
+namespace argparse {
+
+class Argument;
+class ArgumentParser;
+
+}  // namespace argparse
+
+
+/* -------------------------------------------------------------------------- */
+
+namespace flox::resolver {
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @a class flox::resolver::EnvironmentMixinException
+ * @brief An exception thrown by @a flox::resolver::EnvironmentMixin during
+ *        its initialization.
+ * @{
+ */
+FLOX_DEFINE_EXCEPTION( EnvironmentMixinException,
+                       EC_ENVIRONMENT_MIXIN,
+                       "EnvironmentMixin" )
+/** @} */
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief A state blob with files associated with an environment.
+ *
+ * This structure stashes several fields to avoid repeatedly calculating them.
+ */
+class EnvironmentMixin
+{
+
+private:
+
+  /* All member variables are calculated lazily using `std::optional' and
+   * `get<MEMBER>' accessors.
+   * Even for internal access you should use the `get<MEMBER>' accessors to
+   * lazily initialize. */
+
+  /** Path to user level manifest ( if any ). */
+  std::optional<std::filesystem::path> globalManifestPath;
+  /**
+   * Contents of user level manifest with global registry and settings
+   * ( if any ).
+   */
+  std::optional<GlobalManifest> globalManifest;
+
+  /** Path to project level manifest. ( required ) */
+  std::optional<std::filesystem::path> manifestPath;
+  /**
+   * Contents of project level manifest with registry, settings,
+   * activation hook, and list of packages. ( required )
+   */
+  std::optional<Manifest> manifest;
+
+  /** Path to project's lockfile ( if any ). */
+  std::optional<std::filesystem::path> lockfilePath;
+  /** Contents of project's lockfile ( if any ). */
+  std::optional<Lockfile> lockfile;
+
+  /** Lazily initialized environment wrapper. */
+  std::optional<Environment> environment;
+
+
+protected:
+
+  /**
+   * @brief Initialize the @a globalManifestPath member variable.
+   *
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
+   */
+  void
+  initGlobalManifestPath( std::filesystem::path path );
+
+  /**
+   * @brief Initialize the @a globalManifest member variable.
+   *
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
+   */
+  void
+  initGlobalManifest( GlobalManifest manifest );
+
+  /**
+   * @brief Initialize the @a manifestPath member variable.
+   *
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
+   */
+  void
+  initManifestPath( std::filesystem::path path );
+
+  /**
+   * @brief Initialize the @a manifest member variable.
+   *
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
+   */
+  void
+  initManifest( Manifest manifest );
+
+  /**
+   * @brief Initialize the @a lockfilePath member variable.
+   *
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
+   */
+  void
+  initLockfilePath( std::filesystem::path path );
+
+  /**
+   * @brief Initialize the @a lockfile member variable.
+   *
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
+   */
+  void
+  initLockfile( Lockfile lockfile );
+
+
+public:
+
+  /**
+   * @brief Lazily initialize and return the @a globalManifest.
+   *
+   * If @a globalManifest is set simply return it.
+   * If @a globalManifest is unset, but @a globalManifestPath is set then
+   * load from the file.
+   */
+  [[nodiscard]] const std::optional<GlobalManifest> &
+  getGlobalManifest();
+
+  /**
+   * @brief Lazily initialize and return the @a manifest.
+   *
+   * If @a manifest is set simply return it.
+   * If @a manifest is unset, but @a manifestPath is set then
+   * load from the file.
+   */
+  [[nodiscard]] const Manifest &
+  getManifest();
+
+  /**
+   * @brief Lazily initialize and return the @a lockfile.
+   *
+   * If @a lockfile is set simply return it.
+   * If @a lockfile is unset, but @a lockfilePath is set then
+   * load from the file.
+   */
+  [[nodiscard]] const std::optional<Lockfile> &
+  getLockfile();
+
+  /**
+   * @brief Laziliy initialize and return the @a environment.
+   *
+   * The member variable @a manifest or @a manifestPath must be set for
+   * initialization to succeed.
+   * Member variables associated with the _global manifest_ and _lockfile_
+   * are optional.
+   *
+   * After @a getEnvironment() has been called once, it is no longer possible
+   * to use any `init*( MEMBER )` functions.
+   */
+  [[nodiscard]] Environment &
+  getEnvironment();
+
+  /**
+   * @brief Sets the path to the global manifest file to load
+   *        with `--global-manifest`.
+   * @param parser The parser to add the argument to.
+   * @return The argument added to the parser.
+   */
+  argparse::Argument &
+  addGlobalManifestFileOption( argparse::ArgumentParser & parser );
+
+  /**
+   * @brief Sets the path to the manifest file to load with `--manifest`.
+   * @param parser The parser to add the argument to.
+   * @param required Whether the argument is required.
+   * @return The argument added to the parser.
+   */
+  argparse::Argument &
+  addManifestFileOption( argparse::ArgumentParser & parser );
+
+  /**
+   * @brief Sets the path to the manifest file to load with a positional arg.
+   * @param parser The parser to add the argument to.
+   * @param required Whether the argument is required.
+   * @return The argument added to the parser.
+   */
+  argparse::Argument &
+  addManifestFileArg( argparse::ArgumentParser & parser, bool required = true );
+
+  /**
+   * @brief Sets the path to the old lockfile to load with `--lockfile`.
+   * @param parser The parser to add the argument to.
+   * @return The argument added to the parser.
+   */
+  argparse::Argument &
+  addLockfileOption( argparse::ArgumentParser & parser );
+
+
+}; /* End class `EnvironmentMixin' */
+
+
+/* -------------------------------------------------------------------------- */
+
+}  // namespace flox::resolver
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/include/flox/search/command.hh
+++ b/include/flox/search/command.hh
@@ -42,7 +42,7 @@ private:
    *        `--version VERSION` to be used in setting search parameters.
    */
   void
-  addSearchQueryFlags( argparse::ArgumentParser & parser );
+  addSearchQueryOptions( argparse::ArgumentParser & parser );
 
   /**
    * @brief Add argument to any parser to construct

--- a/include/flox/search/command.hh
+++ b/include/flox/search/command.hh
@@ -18,6 +18,7 @@
 #include "flox/pkgdb/write.hh"
 #include "flox/registry.hh"
 #include "flox/search/params.hh"
+#include "flox/resolver/mixins.hh"
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/flox/search/command.hh
+++ b/include/flox/search/command.hh
@@ -17,8 +17,8 @@
 #include "flox/pkgdb/input.hh"
 #include "flox/pkgdb/write.hh"
 #include "flox/registry.hh"
-#include "flox/search/params.hh"
 #include "flox/resolver/mixins.hh"
+#include "flox/search/params.hh"
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/flox/search/command.hh
+++ b/include/flox/search/command.hh
@@ -38,6 +38,13 @@ private:
   SearchParams           params; /**< Query arguments processor. */
 
   /**
+   * @brief Add options to allow flags such as `--pname PNAME` and
+   *        `--version VERSION` to be used in setting search parameters.
+   */
+  void
+  addSearchQueryFlags( argparse::ArgumentParser & parser );
+
+  /**
    * @brief Add argument to any parser to construct
    *        a @a flox::search::SearchParams.
    */

--- a/include/flox/search/params.hh
+++ b/include/flox/search/params.hh
@@ -122,7 +122,8 @@ struct SearchParams
    * @brief The absolute @a std::filesystem::path to a manifest file or an
    *        inline @a flox::resolver::ManifestRaw.
    */
-  std::variant<std::filesystem::path, resolver::ManifestRaw> manifest;
+  std::optional<std::variant<std::filesystem::path, resolver::ManifestRaw>>
+  manifest;
 
   /**
    * @brief The absolute @a std::filesystem::path to a lockfile or an inline
@@ -139,38 +140,8 @@ struct SearchParams
 
 
   /**
-   * @brief If `lockfile` is unset, returns `std::nullopt`.
-   *        Otherwise returns the path to the lockfile or a phony path if the
-   *        lockfile was inlined.
-   */
-  [[nodiscard]] std::optional<std::filesystem::path>
-  getLockfilePath();
-
-  /**
-   * @brief Returns a @a flox::resolver::LockfileRaw or lazily
-   *        loads it from disk ( if provided ).
-   */
-  [[nodiscard]] std::optional<flox::resolver::LockfileRaw>
-  getLockfileRaw();
-
-  /**
-   * @brief Returns the path to the manifest or a phony path if the
-   *        manifest was inlined.
-   */
-  [[nodiscard]] std::filesystem::path
-  getManifestPath();
-
-  /**
-   * @brief Returns a @a flox::resolver::ManifestRaw or lazily
-   *        loads it from disk.
-   */
-  [[nodiscard]] flox::resolver::ManifestRaw
-  getManifestRaw();
-
-  /**
-   * @brief If `global-manifest` is unset, returns `std::nullopt`.
-   *        Otherwise returns the path to the global manifest or a phony path if
-   *        the manifest was inlined.
+   * @brief If `global-manifest` is inlined or unset, returns `std::nullopt`.
+   *        Otherwise returns the path to the global manifest.
    */
   [[nodiscard]] std::optional<std::filesystem::path>
   getGlobalManifestPath();
@@ -181,6 +152,35 @@ struct SearchParams
    */
   [[nodiscard]] std::optional<flox::resolver::GlobalManifestRaw>
   getGlobalManifestRaw();
+
+  /**
+   * @brief If `manifest` is inlined or unset, returns `std::nullopt`.
+   *        Otherwise returns the path to the manifest.
+   */
+  [[nodiscard]] std::optional<std::filesystem::path>
+  getManifestPath();
+
+  /**
+   * @brief Returns a @a flox::resolver::ManifestRaw or lazily
+   *        loads it from disk.
+   *        If @a manifestPath is unset, this returns an empty manifest.
+   */
+  [[nodiscard]] flox::resolver::ManifestRaw
+  getManifestRaw();
+
+  /**
+   * @brief If `lockfile` is inlined or unset, returns `std::nullopt`.
+   *        Otherwise returns the path to the lockfile.
+   */
+  [[nodiscard]] std::optional<std::filesystem::path>
+  getLockfilePath();
+
+  /**
+   * @brief Returns a @a flox::resolver::LockfileRaw or lazily
+   *        loads it from disk ( if provided ).
+   */
+  [[nodiscard]] std::optional<flox::resolver::LockfileRaw>
+  getLockfileRaw();
 
 
 }; /* End struct `SearchParams' */

--- a/include/flox/search/params.hh
+++ b/include/flox/search/params.hh
@@ -123,7 +123,7 @@ struct SearchParams
    *        inline @a flox::resolver::ManifestRaw.
    */
   std::optional<std::variant<std::filesystem::path, resolver::ManifestRaw>>
-  manifest;
+    manifest;
 
   /**
    * @brief The absolute @a std::filesystem::path to a lockfile or an inline

--- a/src/command.cc
+++ b/src/command.cc
@@ -35,7 +35,7 @@ VerboseParser::VerboseParser( const std::string & name,
   : argparse::ArgumentParser( name, version, argparse::default_arguments::help )
 {
   this->add_argument( "-q", "--quiet" )
-    .help( "Decrease the logging verbosity level. May be used up to 3 times." )
+    .help( "decrease the logging verbosity level. May be used up to 3 times." )
     .action(
       [&]( const auto & )
       {
@@ -48,7 +48,7 @@ VerboseParser::VerboseParser( const std::string & name,
     .append();
 
   this->add_argument( "-v", "--verbose" )
-    .help( "Increase the logging verbosity level. May be used up to 4 times." )
+    .help( "increase the logging verbosity level. May be used up to 4 times." )
     .action(
       [&]( const auto & )
       {
@@ -80,7 +80,7 @@ argparse::Argument &
 InlineInputMixin::addSubtreeArg( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--subtree" )
-    .help( "A subtree name, being one of `packages` or `legacyPackages`, "
+    .help( "a subtree name, being one of `packages` or `legacyPackages`, "
            "that should be processed. May be used multiple times." )
     .required()
     .metavar( "SUBTREE" )
@@ -115,7 +115,7 @@ argparse::Argument &
 AttrPathMixin::addAttrPathArgs( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "attr-path" )
-    .help( "Attribute path to scrape" )
+    .help( "attribute path to scrape" )
     .metavar( "ATTRS..." )
     .remaining()
     .action( [&]( const std::string & path )

--- a/src/main.cc
+++ b/src/main.cc
@@ -84,8 +84,6 @@ int
 main( int argc, char * argv[] )
 {
 
-  return run( argc, argv );
-
   try
     {
       return run( argc, argv );

--- a/src/main.cc
+++ b/src/main.cc
@@ -83,6 +83,9 @@ run( int argc, char * argv[] )
 int
 main( int argc, char * argv[] )
 {
+
+  return run( argc, argv );
+
   try
     {
       return run( argc, argv );

--- a/src/pkgdb/command.cc
+++ b/src/pkgdb/command.cc
@@ -49,7 +49,7 @@ argparse::Argument &
 DbPathMixin::addDatabasePathOption( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "-d", "--database" )
-    .help( "Use database at PATH" )
+    .help( "use database at PATH" )
     .metavar( "PATH" )
     .nargs( 1 )
     .action(
@@ -149,7 +149,7 @@ argparse::Argument &
 PkgDbMixin<T>::addTargetArg( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "target" )
-    .help( "The source ( database path or flake-ref ) to read" )
+    .help( "the source ( database path or flake-ref ) to read" )
     .required()
     .metavar( "<DB-PATH|FLAKE-REF>" )
     .action(

--- a/src/pkgdb/get.cc
+++ b/src/pkgdb/get.cc
@@ -33,7 +33,7 @@ GetCommand::GetCommand()
 
   this->pId.add_description( "Lookup an attribute set or package row `id`" );
   this->pId.add_argument( "-p", "--pkg" )
-    .help( "Lookup package path" )
+    .help( "lookup package path" )
     .nargs( 0 )
     .action( [&]( const auto & ) { this->isPkg = true; } );
   this->addTargetArg( this->pId );
@@ -49,12 +49,12 @@ GetCommand::GetCommand()
   this->pPath.add_description(
     "Lookup an (AttrSets|Packages).id attribute path" );
   this->pPath.add_argument( "-p", "--pkg" )
-    .help( "Lookup `Packages.id'" )
+    .help( "lookup `Packages.id'" )
     .nargs( 0 )
     .action( [&]( const auto & ) { this->isPkg = true; } );
   this->addTargetArg( this->pPath );
   this->pPath.add_argument( "id" )
-    .help( "Row `id' to lookup" )
+    .help( "row `id' to lookup" )
     .nargs( 1 )
     .action( [&]( const std::string & rowId )
              { this->id = std::stoull( rowId ); } );
@@ -73,7 +73,7 @@ GetCommand::GetCommand()
   /* In `runPkg' we check for a singleton and if it's an integer it
    * is interpreted as a row id. */
   this->pPkg.add_argument( "id-or-path" )
-    .help( "Attribute path to package, or `Packages.id`" )
+    .help( "attribute path to package, or `Packages.id`" )
     .metavar( "<ID|ATTRS...>" )
     .remaining()
     .action( [&]( const std::string & idOrPath )

--- a/src/pkgdb/list.cc
+++ b/src/pkgdb/list.cc
@@ -25,19 +25,19 @@ ListCommand::ListCommand() : parser( "list" )
   this->parser.add_description( "Summarize available Package DBs" );
 
   this->parser.add_argument( "-c", "--cachedir" )
-    .help( "Summarize databases in a given directory" )
+    .help( "summarize databases in a given directory" )
     .metavar( "PATH" )
     .nargs( 1 )
     .action( [&]( const std::string & cacheDir )
              { this->cacheDir = nix::absPath( cacheDir ); } );
 
   this->parser.add_argument( "-j", "--json" )
-    .help( "Output as JSON" )
+    .help( "output as JSON" )
     .nargs( 0 )
     .action( [&]( const std::string & ) { this->json = true; } );
 
   this->parser.add_argument( "-b", "--basenames" )
-    .help( "Print basenames of databases instead of absolute paths" )
+    .help( "print basenames of databases instead of absolute paths" )
     .nargs( 0 )
     .action( [&]( const std::string & ) { this->basenames = true; } );
 }

--- a/src/pkgdb/scrape.cc
+++ b/src/pkgdb/scrape.cc
@@ -24,7 +24,7 @@ ScrapeCommand::ScrapeCommand() : parser( "scrape" )
 {
   this->parser.add_description( "Scrape a flake and emit a SQLite3 DB" );
   this->parser.add_argument( "-f", "--force" )
-    .help( "Force re-evaluation of flake" )
+    .help( "force re-evaluation of flake" )
     .nargs( 0 )
     .action( [&]( const auto & ) { this->force = true; } );
   this->addDatabasePathOption( this->parser );

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -7,24 +7,30 @@
  *
  * -------------------------------------------------------------------------- */
 
-
 #include <algorithm>
 #include <assert.h>
-#include <map>
+#include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
-#include <variant>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
-#include <argparse/argparse.hpp>
 #include <nix/flake/flakeref.hh>
 #include <nix/ref.hh>
-#include <nix/util.hh>
 #include <nlohmann/json.hpp>
 
+#include "flox/core/types.hh"
+#include "flox/pkgdb/input.hh"
+#include "flox/pkgdb/pkg-query.hh"
 #include "flox/pkgdb/read.hh"
+#include "flox/registry.hh"
 #include "flox/resolver/descriptor.hh"
 #include "flox/resolver/environment.hh"
 #include "flox/resolver/lockfile.hh"
+#include "flox/resolver/manifest-raw.hh"
+#include "flox/resolver/manifest.hh"
 
 
 /* -------------------------------------------------------------------------- */
@@ -469,192 +475,6 @@ Environment::createLockfile()
         }
     }
   return Lockfile( *this->lockfileRaw );
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-const std::optional<GlobalManifest> &
-EnvironmentMixin::getGlobalManifest()
-{
-  if ( ( ! this->globalManifest.has_value() )
-       && this->globalManifestPath.has_value() )
-    {
-      this->globalManifest = GlobalManifest( *this->globalManifestPath );
-    }
-  return this->globalManifest;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-const Manifest &
-EnvironmentMixin::getManifest()
-{
-  if ( ! this->manifest.has_value() )
-    {
-      if ( ! this->manifestPath.has_value() )
-        {
-          throw InvalidManifestFileException(
-            "you must provide the path to a manifest file" );
-        }
-      this->manifest = Manifest( *this->manifestPath );
-    }
-  return *this->manifest;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-const std::optional<Lockfile> &
-EnvironmentMixin::getLockfile()
-{
-  if ( ( ! this->lockfile.has_value() ) && this->lockfilePath.has_value() )
-    {
-      this->lockfile = Lockfile( *this->lockfilePath );
-    }
-  return this->lockfile;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-Environment &
-EnvironmentMixin::getEnvironment()
-{
-  if ( ! this->environment.has_value() )
-    {
-      this->environment = Environment( this->getGlobalManifest(),
-                                       this->getManifest(),
-                                       this->getLockfile() );
-    }
-  return *this->environment;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-argparse::Argument &
-EnvironmentMixin::addGlobalManifestFileOption(
-  argparse::ArgumentParser & parser )
-{
-  return parser.add_argument( "--global-manifest" )
-    .help( "The path to the user's global `manifest.{toml,yaml,json}' file." )
-    .metavar( "PATH" )
-    .action( [&]( const std::string & strPath )
-             { this->initGlobalManifestPath( nix::absPath( strPath ) ); } );
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-argparse::Argument &
-EnvironmentMixin::addManifestFileOption( argparse::ArgumentParser & parser )
-{
-  return parser.add_argument( "--manifest" )
-    .help( "The path to the `manifest.{toml,yaml,json}' file." )
-    .metavar( "PATH" )
-    .action( [&]( const std::string & strPath )
-             { this->initManifestPath( nix::absPath( strPath ) ); } );
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-argparse::Argument &
-EnvironmentMixin::addManifestFileArg( argparse::ArgumentParser & parser,
-                                      bool                       required )
-{
-  argparse::Argument & arg
-    = parser.add_argument( "manifest" )
-        .help( "The path to the project's `manifest.{toml,yaml,json}' file." )
-        .metavar( "MANIFEST-PATH" )
-        .action( [&]( const std::string & strPath )
-                 { this->initManifestPath( nix::absPath( strPath ) ); } );
-  return required ? arg.required() : arg;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-argparse::Argument &
-EnvironmentMixin::addLockfileOption( argparse::ArgumentParser & parser )
-{
-  return parser.add_argument( "--lockfile" )
-    .help( "The path to the projects existing `manifest.lock' file." )
-    .metavar( "PATH" )
-    .action( [&]( const std::string & strPath )
-             { this->initLockfilePath( nix::absPath( strPath ) ); } );
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-/**
- * @brief Generate exception handling boilerplate for
- *        `EnvironmentMixin::init<MEMBER>' functions.
- */
-#define ENV_MIXIN_THROW_IF_SET( member )                               \
-  if ( this->member.has_value() )                                      \
-    {                                                                  \
-      throw EnvironmentMixinException( "`" #member                     \
-                                       "' was already initializaed" ); \
-    }                                                                  \
-  if ( this->environment.has_value() )                                 \
-    {                                                                  \
-      throw EnvironmentMixinException(                                 \
-        "`" #member "' cannot be initializaed after `environment'" );  \
-    }
-
-
-/* -------------------------------------------------------------------------- */
-
-void
-EnvironmentMixin::initGlobalManifestPath( std::filesystem::path path )
-{
-  ENV_MIXIN_THROW_IF_SET( globalManifestPath )
-  this->globalManifestPath = std::move( path );
-}
-
-void
-EnvironmentMixin::initGlobalManifest( GlobalManifest manifest )
-{
-  ENV_MIXIN_THROW_IF_SET( globalManifest )
-  this->globalManifest = std::move( manifest );
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-void
-EnvironmentMixin::initManifestPath( std::filesystem::path path )
-{
-  ENV_MIXIN_THROW_IF_SET( manifestPath )
-  this->manifestPath = std::move( path );
-}
-
-void
-EnvironmentMixin::initManifest( Manifest manifest )
-{
-  ENV_MIXIN_THROW_IF_SET( manifest )
-  this->manifest = std::move( manifest );
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-void
-EnvironmentMixin::initLockfilePath( std::filesystem::path path )
-{
-  ENV_MIXIN_THROW_IF_SET( lockfilePath )
-  this->lockfilePath = std::move( path );
-}
-
-void
-EnvironmentMixin::initLockfile( Lockfile lockfile )
-{
-  ENV_MIXIN_THROW_IF_SET( lockfile )
-  this->lockfile = std::move( lockfile );
 }
 
 

--- a/src/resolver/manifest-raw.cc
+++ b/src/resolver/manifest-raw.cc
@@ -9,9 +9,26 @@
  *
  * -------------------------------------------------------------------------- */
 
-#include <fstream>
+#include <algorithm>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
-#include "flox/resolver/manifest.hh"
+#include <nix/fetchers.hh>
+#include <nix/flake/flakeref.hh>
+#include <nix/ref.hh>
+#include <nlohmann/json.hpp>
+
+#include "flox/core/types.hh"
+#include "flox/core/util.hh"
+#include "flox/pkgdb/pkg-query.hh"
+#include "flox/registry.hh"
+#include "flox/resolver/descriptor.hh"
+#include "flox/resolver/manifest-raw.hh"
 
 
 /* -------------------------------------------------------------------------- */

--- a/src/resolver/manifest-raw.cc
+++ b/src/resolver/manifest-raw.cc
@@ -615,7 +615,10 @@ ManifestRaw::check() const
   if ( this->envBase.has_value() ) { this->envBase->check(); }
   if ( this->install.has_value() )
     {
-      for ( const auto & [iid, desc] : *this->install ) { desc->check( iid ); }
+      for ( const auto & [iid, desc] : *this->install )
+        {
+          if ( desc.has_value() ) { desc->check( iid ); }
+        }
     }
   if ( this->hook.has_value() ) { this->hook->check(); }
   if ( this->registry.has_value() )

--- a/src/resolver/manifest.cc
+++ b/src/resolver/manifest.cc
@@ -7,11 +7,21 @@
  *
  * -------------------------------------------------------------------------- */
 
+#include <algorithm>
 #include <filesystem>
 #include <optional>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
-#include "compat/concepts.hh"
+#include "flox/core/types.hh"
 #include "flox/core/util.hh"
+#include "flox/pkgdb/pkg-query.hh"
+#include "flox/registry.hh"
+#include "flox/resolver/descriptor.hh"
+#include "flox/resolver/manifest-raw.hh"
 #include "flox/resolver/manifest.hh"
 
 

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -214,7 +214,7 @@ EnvironmentMixin::addGlobalManifestFileOption(
   argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--global-manifest" )
-    .help( "The path to the user's global `manifest.{toml,yaml,json}' file." )
+    .help( "the path to the user's global `manifest.{toml,yaml,json}' file." )
     .metavar( "PATH" )
     .action( [&]( const std::string & strPath )
              { this->initGlobalManifestPath( nix::absPath( strPath ) ); } );
@@ -227,7 +227,7 @@ argparse::Argument &
 EnvironmentMixin::addGAManifestOption( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--ga-manifest" )
-    .help( "Use a hard coded global manifest ( for `flox' GA )." )
+    .help( "use a hard coded global manifest ( for `flox' GA )." )
     .nargs( 0 )
     .action(
       [&]( const auto & )
@@ -259,7 +259,7 @@ argparse::Argument &
 EnvironmentMixin::addManifestFileOption( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--manifest" )
-    .help( "The path to the `manifest.{toml,yaml,json}' file." )
+    .help( "the path to the `manifest.{toml,yaml,json}' file." )
     .metavar( "PATH" )
     .action( [&]( const std::string & strPath )
              { this->initManifestPath( nix::absPath( strPath ) ); } );
@@ -274,7 +274,7 @@ EnvironmentMixin::addManifestFileArg( argparse::ArgumentParser & parser,
 {
   argparse::Argument & arg
     = parser.add_argument( "manifest" )
-        .help( "The path to the project's `manifest.{toml,yaml,json}' file." )
+        .help( "the path to the project's `manifest.{toml,yaml,json}' file." )
         .metavar( "MANIFEST-PATH" )
         .action( [&]( const std::string & strPath )
                  { this->initManifestPath( nix::absPath( strPath ) ); } );
@@ -288,7 +288,7 @@ argparse::Argument &
 EnvironmentMixin::addLockfileOption( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--lockfile" )
-    .help( "The path to the projects existing `manifest.lock' file." )
+    .help( "the path to the projects existing `manifest.lock' file." )
     .metavar( "PATH" )
     .action( [&]( const std::string & strPath )
              { this->initLockfilePath( nix::absPath( strPath ) ); } );
@@ -301,7 +301,7 @@ argparse::Argument &
 EnvironmentMixin::addFloxDirectoryOption( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--dir", "-d" )
-    .help( "The directory to search for `manifest.{json,yaml,toml}' and "
+    .help( "the directory to search for `manifest.{json,yaml,toml}' and "
            "`manifest.lock`." )
     .metavar( "PATH" )
     .nargs( 1 )

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -30,6 +30,15 @@ namespace flox::resolver {
 
 /* -------------------------------------------------------------------------- */
 
+const std::optional<std::filesystem::path> &
+EnvironmentMixin::getGlobalManifestPath() const
+{
+  return this->globalManifestPath;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 const std::optional<GlobalManifest> &
 EnvironmentMixin::getGlobalManifest()
 {
@@ -44,6 +53,15 @@ EnvironmentMixin::getGlobalManifest()
 
 /* -------------------------------------------------------------------------- */
 
+const std::optional<std::filesystem::path> &
+EnvironmentMixin::getManifestPath() const
+{
+  return this->manifestPath;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 const Manifest &
 EnvironmentMixin::getManifest()
 {
@@ -51,12 +69,22 @@ EnvironmentMixin::getManifest()
     {
       if ( ! this->manifestPath.has_value() )
         {
-          throw InvalidManifestFileException(
-            "you must provide the path to a manifest file" );
+          throw EnvironmentMixinException(
+            "you must provide an inline manifest or the path to a manifest "
+            "file" );
         }
       this->manifest = Manifest( *this->manifestPath );
     }
   return *this->manifest;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+const std::optional<std::filesystem::path> &
+EnvironmentMixin::getLockfilePath() const
+{
+  return this->manifestPath;
 }
 
 

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -201,6 +201,13 @@ EnvironmentMixin::initGlobalManifestPath( std::filesystem::path path )
 }
 
 void
+EnvironmentMixin::initGlobalManifest( GlobalManifestRaw manifestRaw )
+{
+  ENV_MIXIN_THROW_IF_SET( globalManifest )
+  this->globalManifest = GlobalManifest( std::move( manifestRaw ) );
+}
+
+void
 EnvironmentMixin::initGlobalManifest( GlobalManifest manifest )
 {
   ENV_MIXIN_THROW_IF_SET( globalManifest )
@@ -218,6 +225,13 @@ EnvironmentMixin::initManifestPath( std::filesystem::path path )
 }
 
 void
+EnvironmentMixin::initManifest( ManifestRaw manifestRaw )
+{
+  ENV_MIXIN_THROW_IF_SET( manifest )
+  this->manifest = Manifest( std::move( manifestRaw ) );
+}
+
+void
 EnvironmentMixin::initManifest( Manifest manifest )
 {
   ENV_MIXIN_THROW_IF_SET( manifest )
@@ -232,6 +246,13 @@ EnvironmentMixin::initLockfilePath( std::filesystem::path path )
 {
   ENV_MIXIN_THROW_IF_SET( lockfilePath )
   this->lockfilePath = std::move( path );
+}
+
+void
+EnvironmentMixin::initLockfile( LockfileRaw lockfileRaw )
+{
+  ENV_MIXIN_THROW_IF_SET( lockfile );
+  this->lockfile = Lockfile( std::move( lockfileRaw ) );
 }
 
 void

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -1,0 +1,226 @@
+/* ========================================================================== *
+ *
+ * @file resolver/mixins.cc
+ *
+ * @brief State blobs for flox commands.
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+
+#include <argparse/argparse.hpp>
+#include <nix/util.hh>
+
+#include "flox/resolver/environment.hh"
+#include "flox/resolver/lockfile.hh"
+#include "flox/resolver/manifest-raw.hh"
+#include "flox/resolver/manifest.hh"
+#include "flox/resolver/mixins.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+namespace flox::resolver {
+
+/* -------------------------------------------------------------------------- */
+
+const std::optional<GlobalManifest> &
+EnvironmentMixin::getGlobalManifest()
+{
+  if ( ( ! this->globalManifest.has_value() )
+       && this->globalManifestPath.has_value() )
+    {
+      this->globalManifest = GlobalManifest( *this->globalManifestPath );
+    }
+  return this->globalManifest;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+const Manifest &
+EnvironmentMixin::getManifest()
+{
+  if ( ! this->manifest.has_value() )
+    {
+      if ( ! this->manifestPath.has_value() )
+        {
+          throw InvalidManifestFileException(
+            "you must provide the path to a manifest file" );
+        }
+      this->manifest = Manifest( *this->manifestPath );
+    }
+  return *this->manifest;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+const std::optional<Lockfile> &
+EnvironmentMixin::getLockfile()
+{
+  if ( ( ! this->lockfile.has_value() ) && this->lockfilePath.has_value() )
+    {
+      this->lockfile = Lockfile( *this->lockfilePath );
+    }
+  return this->lockfile;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+Environment &
+EnvironmentMixin::getEnvironment()
+{
+  if ( ! this->environment.has_value() )
+    {
+      this->environment = Environment( this->getGlobalManifest(),
+                                       this->getManifest(),
+                                       this->getLockfile() );
+    }
+  return *this->environment;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+argparse::Argument &
+EnvironmentMixin::addGlobalManifestFileOption(
+  argparse::ArgumentParser & parser )
+{
+  return parser.add_argument( "--global-manifest" )
+    .help( "The path to the user's global `manifest.{toml,yaml,json}' file." )
+    .metavar( "PATH" )
+    .action( [&]( const std::string & strPath )
+             { this->initGlobalManifestPath( nix::absPath( strPath ) ); } );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+argparse::Argument &
+EnvironmentMixin::addManifestFileOption( argparse::ArgumentParser & parser )
+{
+  return parser.add_argument( "--manifest" )
+    .help( "The path to the `manifest.{toml,yaml,json}' file." )
+    .metavar( "PATH" )
+    .action( [&]( const std::string & strPath )
+             { this->initManifestPath( nix::absPath( strPath ) ); } );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+argparse::Argument &
+EnvironmentMixin::addManifestFileArg( argparse::ArgumentParser & parser,
+                                      bool                       required )
+{
+  argparse::Argument & arg
+    = parser.add_argument( "manifest" )
+        .help( "The path to the project's `manifest.{toml,yaml,json}' file." )
+        .metavar( "MANIFEST-PATH" )
+        .action( [&]( const std::string & strPath )
+                 { this->initManifestPath( nix::absPath( strPath ) ); } );
+  return required ? arg.required() : arg;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+argparse::Argument &
+EnvironmentMixin::addLockfileOption( argparse::ArgumentParser & parser )
+{
+  return parser.add_argument( "--lockfile" )
+    .help( "The path to the projects existing `manifest.lock' file." )
+    .metavar( "PATH" )
+    .action( [&]( const std::string & strPath )
+             { this->initLockfilePath( nix::absPath( strPath ) ); } );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Generate exception handling boilerplate for
+ *        `EnvironmentMixin::init<MEMBER>' functions.
+ */
+#define ENV_MIXIN_THROW_IF_SET( member )                               \
+  if ( this->member.has_value() )                                      \
+    {                                                                  \
+      throw EnvironmentMixinException( "`" #member                     \
+                                       "' was already initializaed" ); \
+    }                                                                  \
+  if ( this->environment.has_value() )                                 \
+    {                                                                  \
+      throw EnvironmentMixinException(                                 \
+        "`" #member "' cannot be initializaed after `environment'" );  \
+    }
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+EnvironmentMixin::initGlobalManifestPath( std::filesystem::path path )
+{
+  ENV_MIXIN_THROW_IF_SET( globalManifestPath )
+  this->globalManifestPath = std::move( path );
+}
+
+void
+EnvironmentMixin::initGlobalManifest( GlobalManifest manifest )
+{
+  ENV_MIXIN_THROW_IF_SET( globalManifest )
+  this->globalManifest = std::move( manifest );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+EnvironmentMixin::initManifestPath( std::filesystem::path path )
+{
+  ENV_MIXIN_THROW_IF_SET( manifestPath )
+  this->manifestPath = std::move( path );
+}
+
+void
+EnvironmentMixin::initManifest( Manifest manifest )
+{
+  ENV_MIXIN_THROW_IF_SET( manifest )
+  this->manifest = std::move( manifest );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+EnvironmentMixin::initLockfilePath( std::filesystem::path path )
+{
+  ENV_MIXIN_THROW_IF_SET( lockfilePath )
+  this->lockfilePath = std::move( path );
+}
+
+void
+EnvironmentMixin::initLockfile( Lockfile lockfile )
+{
+  ENV_MIXIN_THROW_IF_SET( lockfile )
+  this->lockfile = std::move( lockfile );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+}  // namespace flox::resolver
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/src/search/command.cc
+++ b/src/search/command.cc
@@ -44,7 +44,7 @@ SearchCommand::addSearchParamArgs( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "parameters" )
     .help( "search paramaters as inline JSON or a path to a file" )
-    .metavar( "PARAMS" )
+    .metavar( "[PARAMS]" )
     .nargs( argparse::nargs_pattern::optional )
     .action(
       [&]( const std::string & params )

--- a/src/search/command.cc
+++ b/src/search/command.cc
@@ -61,6 +61,7 @@ SearchCommand::SearchCommand() : parser( "search" )
 {
   this->parser.add_description(
     "Search a set of flakes and emit a list satisfactory packages" );
+  this->addGAManifestOption( this->parser );
   this->addSearchParamArgs( this->parser );
 }
 
@@ -75,21 +76,20 @@ SearchCommand::initEnvironment()
   if ( maybePath.has_value() ) { this->initGlobalManifestPath( *maybePath ); }
   if ( auto raw = this->params.getGlobalManifestRaw(); raw.has_value() )
     {
-      this->initGlobalManifest( resolver::GlobalManifest( *maybePath, *raw ) );
+      this->initGlobalManifest( *raw );
     }
 
   /* Init manifest. */
-  auto path = this->params.getManifestPath();
-  this->initManifestPath( path );
-  this->initManifest(
-    resolver::Manifest( path, this->params.getManifestRaw() ) );
+  maybePath = this->params.getManifestPath();
+  if ( maybePath.has_value() ) { this->initGlobalManifestPath( *maybePath ); }
+  this->initManifest( this->params.getManifestRaw() );
 
   /* Init lockfile . */
   maybePath = this->params.getLockfilePath();
   if ( maybePath.has_value() ) { this->initLockfilePath( *maybePath ); }
   if ( auto raw = this->params.getLockfileRaw(); raw.has_value() )
     {
-      this->initLockfile( resolver::Lockfile( *maybePath, *raw ) );
+      this->initLockfile( *raw );
     }
 }
 

--- a/src/search/command.cc
+++ b/src/search/command.cc
@@ -61,28 +61,28 @@ void
 SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
 {
   parser.add_argument( "--name" )
-    .help( "search for packages by exact `name` match" )
+    .help( "search for packages by exact `name` match." )
     .metavar( "NAME" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.name = arg; } );
 
   parser.add_argument( "--pname" )
-    .help( "search for packages by exact `pname` match" )
+    .help( "search for packages by exact `pname` match." )
     .metavar( "PNAME" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.pname = arg; } );
 
   parser.add_argument( "--version" )
-    .help( "search for packages by exact `version` match" )
+    .help( "search for packages by exact `version` match." )
     .metavar( "VERSION" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.version = arg; } );
 
   parser.add_argument( "--semver" )
-    .help( "search for packages by semantic version range matching" )
+    .help( "search for packages by semantic version range matching." )
     .metavar( "VERSION" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
@@ -90,14 +90,14 @@ SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
 
   parser.add_argument( "--match" )
     .help( "search for packages by partially matching `pname`, "
-           "`description`, or `attrName`" )
+           "`description`, or `attrName`." )
     .metavar( "MATCH" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.partialMatch = arg; } );
 
   parser.add_argument( "--match-name" )
-    .help( "search for packages by partially matching `pname` or `attrName`" )
+    .help( "search for packages by partially matching `pname` or `attrName`." )
     .metavar( "MATCH" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
@@ -110,7 +110,7 @@ SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
 SearchCommand::SearchCommand() : parser( "search" )
 {
   this->parser.add_description(
-    "Search a set of flakes and emit a list satisfactory packages" );
+    "Search a set of flakes and emit a list satisfactory packages." );
   this->addGAManifestOption( this->parser );
   this->addSearchParamArgs( this->parser );
   this->addFloxDirectoryOption( this->parser );

--- a/src/search/command.cc
+++ b/src/search/command.cc
@@ -61,21 +61,21 @@ void
 SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
 {
   parser.add_argument( "--name" )
-    .help( "search for packages by exact `name` match." )
+    .help( "search for packages by exact `name' match." )
     .metavar( "NAME" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.name = arg; } );
 
   parser.add_argument( "--pname" )
-    .help( "search for packages by exact `pname` match." )
+    .help( "search for packages by exact `pname' match." )
     .metavar( "PNAME" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.pname = arg; } );
 
   parser.add_argument( "--version" )
-    .help( "search for packages by exact `version` match." )
+    .help( "search for packages by exact `version' match." )
     .metavar( "VERSION" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
@@ -89,15 +89,15 @@ SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
              { this->params.query.semver = arg; } );
 
   parser.add_argument( "--match" )
-    .help( "search for packages by partially matching `pname`, "
-           "`description`, or `attrName`." )
+    .help( "search for packages by partially matching `pname', "
+           "`description', or `attrName'." )
     .metavar( "MATCH" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.partialMatch = arg; } );
 
   parser.add_argument( "--match-name" )
-    .help( "search for packages by partially matching `pname` or `attrName`." )
+    .help( "search for packages by partially matching `pname' or `attrName'." )
     .metavar( "MATCH" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )

--- a/src/search/command.cc
+++ b/src/search/command.cc
@@ -58,7 +58,7 @@ SearchCommand::addSearchParamArgs( argparse::ArgumentParser & parser )
 /* -------------------------------------------------------------------------- */
 
 void
-SearchCommand::addSearchQueryFlags( argparse::ArgumentParser & parser )
+SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
 {
   parser.add_argument( "--name" )
     .help( "search for packages by exact `name` match" )
@@ -113,7 +113,8 @@ SearchCommand::SearchCommand() : parser( "search" )
     "Search a set of flakes and emit a list satisfactory packages" );
   this->addGAManifestOption( this->parser );
   this->addSearchParamArgs( this->parser );
-  this->addSearchQueryFlags( this->parser );
+  this->addFloxDirectoryOption( this->parser );
+  this->addSearchQueryOptions( this->parser );
 }
 
 

--- a/src/search/command.cc
+++ b/src/search/command.cc
@@ -44,8 +44,8 @@ SearchCommand::addSearchParamArgs( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "parameters" )
     .help( "search paramaters as inline JSON or a path to a file" )
-    .required()
     .metavar( "PARAMS" )
+    .nargs( argparse::nargs_pattern::optional )
     .action(
       [&]( const std::string & params )
       {
@@ -57,12 +57,63 @@ SearchCommand::addSearchParamArgs( argparse::ArgumentParser & parser )
 
 /* -------------------------------------------------------------------------- */
 
+void
+SearchCommand::addSearchQueryFlags( argparse::ArgumentParser & parser )
+{
+  parser.add_argument( "--name" )
+    .help( "search for packages by exact `name` match" )
+    .metavar( "NAME" )
+    .nargs( 1 )
+    .action( [&]( const std::string & arg )
+             { this->params.query.name = arg; } );
+
+  parser.add_argument( "--pname" )
+    .help( "search for packages by exact `pname` match" )
+    .metavar( "PNAME" )
+    .nargs( 1 )
+    .action( [&]( const std::string & arg )
+             { this->params.query.pname = arg; } );
+
+  parser.add_argument( "--version" )
+    .help( "search for packages by exact `version` match" )
+    .metavar( "VERSION" )
+    .nargs( 1 )
+    .action( [&]( const std::string & arg )
+             { this->params.query.version = arg; } );
+
+  parser.add_argument( "--semver" )
+    .help( "search for packages by semantic version range matching" )
+    .metavar( "VERSION" )
+    .nargs( 1 )
+    .action( [&]( const std::string & arg )
+             { this->params.query.semver = arg; } );
+
+  parser.add_argument( "--match" )
+    .help( "search for packages by partially matching `pname`, "
+           "`description`, or `attrName`" )
+    .metavar( "MATCH" )
+    .nargs( 1 )
+    .action( [&]( const std::string & arg )
+             { this->params.query.partialMatch = arg; } );
+
+  parser.add_argument( "--match-name" )
+    .help( "search for packages by partially matching `pname` or `attrName`" )
+    .metavar( "MATCH" )
+    .nargs( 1 )
+    .action( [&]( const std::string & arg )
+             { this->params.query.partialNameMatch = arg; } );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 SearchCommand::SearchCommand() : parser( "search" )
 {
   this->parser.add_description(
     "Search a set of flakes and emit a list satisfactory packages" );
   this->addGAManifestOption( this->parser );
   this->addSearchParamArgs( this->parser );
+  this->addSearchQueryFlags( this->parser );
 }
 
 

--- a/src/search/command.cc
+++ b/src/search/command.cc
@@ -83,7 +83,7 @@ SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
 
   parser.add_argument( "--semver" )
     .help( "search for packages by semantic version range matching." )
-    .metavar( "VERSION" )
+    .metavar( "RANGE" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.semver = arg; } );

--- a/src/search/params.cc
+++ b/src/search/params.cc
@@ -95,7 +95,10 @@ from_json( const nlohmann::json & jfrom, SearchQuery & qry )
 void
 to_json( nlohmann::json & jto, const SearchQuery & qry )
 {
-  pkgdb::to_json( jto, dynamic_cast<const pkgdb::PkgDescriptorBase &>( qry ) );
+  jto["name"]       = qry.name;
+  jto["pname"]      = qry.pname;
+  jto["version"]    = qry.version;
+  jto["semver"]     = qry.semver;
   jto["match"]      = qry.partialMatch;
   jto["match-name"] = qry.partialNameMatch;
 }

--- a/src/search/params.cc
+++ b/src/search/params.cc
@@ -148,14 +148,10 @@ SearchParams::getLockfileRaw()
 std::optional<std::filesystem::path>
 SearchParams::getGlobalManifestPath()
 {
-  if ( this->globalManifest.has_value() )
+  if ( this->globalManifest.has_value() &&
+       std::holds_alternative<std::filesystem::path>( *this->globalManifest ) )
     {
-      if ( std::holds_alternative<std::filesystem::path>(
-             *this->globalManifest ) )
-        {
-          return std::get<std::filesystem::path>( *this->globalManifest );
-        }
-      return "<INLINE-GLOBAL-MANIFEST>.json";
+      return std::get<std::filesystem::path>( *this->globalManifest );
     }
   return std::nullopt;
 }
@@ -179,14 +175,15 @@ SearchParams::getGlobalManifestRaw()
 
 /* -------------------------------------------------------------------------- */
 
-std::filesystem::path
+std::optional<std::filesystem::path>
 SearchParams::getManifestPath()
 {
-  if ( std::holds_alternative<std::filesystem::path>( this->manifest ) )
+  if ( this->manifest.has_value() &&
+       std::holds_alternative<std::filesystem::path>( *this->manifest ) )
     {
-      return std::get<std::filesystem::path>( this->manifest );
+      return std::get<std::filesystem::path>( *this->manifest );
     }
-  return "<INLINE-MANIFEST>.json";
+  return std::nullopt;
 }
 
 
@@ -195,11 +192,12 @@ SearchParams::getManifestPath()
 resolver::ManifestRaw
 SearchParams::getManifestRaw()
 {
-  if ( std::holds_alternative<resolver::ManifestRaw>( this->manifest ) )
+  if ( ! this->manifest.has_value() ) { return {}; }
+  if ( std::holds_alternative<resolver::ManifestRaw>( *this->manifest ) )
     {
-      return std::get<resolver::ManifestRaw>( this->manifest );
+      return std::get<resolver::ManifestRaw>( *this->manifest );
     }
-  return readAndCoerceJSON( std::get<std::filesystem::path>( this->manifest ) );
+  return readAndCoerceJSON( std::get<std::filesystem::path>( *this->manifest ) );
 }
 
 

--- a/tests/search.bats
+++ b/tests/search.bats
@@ -273,17 +273,33 @@ genParamsNixpkgsFlox() {
   run $SEARCH_PARAMS '{}';
   assert_success;
 
+  run sh -c "$SEARCH_PARAMS '{}'|jq -r '.manifest';";
+  assert_success;
+  assert_output 'null';
+
+  run sh -c "$SEARCH_PARAMS '{}'|jq -r '.query.name';";
+  assert_success;
+  assert_output 'null';
+
+  run sh -c "$SEARCH_PARAMS '{}'|jq -r '.query.pname';";
+  assert_success;
+  assert_output 'null';
+
+  run sh -c "$SEARCH_PARAMS '{}'|jq -r '.query.version';";
+  assert_success;
+  assert_output 'null';
+
+  run sh -c "$SEARCH_PARAMS '{}'|jq -r '.query.semver';";
+  assert_success;
+  assert_output 'null';
+
   run sh -c "$SEARCH_PARAMS '{}'|jq -r '.query.match';";
   assert_success;
   assert_output 'null';
 
-  run sh -c "$SEARCH_PARAMS '{}'|jq -r '.query[\"name-match\"]';";
+  run sh -c "$SEARCH_PARAMS '{}'|jq -r '.query[\"match-name\"]';";
   assert_success;
   assert_output 'null';
-
-  run sh -c "$SEARCH_PARAMS '{}'|jq -r '.manifest';";
-  assert_success;
-  refute_output --regexp '.';
 
   run sh -c "$SEARCH_PARAMS '{}'|jq -r '.[\"global-manifest\"]';";
   assert_success;


### PR DESCRIPTION
- move `[Global]ManifestRaw` to separate header
- move `EnvironmentMixin` to separate file
- path getters on `EnvironmentMixin`
- add `EnvironmentMixin::init<MEMBER>` from `<TYPE>Raw`
- make`manifest` field optional in `SearchParams`: `flox search '{ "query": { ... } }'`
- `SearchCommand::addSearchParamArgs`: `flox search --pname hello --version 4.2.0 ...;`
- fix: `to_json` for `SearchQuery`
- `EnvironmentMixin::addFloxDirectoryOption`: `flox search --dir ./.flox '{ "query": { ... } }';`
- `EnvironmentMixin::addGAManifestOption`: `flox search --ga-manifest '{ "query": { ... } }';`