### PR TITLE
chore: drop `manifestPath` and `lockfilePath` member variables

### DIFF
--- a/include/flox/resolver/environment.hh
+++ b/include/flox/resolver/environment.hh
@@ -90,11 +90,11 @@ private:
 
   /**
    * @brief Indicator for lockfile upgrade operations.
-   * 
-    * `true` means upgrade everything.
-    * `false` or an empty vector mean upgrade nothing.
-    * A list of `InstallID`s indicates a subset of packages to be upgraded.
-    */
+   *
+   * `true` means upgrade everything.
+   * `false` or an empty vector mean upgrade nothing.
+   * A list of `InstallID`s indicates a subset of packages to be upgraded.
+   */
   using Upgrades = std::variant<bool, std::vector<InstallID>>;
   /** Packages to force an upgrade for, even if they are already locked. */
   Upgrades upgrades;

--- a/include/flox/resolver/lockfile.hh
+++ b/include/flox/resolver/lockfile.hh
@@ -201,7 +201,7 @@ private:
    * Handle for the manifest used to create the lockfile.
    * This reads the lockfile's `manifest`.
    */
-  Manifest    manifest;
+  Manifest manifest;
   /** Maps `{ <FINGERPRINT>: <INPUT> }` for all `packages` members' inputs. */
   RegistryRaw packagesRegistryRaw;
 

--- a/include/flox/resolver/lockfile.hh
+++ b/include/flox/resolver/lockfile.hh
@@ -194,9 +194,14 @@ class Lockfile
 
 private:
 
-  std::optional<std::filesystem::path> lockfilePath;
-  LockfileRaw                          lockfileRaw;
-  Manifest                             manifest;
+  /** Raw representation of the lockfile. */
+  LockfileRaw lockfileRaw;
+
+  /**
+   * Handle for the manifest used to create the lockfile.
+   * This reads the lockfile's `manifest`.
+   */
+  Manifest    manifest;
   /** Maps `{ <FINGERPRINT>: <INPUT> }` for all `packages` members' inputs. */
   RegistryRaw packagesRegistryRaw;
 
@@ -245,12 +250,6 @@ public:
     this->init();
   }
 
-  Lockfile( std::filesystem::path lockfilePath, LockfileRaw raw )
-    : lockfilePath( std::move( lockfilePath ) ), lockfileRaw( std::move( raw ) )
-  {
-    this->init();
-  }
-
   explicit Lockfile( std::filesystem::path lockfilePath );
 
   Lockfile &
@@ -260,13 +259,6 @@ public:
   Lockfile &
   operator=( Lockfile && )
     = default;
-
-  /** @brief Get the filesystem path to the lockfile ( if any ). */
-  [[nodiscard]] const std::optional<std::filesystem::path> &
-  getLockfilePath() const
-  {
-    return this->lockfilePath;
-  }
 
   /** @brief Get the _raw_ representation of the lockfile. */
   [[nodiscard]] const LockfileRaw &

--- a/include/flox/resolver/manifest.hh
+++ b/include/flox/resolver/manifest.hh
@@ -31,9 +31,10 @@
 
 /* Forward Declarations. */
 
-namespace flox { namespace resolver {
+namespace flox::resolver {
 struct ManifestDescriptor;
-}}  // namespace flox::resolver
+}  // namespace flox::resolver
+
 namespace nix {
 class Store;
 }
@@ -64,16 +65,15 @@ protected:
   /* We need these `protected' so they can be set by `Manifest'. */
   // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
   // TODO: remove `manifestPath'
-  std::filesystem::path manifestPath;
-  ManifestRaw           manifestRaw;
-  RegistryRaw           registryRaw;
+  ManifestRaw manifestRaw;
+  RegistryRaw registryRaw;
   // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
 
 
   /**
    * @brief Initialize @a registryRaw from @a manifestRaw. */
-  virtual void
-  init();
+  void
+  initRegistry();
 
 
 public:
@@ -83,21 +83,16 @@ public:
   GlobalManifest( const GlobalManifest & ) = default;
   GlobalManifest( GlobalManifest && )      = default;
 
-  // TODO: remove `manifestPath'
-  GlobalManifest( std::filesystem::path manifestPath, GlobalManifestRaw raw )
-    : manifestPath( std::move( manifestPath ) ), manifestRaw( std::move( raw ) )
+  explicit GlobalManifest( GlobalManifestRaw raw )
+    : manifestRaw( std::move( raw ) )
   {
-    this->manifestRaw.check();
-    if ( this->manifestRaw.registry.has_value() )
-      {
-        this->registryRaw = *this->manifestRaw.registry;
-      }
+    this->initRegistry();
   }
 
-  // TODO: remove `manifestPath'
-  explicit GlobalManifest( GlobalManifestRaw raw )
-    : GlobalManifest( "manifest.json", std::move( raw ) )
-  {}
+  explicit GlobalManifest( ManifestRaw raw ) : manifestRaw( std::move( raw ) )
+  {
+    this->initRegistry();
+  }
 
   explicit GlobalManifest( std::filesystem::path manifestPath );
 
@@ -108,13 +103,6 @@ public:
   GlobalManifest &
   operator=( GlobalManifest && )
     = default;
-
-  // TODO: remove `manifestPath'
-  [[nodiscard]] std::filesystem::path
-  getManifestPath() const
-  {
-    return this->manifestPath;
-  }
 
   [[nodiscard]] const ManifestRaw &
   getManifestRaw() const
@@ -190,10 +178,10 @@ private:
   check() const;
 
   /**
-   * @brief Initialize @a registryRaw and @a descriptors from @a manifestRaw.
+   * @brief Initialize @a descriptors from @a manifestRaw.
    */
   void
-  init() override;
+  initDescriptors();
 
 
 public:
@@ -203,16 +191,12 @@ public:
   Manifest( const Manifest & ) = default;
   Manifest( Manifest && )      = default;
 
-  // TODO: remove `manifestPath'
-  Manifest( std::filesystem::path manifestPath, ManifestRaw raw );
-
-  // TODO: remove `manifestPath'
-  explicit Manifest( ManifestRaw raw )
-    : Manifest( "manifest.json", std::move( raw ) )
-  {}
+  explicit Manifest( ManifestRaw raw ) : GlobalManifest( std::move( raw ) )
+  {
+    this->initDescriptors();
+  }
 
   explicit Manifest( std::filesystem::path manifestPath );
-
 
   Manifest &
   operator=( const Manifest & )
@@ -237,12 +221,8 @@ public:
   [[nodiscard]] std::vector<InstallDescriptors>
   getGroupedDescriptors() const;
 
+
 }; /* End class `Manifest' */
-
-
-/* -------------------------------------------------------------------------- */
-
-// TODO: class GlobalManifestMixin : public pkgdb::PkgDbRegistryMixin
 
 
 /* -------------------------------------------------------------------------- */

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -132,7 +132,8 @@ Environment::groupIsLocked( const InstallDescriptors & group,
       /* Check for upgrades. */
       if ( bool * upgradeEverything = std::get_if<bool>( &this->upgrades ) )
         {
-          /* If we're upgrading everything, the group needs to be locked again. */
+          /* If we're upgrading everything, the group needs to be locked again.
+           */
           if ( *upgradeEverything ) { return false; }
         }
       else

--- a/src/resolver/lockfile.cc
+++ b/src/resolver/lockfile.cc
@@ -131,13 +131,7 @@ Lockfile::init()
         }
     }
 
-  std::string manifestPath = "manifest.json"; /* Phony */
-  if ( this->lockfilePath.has_value() )
-    {
-      manifestPath = this->lockfilePath->parent_path() / manifestPath;
-    }
-
-  this->manifest = Manifest( manifestPath, this->lockfileRaw.manifest );
+  this->manifest = Manifest( this->lockfileRaw.manifest );
 
   this->check();
 }
@@ -160,8 +154,7 @@ readLockfileFromPath( const std::filesystem::path & lockfilePath )
 /* -------------------------------------------------------------------------- */
 
 Lockfile::Lockfile( std::filesystem::path lockfilePath )
-  : lockfilePath( std::move( lockfilePath ) )
-  , lockfileRaw( readLockfileFromPath( this->lockfilePath.value() ) )
+  : lockfileRaw( readLockfileFromPath( lockfilePath ) )
 {
   this->init();
 }

--- a/src/resolver/manifest.cc
+++ b/src/resolver/manifest.cc
@@ -135,8 +135,7 @@ Manifest::check() const
                == maybeSystems->end() )
             {
               throw InvalidManifestFileException(
-                "descriptor `install." + iid + "' specifies system `"
-                + system
+                "descriptor `install." + iid + "' specifies system `" + system
                 + "' which is not in `options.systems' in the manifest." );
             }
         }

--- a/src/resolver/manifest.cc
+++ b/src/resolver/manifest.cc
@@ -52,7 +52,7 @@ readManifestFromPath( const std::filesystem::path & manifestPath )
 /* -------------------------------------------------------------------------- */
 
 void
-GlobalManifest::init()
+GlobalManifest::initRegistry()
 {
   this->manifestRaw.check();
   if ( this->manifestRaw.registry.has_value() )
@@ -65,10 +65,9 @@ GlobalManifest::init()
 /* -------------------------------------------------------------------------- */
 
 GlobalManifest::GlobalManifest( std::filesystem::path manifestPath )
-  : manifestPath( std::move( manifestPath ) )
-  , manifestRaw( readManifestFromPath<GlobalManifestRaw>( this->manifestPath ) )
+  : manifestRaw( readManifestFromPath<GlobalManifestRaw>( manifestPath ) )
 {
-  this->init();
+  this->initRegistry();
 }
 
 
@@ -114,30 +113,31 @@ void
 Manifest::check() const
 {
   this->manifestRaw.check();
+  std::optional<std::vector<std::string>> maybeSystems;
+  if ( auto maybeOpts = this->getManifestRaw().options; maybeOpts.has_value() )
+    {
+      maybeSystems = maybeOpts->systems;
+    }
+
   for ( const auto & [iid, desc] : this->descriptors )
     {
-      if ( desc.systems.has_value() )
+      if ( ! desc.systems.has_value() ) { continue; }
+      if ( ! maybeSystems.has_value() )
         {
-          if ( ( ! this->manifestRaw.options.has_value() )
-               || ( ! this->manifestRaw.options->systems.has_value() ) )
+          throw InvalidManifestFileException(
+            "descriptor `install." + iid
+            + "' specifies `systems' but no `options.systems' are specified"
+              " in the manifest." );
+        }
+      for ( const auto & system : *desc.systems )
+        {
+          if ( std::find( maybeSystems->begin(), maybeSystems->end(), system )
+               == maybeSystems->end() )
             {
               throw InvalidManifestFileException(
-                "descriptor `install." + iid
-                + "' specifies `systems' but no `options.systems' are specified"
-                  " in the manifest." );
-            }
-          for ( const auto & system : *desc.systems )
-            {
-              if ( std::find( this->manifestRaw.options->systems->begin(),
-                              this->manifestRaw.options->systems->end(),
-                              system )
-                   == this->manifestRaw.options->systems->end() )
-                {
-                  throw InvalidManifestFileException(
-                    "descriptor `install." + iid + "' specifies system `"
-                    + system
-                    + "' which is not in `options.systems' in the manifest." );
-                }
+                "descriptor `install." + iid + "' specifies system `"
+                + system
+                + "' which is not in `options.systems' in the manifest." );
             }
         }
     }
@@ -147,14 +147,8 @@ Manifest::check() const
 /* -------------------------------------------------------------------------- */
 
 void
-Manifest::init()
+Manifest::initDescriptors()
 {
-  this->manifestRaw.check();
-  if ( this->manifestRaw.registry.has_value() )
-    {
-      this->registryRaw = *this->manifestRaw.registry;
-    }
-
   if ( ! this->manifestRaw.install.has_value() ) { return; }
   for ( const auto & [iid, raw] : *this->manifestRaw.install )
     {
@@ -176,21 +170,10 @@ Manifest::init()
 
 /* -------------------------------------------------------------------------- */
 
-Manifest::Manifest( std::filesystem::path manifestPath, ManifestRaw raw )
-{
-  this->manifestPath = std::move( manifestPath );
-  this->manifestRaw  = std::move( raw );
-  this->init();
-}
-
-
-/* -------------------------------------------------------------------------- */
-
 Manifest::Manifest( std::filesystem::path manifestPath )
+  : GlobalManifest( readManifestFromPath<ManifestRaw>( manifestPath ) )
 {
-  this->manifestPath = std::move( manifestPath );
-  this->manifestRaw  = readManifestFromPath<ManifestRaw>( this->manifestPath );
-  this->init();
+  this->initDescriptors();
 }
 
 
@@ -226,6 +209,7 @@ Manifest::getGroupedDescriptors() const
     }
   return allDescriptors;
 }
+
 
 /* -------------------------------------------------------------------------- */
 

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -199,9 +199,10 @@ EnvironmentMixin::getEnvironment()
 {
   if ( ! this->environment.has_value() )
     {
-      this->environment = Environment( this->getGlobalManifest(),
-                                       this->getManifest(),
-                                       this->getLockfile() );
+      this->environment
+        = std::make_optional<Environment>( this->getGlobalManifest(),
+                                           this->getManifest(),
+                                           this->getLockfile() );
     }
   return *this->environment;
 }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
+environment
 exceptions
 is_sqlite3
 lockfile

--- a/tests/environment.cc
+++ b/tests/environment.cc
@@ -233,8 +233,7 @@ test_groupIsLocked0()
   manifestRaw.options->systems = { _system };
   manifestRaw.registry         = registryWithNixpkgs;
 
-  /* TODO move path out of manifest? */
-  Manifest manifest( "dummy path", manifestRaw );
+  Manifest manifest( manifestRaw );
 
   /* Create expected lockfile, reusing manifestRaw */
   LockfileRaw lockfileRaw;
@@ -279,7 +278,7 @@ test_groupIsLocked1()
   nlohmann::json helloJSON = { { "systems", { _system } } };
   modifiedManifestRaw.install->at( "hello" )
     = ManifestDescriptorRaw( helloJSON );
-  Manifest manifest( "", modifiedManifestRaw );
+  Manifest manifest( modifiedManifestRaw );
 
   /* All groups should be locked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
@@ -315,7 +314,7 @@ test_groupIsLocked2()
   nlohmann::json helloJSON = { { "systems", nlohmann::json::array() } };
   modifiedManifestRaw.install->at( "hello" )
     = ManifestDescriptorRaw( helloJSON );
-  Manifest manifest( "", modifiedManifestRaw );
+  Manifest manifest( modifiedManifestRaw );
 
   /* All groups should be unlocked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
@@ -326,9 +325,7 @@ test_groupIsLocked2()
   return true;
 }
 
-/**
- * @brief test moving a package to a different group unlocks it.
- */
+/** @brief Test moving a package to a different group unlocks it. */
 bool
 test_groupIsLocked3()
 {
@@ -351,7 +348,7 @@ test_groupIsLocked3()
   nlohmann::json helloJSON = { { "package-group", "red" } };
   modifiedManifestRaw.install->at( "hello" )
     = ManifestDescriptorRaw( helloJSON );
-  Manifest manifest( "", modifiedManifestRaw );
+  Manifest manifest( modifiedManifestRaw );
 
   /* All groups should be unlocked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
@@ -386,7 +383,7 @@ test_groupIsLocked4()
   /* Add curl to the manifest (but not the lockfile) */
   ManifestRaw modifiedManifestRaw( manifestRaw );
   ( *modifiedManifestRaw.install )["curl"] = std::nullopt;
-  Manifest manifest( "", modifiedManifestRaw );
+  Manifest manifest( modifiedManifestRaw );
 
   /* All groups should be unlocked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
@@ -422,7 +419,7 @@ test_groupIsLocked5()
   ManifestRaw    modifiedManifestRaw( manifestRaw );
   nlohmann::json curlJSON                  = { { "package-group", "blue" } };
   ( *modifiedManifestRaw.install )["curl"] = ManifestDescriptorRaw( curlJSON );
-  Manifest manifest( "", manifestRaw );
+  Manifest manifest( manifestRaw );
 
   /* The group with hello should stay locked, but curl should be unlocked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
@@ -454,7 +451,7 @@ test_groupIsLocked6()
   manifestRaw.options     = Options {};
   manifestRaw.options->systems = { _system };
   manifestRaw.registry         = registryWithNixpkgs;
-  Manifest manifest( "", manifestRaw );
+  Manifest manifest( manifestRaw );
 
   /* Create expected lockfile, reusing manifestRaw */
   LockfileRaw lockfileRaw;
@@ -490,8 +487,7 @@ test_createLockfile_new()
   manifestRaw.options->systems = { _system };
   manifestRaw.registry         = registryWithNixpkgs;
 
-  /* TODO move path out of manifest? */
-  Manifest manifest( "dummy path", manifestRaw );
+  Manifest manifest( manifestRaw );
 
   /* Create expected lockfile, reusing manifestRaw */
   LockfileRaw expectedLockfileRaw;
@@ -523,8 +519,7 @@ test_createLockfile_existing()
   manifestRaw.options->systems = { _system };
   manifestRaw.registry         = registryWithNixpkgs;
 
-  /* TODO move path out of manifest? */
-  Manifest manifest( "dummy path", manifestRaw );
+  Manifest manifest( manifestRaw );
 
   /* Create existing/expected lockfile, reusing manifestRaw */
   LockfileRaw expectedLockfileRaw;
@@ -561,8 +556,7 @@ test_createLockfile_both()
   manifestRaw.options->systems = { _system };
   manifestRaw.registry         = registryWithNixpkgs;
 
-  /* TODO move path out of manifest? */
-  Manifest manifest( "dummy path", manifestRaw );
+  Manifest manifest( manifestRaw );
 
   /* Create existing lockfile with hello but not curl. We have to create another
    * manifest with hello but not curl. */
@@ -574,8 +568,7 @@ test_createLockfile_both()
   existingManifestRaw.options->systems = { _system };
   existingManifestRaw.registry         = registryWithNixpkgs;
 
-  /* TODO move path out of manifest? */
-  Manifest existingManifest( "dummy path", existingManifestRaw );
+  Manifest existingManifest( existingManifestRaw );
 
   LockfileRaw existingLockfileRaw;
   existingLockfileRaw.packages

--- a/tests/environment.cc
+++ b/tests/environment.cc
@@ -21,6 +21,7 @@ using namespace flox;
 using namespace flox::resolver;
 using namespace nlohmann::literals;
 
+
 /* -------------------------------------------------------------------------- */
 
 class TestEnvironment : public Environment
@@ -31,9 +32,12 @@ public:
   using Environment::groupIsLocked;
 };
 
-/* Scraping should be cross platform, so even though this is hardcoded, it
- * should work on other systems. */
+/**
+ * Scraping should be cross platform, so even though this is hardcoded, it
+ * should work on other systems.
+ */
 const System _system = "x86_64-linux";
+
 
 /* -------------------------------------------------------------------------- */
 
@@ -63,8 +67,7 @@ LockedPackageRaw helloLocked( helloLockedJSON );
 
 /* -------------------------------------------------------------------------- */
 
-/* Change a few fields from what we'd get if actual resultion was performed.
- */
+/** Change a few fields from what we'd get if actual resultion was performed. */
 nlohmann::json mockHelloLockedJSON {
   { "input",
     { { "fingerprint", nixpkgsFingerprintStr },
@@ -142,6 +145,7 @@ equalLockedInputRaw( const LockedInputRaw & first,
   return true;
 }
 
+
 /* -------------------------------------------------------------------------- */
 
 bool
@@ -155,8 +159,8 @@ equalAttrPath( const AttrPath & first, const AttrPath & second )
   return true;
 }
 
-/* -------------------------------------------------------------------------- */
 
+/* -------------------------------------------------------------------------- */
 
 bool
 equalLockedPackageRaw( const LockedPackageRaw & first,
@@ -218,11 +222,10 @@ equalLockfile( const Lockfile & first, const Lockfile & second )
   // RegistryRaw packagesRegistryRaw;
 }
 
+
 /* -------------------------------------------------------------------------- */
 
-/**
- * @brief test unmodified manifest descriptor stays locked.
- */
+/** @brief Test unmodified manifest descriptor stays locked. */
 bool
 test_groupIsLocked0()
 {
@@ -252,9 +255,12 @@ test_groupIsLocked0()
   return true;
 }
 
+
+/* -------------------------------------------------------------------------- */
+
 /**
- * @brief test that explicitly requiring the locked system doesn't unlock the
- *        group.
+ * @brief Test that explicitly requiring the locked system doesn't unlock
+ *        the group.
  */
 bool
 test_groupIsLocked1()
@@ -289,9 +295,10 @@ test_groupIsLocked1()
   return true;
 }
 
-/**
- * @brief test disabling the locked system unlocks the group.
- */
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test disabling the locked system unlocks the group. */
 bool
 test_groupIsLocked2()
 {
@@ -324,6 +331,9 @@ test_groupIsLocked2()
     }
   return true;
 }
+
+
+/* -------------------------------------------------------------------------- */
 
 /** @brief Test moving a package to a different group unlocks it. */
 bool
@@ -360,9 +370,9 @@ test_groupIsLocked3()
 }
 
 
-/**
- * @brief test adding a package to the default group unlocks it.
- */
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test adding a package to the default group unlocks it. */
 bool
 test_groupIsLocked4()
 {
@@ -394,9 +404,12 @@ test_groupIsLocked4()
   return true;
 }
 
+
+/* -------------------------------------------------------------------------- */
+
 /**
- * @brief test adding a package to a different group doesn't unlock the default
- *        group.
+ * @brief Test adding a package to a different group doesn't unlock the
+ *        default group.
  */
 bool
 test_groupIsLocked5()
@@ -438,9 +451,10 @@ test_groupIsLocked5()
   return true;
 }
 
-/**
- * @brief test that two separate groups both stay locked.
- */
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test that two separate groups both stay locked. */
 bool
 test_groupIsLocked6()
 {
@@ -471,11 +485,10 @@ test_groupIsLocked6()
   return true;
 }
 
+
 /* -------------------------------------------------------------------------- */
 
-/**
- * @brief test upgrades correctly control locking.
- */
+/** @brief Test upgrades correctly control locking. */
 bool
 test_groupIsLocked_upgrades()
 {
@@ -486,8 +499,7 @@ test_groupIsLocked_upgrades()
   manifestRaw.options->systems = { _system };
   manifestRaw.registry         = registryWithNixpkgs;
 
-  /* TODO move path out of manifest? */
-  Manifest manifest( "dummy path", manifestRaw );
+  Manifest manifest( manifestRaw );
 
   /* Create expected lockfile, reusing manifestRaw */
   LockfileRaw lockfileRaw;
@@ -535,9 +547,7 @@ test_groupIsLocked_upgrades()
 
 /* -------------------------------------------------------------------------- */
 
-/**
- * @brief createLockfile creates a lock when there is no existing lockfile.
- */
+/** @brief createLockfile creates a lock when there is no existing lockfile. */
 bool
 test_createLockfile_new()
 {
@@ -565,11 +575,10 @@ test_createLockfile_new()
   return true;
 }
 
+
 /* -------------------------------------------------------------------------- */
 
-/**
- * @brief createLockfile reuses existing lockfile entry.
- */
+/** @brief `createLockfile()` reuses existing lockfile entry. */
 bool
 test_createLockfile_existing()
 {
@@ -602,8 +611,8 @@ test_createLockfile_existing()
 /* -------------------------------------------------------------------------- */
 
 /**
- * @brief createLockfile both reuses existing lockfile entry and locks unlocked
- *        packages.
+ * @brief `createLockfile()` both reuses existing lockfile entry and locks
+ *        unlocked packages.
  */
 bool
 test_createLockfile_both()


### PR DESCRIPTION
- Drops `manifestPath` from `GlobalManifest` and `Manifest`.
- Drops `lockfilePath` from `Lockfile`.

These variables were frequently plugged with phony values, and weren't really required anywhere.