### PR TITLE
feat: raise priority of depth ranking

### DIFF
--- a/src/pkgdb/pkg-query.cc
+++ b/src/pkgdb/pkg-query.cc
@@ -436,9 +436,10 @@ PkgQuery::initOrderBy()
   /* Establish ordering. */
   this->addOrderBy( R"SQL(
     exactPname              DESC
-  , exactAttrName           DESC
   , matchExactPname         DESC
+  , exactAttrName           DESC
   , matchExactAttrName      DESC
+  , depth                   ASC
   , matchPartialPname       DESC
   , matchPartialAttrName    DESC
   , matchPartialDescription DESC
@@ -475,7 +476,6 @@ PkgQuery::initOrderBy()
   , v_PackagesSearch.version ASC NULLS LAST
   , brokenRank ASC
   , unfreeRank ASC
-  , depth ASC
   , attrName ASC
   )SQL" );
 }


### PR DESCRIPTION
Raises ranking associated with attribute path _depth_ so that search/resolution prefers packages closer to the top level:

Example before this change:
```
$ pkgdb search --match go|head -n2|jq '.relPath|join( "." )';
emacsPackages.go
go
```

Example after this change:
```
$ pkgdb search --match go|head -n2|jq '.relPath|join( "." )';
go
emacsPackages.go
```
