### PR TITLE
fix: don't pass manifest as global manifest

### DIFF
--- a/include/flox/resolver/mixins.hh
+++ b/include/flox/resolver/mixins.hh
@@ -45,7 +45,7 @@ namespace flox::resolver {
  */
 FLOX_DEFINE_EXCEPTION( EnvironmentMixinException,
                        EC_ENVIRONMENT_MIXIN,
-                       "EnvironmentMixin" )
+                       "error handling manifest or lockfile" )
 /** @} */
 
 

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -38,12 +38,12 @@ namespace flox::resolver {
   if ( this->member.has_value() )                                      \
     {                                                                  \
       throw EnvironmentMixinException( "`" #member                     \
-                                       "' was already initializaed" ); \
+                                       "' was already initialized" ); \
     }                                                                  \
   if ( this->environment.has_value() )                                 \
     {                                                                  \
       throw EnvironmentMixinException(                                 \
-        "`" #member "' cannot be initializaed after `environment'" );  \
+        "`" #member "' cannot be initialized after `environment'" );  \
     }
 
 

--- a/src/search/command.cc
+++ b/src/search/command.cc
@@ -133,7 +133,7 @@ SearchCommand::initEnvironment()
 
   /* Init manifest. */
   maybePath = this->params.getManifestPath();
-  if ( maybePath.has_value() ) { this->initGlobalManifestPath( *maybePath ); }
+  if ( maybePath.has_value() ) { this->initManifestPath( *maybePath ); }
   this->initManifest( this->params.getManifestRaw() );
 
   /* Init lockfile . */

--- a/tests/data/manifest/ga1.toml
+++ b/tests/data/manifest/ga1.toml
@@ -1,0 +1,21 @@
+# A manifest that doesn't have a registry so you can use it with --ga-registry
+[options]
+systems = ["x86_64-linux", "aarch64-darwin"]
+
+[install.charasay]
+version = "^2"
+[install.pip]
+path = "python310Packages.pip"
+# Expect failure
+[install.bad]
+optional = true
+
+[vars]
+message = "Howdy"
+message2 = "partner"
+
+[hook]
+script = """
+hello >&2;
+cowsay "$message $message2" >&2;
+"""

--- a/tests/data/manifest/global-manifest0.toml
+++ b/tests/data/manifest/global-manifest0.toml
@@ -1,0 +1,18 @@
+[options.allow]
+# Whether non-FOSS packages should appear in search/install results.
+unfree = true
+
+# Whether "broken" packages should appear in search/install results.
+# These are packages with known build/runtime issues.
+broken = false
+
+# Limit search/install results to only packages which
+# certain SPDX Identifiers by listing them below.
+# Leaving `licenses' undefined allows any license to be used.
+# See all valid license ids here: https://spdx.org/licenses/
+licenses = ["LGPL2-or-later"]
+
+[options.semver]
+# Whether unstable/pre-release versions of software should be
+# preferred over the latest stable release in search/install results.
+prefer-pre-releases = false


### PR DESCRIPTION
Don't pass the manifest as a global manifest. This also adds two test data files for manifests as they are handled today e.g. with the `--ga-registry` flag.