### PR TITLE
feat: use group's old locked input when possible

### DIFF
--- a/include/flox/resolver/environment.hh
+++ b/include/flox/resolver/environment.hh
@@ -200,7 +200,7 @@ protected:
   [[nodiscard]] bool
   groupIsLocked( const InstallDescriptors & group,
                  const Lockfile &           oldLockfile,
-                 const System &             system );
+                 const System &             system ) const;
 
 
 public:


### PR DESCRIPTION
Split out some minor cleanup into the first commit.

The second commit implements the "Try to resolve X in the same revision, R, used by other members of group Y." part of the locking flowchart. There's definitely a lot of cases to consider, so I just picked behavior that makes sense for now - happy to revisit any of those choices now or in the future. In more detail...

When re-locking an environment, for each group, try to use the locked
input for the group present in the old lockfile. If resolution fails in
that input, continue to the other inputs in the environment's registry.

Choosing the locked input for a group is full of edge cases, because the
new group may be different than whatever was in the group in the old
lockfile. We still want to reuse old locked inputs when we can. For
example:
- If the group name has changed, but nothing else has, we want to use
  the locked input.
- If packages have been added to a group, we want to use the locked
  input from a package that was already in the group.
- If groups are combined into a new group with a new name, we want to
  try to use one of the old locked inputs (for now we just use the first
  one we find).

If, on the other hand, a package has changed, we don't want to use its
locked input.