### PR TITLE
feat: pkgdb manifest lock --ga-registry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,7 +134,7 @@ jobs:
         run: nix develop '.#ci' --no-update-lock-file --command make tests -j4
 
       - name: Run Tests
-        run: nix develop '.#ci' --no-update-lock-file --command make check -j4
+        run: nix develop '.#ci' --no-update-lock-file --command make check
 
       - name: Run Installed
         run: nix run . --no-update-lock-file -- --help

--- a/README.md
+++ b/README.md
@@ -240,6 +240,26 @@ At this time there is no automated garbage collection mechanism, but simply
 deleting you cache directory will suffice.
 
 
+### Options and Settings
+
+#### `--ga-registry`
+
+Several commands such as `pkgdb search` and `pkgdb manifest` take an option
+`--ga-registry` which changes the behavior of _registry_ constructs to contain
+only a single input which provides `nixpkgs=github:NixOS/nixpkgs/release-23.05`.
+
+When `--ga-registry` is provided, it is an error for users to write `env-base`
+or `registry` fields.
+
+In the future this flag will be removed allowing users to set custom registries
+with multiple inputs or multiple branches.
+
+For the purposes of testing we have provided an environment variable
+`_PKGDB_GA_REGISTRY_REF_OR_REV` where you can provide an alternative `git` ref
+( tag or branch name ) or a long revision hash.
+This is used in our test suite.
+
+
 ## More Documentation
 - [Registry Schema](./docs/registry.md)
 - [Search Parameters](./docs/search.md)

--- a/include/flox/registry.hh
+++ b/include/flox/registry.hh
@@ -176,7 +176,7 @@ struct RegistryInput : public InputPreferences
         return false;
       }
 
-    return this->from->to_string() != other.from->to_string();
+    return ( *this->from ) == ( *other.from );
   }
 
   [[nodiscard]] bool

--- a/include/flox/registry.hh
+++ b/include/flox/registry.hh
@@ -86,6 +86,18 @@ struct InputPreferences
   void
   merge( const InputPreferences & overrides );
 
+  [[nodiscard]] bool
+  operator==( const InputPreferences & other ) const
+  {
+    return this->subtrees == other.subtrees;
+  }
+
+  [[nodiscard]] bool
+  operator!=( const InputPreferences & other ) const
+  {
+    return ! ( ( *this ) == other );
+  }
+
 
 }; /* End struct `InputPreferences' */
 
@@ -147,6 +159,31 @@ struct RegistryInput : public InputPreferences
   {
     return static_cast<nix::ref<nix::FlakeRef>>( this->from );
   };
+
+  [[nodiscard]] bool
+  operator==( const RegistryInput & other ) const
+  {
+    if ( static_cast<InputPreferences>( *this )
+         != static_cast<InputPreferences>( other ) )
+      {
+        return false;
+      }
+
+    if ( this->from == other.from ) { return true; }
+
+    if ( ( this->from == nullptr ) || ( other.from == nullptr ) )
+      {
+        return false;
+      }
+
+    return this->from->to_string() != other.from->to_string();
+  }
+
+  [[nodiscard]] bool
+  operator!=( const RegistryInput & other ) const
+  {
+    return ! ( ( *this ) == other );
+  }
 
 
 }; /* End struct `RegistryInput' */
@@ -359,6 +396,15 @@ struct RegistryRaw
    */
   void
   merge( const RegistryRaw & overrides );
+
+  [[nodiscard]] bool
+  operator==( const RegistryRaw & other ) const;
+
+  [[nodiscard]] bool
+  operator!=( const RegistryRaw & other ) const
+  {
+    return ! ( *this == other );
+  }
 
 
 }; /* End struct `RegistryRaw' */

--- a/include/flox/resolver/command.hh
+++ b/include/flox/resolver/command.hh
@@ -24,7 +24,7 @@ namespace flox::resolver {
 /* -------------------------------------------------------------------------- */
 
 /** @brief Lock a manifest file. */
-class LockCommand : public EnvironmentMixin
+class LockCommand : public GAEnvironmentMixin
 {
 
 private:

--- a/include/flox/resolver/manifest-raw.hh
+++ b/include/flox/resolver/manifest-raw.hh
@@ -386,7 +386,7 @@ struct GlobalManifestRawGA
   GlobalManifestRawGA( const GlobalManifestRawGA & ) = default;
   GlobalManifestRawGA( GlobalManifestRawGA && )      = default;
 
-  GlobalManifestRawGA( std::optional<Options> options )
+  explicit GlobalManifestRawGA( std::optional<Options> options )
     : options( std::move( options ) )
   {}
 
@@ -528,11 +528,11 @@ struct ManifestRawGA : public GlobalManifestRawGA
 
   explicit operator ManifestRaw() const
   {
-    ManifestRaw raw( static_cast<GlobalManifestRaw>(
-      static_cast<GlobalManifestRawGA>( *this ) ) );
-    raw.install = this->install;
-    raw.vars    = this->vars;
-    raw.hook    = this->hook;
+    ManifestRaw raw;
+    raw.registry = getGARegistry();
+    raw.install  = this->install;
+    raw.vars     = this->vars;
+    raw.hook     = this->hook;
     return raw;
   }
 

--- a/include/flox/resolver/manifest-raw.hh
+++ b/include/flox/resolver/manifest-raw.hh
@@ -36,6 +36,16 @@ namespace flox::resolver {
 
 /* -------------------------------------------------------------------------- */
 
+/* Forward Declarations */
+
+struct GlobalManifestRaw;
+struct ManifestRaw;
+struct GlobalManifestRawGA;
+struct ManifestRawGA;
+
+
+/* -------------------------------------------------------------------------- */
+
 /**
  * @class flox::resolver::InvalidManifestFileException
  * @brief An exception thrown when a manifest file is invalid.
@@ -163,6 +173,8 @@ struct GlobalManifestRaw
     this->registry = std::nullopt;
     this->options  = std::nullopt;
   }
+
+  explicit operator GlobalManifestRawGA() const;
 
 
 }; /* End struct `GlobalManifestRaw' */
@@ -331,6 +343,8 @@ struct ManifestRaw : public GlobalManifestRaw
   nlohmann::json
   diff( const ManifestRaw & old ) const;
 
+  explicit operator ManifestRawGA() const;
+
 
 }; /* End struct `ManifestRaw' */
 
@@ -372,6 +386,10 @@ struct GlobalManifestRawGA
   GlobalManifestRawGA( const GlobalManifestRawGA & ) = default;
   GlobalManifestRawGA( GlobalManifestRawGA && )      = default;
 
+  GlobalManifestRawGA( std::optional<Options> options )
+    : options( std::move( options ) )
+  {}
+
   GlobalManifestRawGA &
   operator=( const GlobalManifestRawGA & )
     = default;
@@ -392,6 +410,16 @@ struct GlobalManifestRawGA
   clear()
   {
     this->options = std::nullopt;
+  }
+
+  explicit operator GlobalManifestRaw() const
+  {
+    return GlobalManifestRaw( getGARegistry(), this->options );
+  }
+
+  explicit operator ManifestRaw() const
+  {
+    return ManifestRaw( static_cast<GlobalManifestRaw>( *this ) );
   }
 
 
@@ -497,6 +525,16 @@ struct ManifestRawGA : public GlobalManifestRawGA
    */
   nlohmann::json
   diff( const ManifestRawGA & old ) const;
+
+  explicit operator ManifestRaw() const
+  {
+    ManifestRaw raw( static_cast<GlobalManifestRaw>(
+      static_cast<GlobalManifestRawGA>( *this ) ) );
+    raw.install = this->install;
+    raw.vars    = this->vars;
+    raw.hook    = this->hook;
+    return raw;
+  }
 
 
 }; /* End struct `ManifestRawGA' */

--- a/include/flox/resolver/mixins.hh
+++ b/include/flox/resolver/mixins.hh
@@ -238,7 +238,7 @@ public:
    * If @a manifest is unset, but @a manifestPath is set then
    * load from the file.
    */
-  [[nodiscard]] virtual const EnvironmentManifest &
+  [[nodiscard]] const EnvironmentManifest &
   getManifest();
 
   /** @brief Get the filesystem path to the lockfile ( if any ). */
@@ -266,7 +266,7 @@ public:
    * After @a getEnvironment() has been called once, it is no longer possible
    * to use any `init*( MEMBER )` functions.
    */
-  [[nodiscard]] Environment &
+  [[nodiscard]] virtual Environment &
   getEnvironment();
 
   /**
@@ -359,6 +359,16 @@ protected:
    */
   void
   initManifest( ManifestRaw manifestRaw ) override;
+
+  /**
+   * @brief Lazily initialize and return the @a globalManifest.
+   *
+   * If @a globalManifest is set simply return it.
+   * If @a globalManifest is unset, but @a globalManifestPath is set then
+   * load from the file.
+   */
+  [[nodiscard]] const std::optional<GlobalManifest> &
+  getGlobalManifest() override;
 
 
 public:

--- a/include/flox/resolver/mixins.hh
+++ b/include/flox/resolver/mixins.hh
@@ -404,6 +404,16 @@ public:
   argparse::Argument &
   addGARegistryOption( argparse::ArgumentParser & parser );
 
+  /**
+   * @brief Lazily initialize and return the @a globalManifest.
+   *
+   * If @a globalManifest is set simply return it.
+   * If @a globalManifest is unset, but @a globalManifestPath is set then
+   * load from the file.
+   */
+  [[nodiscard]] const std::optional<GlobalManifest> &
+  getGlobalManifest() override;
+
 
 }; /* End class `GAEnvironmentMixin' */
 

--- a/include/flox/resolver/mixins.hh
+++ b/include/flox/resolver/mixins.hh
@@ -120,7 +120,8 @@ protected:
   initGlobalManifest( GlobalManifestRaw manifestRaw );
 
   /**
-   * @brief Initialize the @a globalManifest member variable.
+   * @brief Initialize the @a globalManifest member variable by reading from
+   *        a path.
    *
    * This may only be called once and must be called before
    * `getEnvironment()` is ever used - otherwise an exception will be thrown.
@@ -129,8 +130,8 @@ protected:
    * @a flox::resolver::EnvirontMixin base at runtime without accessing
    * private member variables.
    */
-  void
-  initGlobalManifest( GlobalManifest manifest );
+  virtual void
+  initGlobalManifest( std::filesystem::path path );
 
   /**
    * @brief Initialize the @a manifestPath member variable.
@@ -159,7 +160,7 @@ protected:
   initManifest( ManifestRaw manifestRaw );
 
   /**
-   * @brief Initialize the @a manifest member variable.
+   * @brief Initialize the @a manifest member variable by reading from a path.
    *
    * This may only be called once and must be called before
    * `getEnvironment()` is ever used - otherwise an exception will be thrown.
@@ -168,8 +169,8 @@ protected:
    * @a flox::resolver::EnvirontMixin base at runtime without accessing
    * private member variables.
    */
-  void
-  initManifest( EnvironmentManifest manifest );
+  virtual void
+  initManifest( std::filesystem::path path );
 
   /**
    * @brief Initialize the @a lockfilePath member variable.
@@ -346,6 +347,22 @@ protected:
   initGlobalManifest( GlobalManifestRaw manifestRaw ) override;
 
   /**
+   * @brief Initialize the @a globalManifest member variable by reading from
+   *        a path.
+   *        This form enforces `--ga-registry` by disallowing `registry` in its
+   *        input, and injecting a hard coded `registry`.
+   *
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
+   */
+  void
+  initGlobalManifest( std::filesystem::path path ) override;
+
+  /**
    * @brief Initialize the @a manifest member variable.
    *        This form enforces `--ga-registry` by disallowing `registry` in its
    *        input, and injecting a hard coded `registry`.
@@ -361,14 +378,19 @@ protected:
   initManifest( ManifestRaw manifestRaw ) override;
 
   /**
-   * @brief Lazily initialize and return the @a globalManifest.
+   * @brief Initialize the @a manifest member variable by reading from a path.
+   *        This form enforces `--ga-registry` by disallowing `registry` in its
+   *        input, and injecting a hard coded `registry`.
    *
-   * If @a globalManifest is set simply return it.
-   * If @a globalManifest is unset, but @a globalManifestPath is set then
-   * load from the file.
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
    */
-  [[nodiscard]] const std::optional<GlobalManifest> &
-  getGlobalManifest() override;
+  void
+  initManifest( std::filesystem::path path ) override;
 
 
 public:

--- a/src/registry.cc
+++ b/src/registry.cc
@@ -376,11 +376,18 @@ lockRegistry( const RegistryRaw & unlocked, const nix::ref<nix::Store> & store )
 RegistryRaw
 getGARegistry()
 {
+  static const std::string refOrRev
+    = nix::getEnv( "_PKGDB_GA_REGISTRY_REF_OR_REV" )
+        .value_or( "release-23.05" );
   static const nix::FlakeRef nixpkgsRef
-    = nlohmann::json { { "type", "github" },
-                       { "owner", "NixOS" },
-                       { "repo", "nixpkgs" },
-                       { "ref", "release-23.05" } };
+    = nix::parseFlakeRef( "github:NixOS/nixpkgs/" + refOrRev );
+  if ( nix::lvlTalkative < nix::verbosity )
+    {
+      nix::logger->log( nix::lvlTalkative,
+                        "GA Registry is using `nixpkgs' as `"
+                        + nixpkgsRef.to_string() + "'."
+                      );
+    }
   return RegistryRaw(
     std::map<std::string, RegistryInput> {
       { "nixpkgs",

--- a/src/registry.cc
+++ b/src/registry.cc
@@ -385,8 +385,7 @@ getGARegistry()
     {
       nix::logger->log( nix::lvlTalkative,
                         "GA Registry is using `nixpkgs' as `"
-                        + nixpkgsRef.to_string() + "'."
-                      );
+                          + nixpkgsRef.to_string() + "'." );
     }
   return RegistryRaw(
     std::map<std::string, RegistryInput> {

--- a/src/registry.cc
+++ b/src/registry.cc
@@ -391,6 +391,28 @@ getGARegistry()
 
 /* -------------------------------------------------------------------------- */
 
+bool
+RegistryRaw::operator==( const RegistryRaw & other ) const
+{
+  if ( this->priority != other.priority ) { return false; }
+  if ( this->defaults != other.defaults ) { return false; }
+  for ( const auto & [key, value] : this->inputs )
+    {
+      try
+        {
+          if ( other.inputs.at( key ) != value ) { return false; }
+        }
+      catch ( ... )
+        {
+          return false;
+        }
+    }
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 }  // namespace flox
 
 

--- a/src/resolver/command.cc
+++ b/src/resolver/command.cc
@@ -26,6 +26,7 @@ LockCommand::LockCommand() : parser( "lock" )
   this->addGlobalManifestFileOption( this->parser );
   this->addManifestFileArg( this->parser );
   this->addLockfileOption( this->parser );
+  this->addGARegistryOption( this->parser );
 }
 
 

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -55,8 +55,8 @@ Environment::getCombinedRegistryRaw()
     {
       if ( this->globalManifest.has_value() )
         {
-          this->combinedRegistryRaw = this->globalManifest->getRegistryRaw();
-          this->combinedRegistryRaw.value().merge(
+          this->combinedRegistryRaw = this->globalManifest->getLockedRegistry();
+          this->combinedRegistryRaw->merge(
             this->manifest.getLockedRegistry() );
         }
       else { this->combinedRegistryRaw = this->manifest.getLockedRegistry(); }

--- a/src/resolver/manifest-raw.cc
+++ b/src/resolver/manifest-raw.cc
@@ -343,6 +343,20 @@ to_json( nlohmann::json & jto, const Options & opts )
 
 /* -------------------------------------------------------------------------- */
 
+GlobalManifestRaw::operator GlobalManifestRawGA() const
+{
+  if ( this->registry.has_value()
+       && ( ( *this->registry ) != getGARegistry() ) )
+    {
+      throw InvalidManifestFileException(
+        "global manifest `registry' does not match the GA registry" );
+    }
+  return GlobalManifestRawGA( this->options );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 void
 from_json( const nlohmann::json & jfrom, GlobalManifestRaw & manifest )
 {
@@ -546,6 +560,19 @@ varsFromJSON( const nlohmann::json &                         jfrom,
         }
       vars.emplace( key, std::move( val ) );
     }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+ManifestRaw::operator ManifestRawGA() const
+{
+  ManifestRawGA raw( static_cast<GlobalManifestRawGA>(
+    static_cast<GlobalManifestRaw>( *this ) ) );
+  raw.install = this->install;
+  raw.vars    = this->vars;
+  raw.hook    = this->hook;
+  return raw;
 }
 
 

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -130,6 +130,7 @@ EnvironmentMixin::getGlobalManifestPath() const
 
 /* -------------------------------------------------------------------------- */
 
+// FIXME: Use `initGlobalManifest'
 const std::optional<GlobalManifest> &
 EnvironmentMixin::getGlobalManifest()
 {
@@ -153,6 +154,7 @@ EnvironmentMixin::getManifestPath() const
 
 /* -------------------------------------------------------------------------- */
 
+// FIXME: Use `initManifest'
 const EnvironmentManifest &
 EnvironmentMixin::getManifest()
 {
@@ -346,6 +348,20 @@ GAEnvironmentMixin::initManifest( ManifestRaw manifestRaw )
       manifestRaw.registry = getGARegistry();
     }
   this->EnvironmentMixin::initManifest( std::move( manifestRaw ) );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+const std::optional<GlobalManifest> &
+GAEnvironmentMixin::getGlobalManifest()
+{
+  if ( ( ! this->EnvironmentMixin::getGlobalManifest().has_value() )
+       && this->gaRegistry )
+    {
+      this->initGlobalManifest( GlobalManifestRaw() );
+    }
+  return this->EnvironmentMixin::getGlobalManifest();
 }
 
 

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -88,10 +88,7 @@ void
 EnvironmentMixin::initManifest( std::filesystem::path path )
 {
   ENV_MIXIN_THROW_IF_SET( manifest )
-  if ( ! this->manifestPath.has_value() )
-    {
-      this->globalManifestPath = path;
-    }
+  if ( ! this->manifestPath.has_value() ) { this->globalManifestPath = path; }
   this->manifest = EnvironmentManifest( std::move( path ) );
 }
 
@@ -144,7 +141,7 @@ EnvironmentMixin::getGlobalManifest()
   if ( ( ! this->globalManifest.has_value() )
        && this->globalManifestPath.has_value() )
     {
-      this->initGlobalManifest( * this->globalManifestPath );
+      this->initGlobalManifest( *this->globalManifestPath );
     }
   return this->globalManifest;
 }
@@ -351,10 +348,7 @@ GAEnvironmentMixin::initGlobalManifest( std::filesystem::path path )
       manifestRaw.registry = manifest.getRegistryRaw();
       this->EnvironmentMixin::initGlobalManifest( std::move( manifestRaw ) );
     }
-  else
-    {
-      this->EnvironmentMixin::initGlobalManifest( std::move( path ) );
-    }
+  else { this->EnvironmentMixin::initGlobalManifest( std::move( path ) ); }
 }
 
 
@@ -388,10 +382,7 @@ GAEnvironmentMixin::initManifest( std::filesystem::path path )
       manifestRaw.registry = manifest.getRegistryRaw();
       this->EnvironmentMixin::initManifest( std::move( manifestRaw ) );
     }
-  else
-    {
-      this->EnvironmentMixin::initManifest( std::move( path ) );
-    }
+  else { this->EnvironmentMixin::initManifest( std::move( path ) ); }
 }
 
 

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -138,7 +138,6 @@ EnvironmentMixin::getGlobalManifestPath() const
 
 /* -------------------------------------------------------------------------- */
 
-// FIXME: Use `initGlobalManifest'
 const std::optional<GlobalManifest> &
 EnvironmentMixin::getGlobalManifest()
 {
@@ -173,7 +172,7 @@ EnvironmentMixin::getManifest()
             "you must provide an inline manifest or the path to a manifest "
             "file" );
         }
-      this->manifest = EnvironmentManifest( *this->manifestPath );
+      this->initManifest( *this->manifestPath );
     }
   return *this->manifest;
 }
@@ -343,6 +342,25 @@ GAEnvironmentMixin::initGlobalManifest( GlobalManifestRaw manifestRaw )
 /* -------------------------------------------------------------------------- */
 
 void
+GAEnvironmentMixin::initGlobalManifest( std::filesystem::path path )
+{
+  if ( this->gaRegistry )
+    {
+      GlobalManifestGA  manifest( std::move( path ) );
+      GlobalManifestRaw manifestRaw( manifest.getManifestRaw() );
+      manifestRaw.registry = manifest.getRegistryRaw();
+      this->EnvironmentMixin::initGlobalManifest( std::move( manifestRaw ) );
+    }
+  else
+    {
+      this->EnvironmentMixin::initGlobalManifest( std::move( path ) );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
 GAEnvironmentMixin::initManifest( ManifestRaw manifestRaw )
 {
   if ( this->gaRegistry )
@@ -355,6 +373,25 @@ GAEnvironmentMixin::initManifest( ManifestRaw manifestRaw )
       manifestRaw.registry = getGARegistry();
     }
   this->EnvironmentMixin::initManifest( std::move( manifestRaw ) );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+GAEnvironmentMixin::initManifest( std::filesystem::path path )
+{
+  if ( this->gaRegistry )
+    {
+      EnvironmentManifestGA manifest( std::move( path ) );
+      ManifestRaw           manifestRaw( manifest.getManifestRaw() );
+      manifestRaw.registry = manifest.getRegistryRaw();
+      this->EnvironmentMixin::initManifest( std::move( manifestRaw ) );
+    }
+  else
+    {
+      this->EnvironmentMixin::initManifest( std::move( path ) );
+    }
 }
 
 

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -57,17 +57,21 @@ EnvironmentMixin::initGlobalManifestPath( std::filesystem::path path )
 }
 
 void
+EnvironmentMixin::initGlobalManifest( std::filesystem::path path )
+{
+  ENV_MIXIN_THROW_IF_SET( globalManifest )
+  if ( ! this->globalManifestPath.has_value() )
+    {
+      this->globalManifestPath = path;
+    }
+  this->globalManifest = GlobalManifest( std::move( path ) );
+}
+
+void
 EnvironmentMixin::initGlobalManifest( GlobalManifestRaw manifestRaw )
 {
   ENV_MIXIN_THROW_IF_SET( globalManifest )
   this->globalManifest = GlobalManifest( std::move( manifestRaw ) );
-}
-
-void
-EnvironmentMixin::initGlobalManifest( GlobalManifest manifest )
-{
-  ENV_MIXIN_THROW_IF_SET( globalManifest )
-  this->globalManifest = std::move( manifest );
 }
 
 
@@ -81,17 +85,21 @@ EnvironmentMixin::initManifestPath( std::filesystem::path path )
 }
 
 void
+EnvironmentMixin::initManifest( std::filesystem::path path )
+{
+  ENV_MIXIN_THROW_IF_SET( manifest )
+  if ( ! this->manifestPath.has_value() )
+    {
+      this->globalManifestPath = path;
+    }
+  this->manifest = EnvironmentManifest( std::move( path ) );
+}
+
+void
 EnvironmentMixin::initManifest( ManifestRaw manifestRaw )
 {
   ENV_MIXIN_THROW_IF_SET( manifest )
   this->manifest = EnvironmentManifest( std::move( manifestRaw ) );
-}
-
-void
-EnvironmentMixin::initManifest( EnvironmentManifest manifest )
-{
-  ENV_MIXIN_THROW_IF_SET( manifest )
-  this->manifest = std::move( manifest );
 }
 
 
@@ -137,7 +145,7 @@ EnvironmentMixin::getGlobalManifest()
   if ( ( ! this->globalManifest.has_value() )
        && this->globalManifestPath.has_value() )
     {
-      this->globalManifest = GlobalManifest( *this->globalManifestPath );
+      this->initGlobalManifest( * this->globalManifestPath );
     }
   return this->globalManifest;
 }
@@ -154,7 +162,6 @@ EnvironmentMixin::getManifestPath() const
 
 /* -------------------------------------------------------------------------- */
 
-// FIXME: Use `initManifest'
 const EnvironmentManifest &
 EnvironmentMixin::getManifest()
 {

--- a/tests/data/manifest/global-manifest0.toml
+++ b/tests/data/manifest/global-manifest0.toml
@@ -1,3 +1,9 @@
+[registry.inputs.nixpkgs.from]
+type = "github"
+owner = "NixOS"
+repo = "nixpkgs"
+rev = "e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+
 [options.allow]
 # Whether non-FOSS packages should appear in search/install results.
 unfree = true

--- a/tests/ga-registry.bats
+++ b/tests/ga-registry.bats
@@ -138,6 +138,42 @@ setup_file() {
 
 
 # ---------------------------------------------------------------------------- #
+
+# bats test_tags=manifest:ga-registry, lock:ga-registry, manifest:global
+
+@test "'pkgdb manifest lock --ga-registry' merges global manifest options" {
+  run $PKGDB manifest lock --ga-registry                               \
+                           --global-manifest "$TDATA/global-ga0.toml"  \
+                           "$TDATA/ga0.toml";
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=manifest:ga-registry, lock:ga-registry, manifest:global
+
+@test "'pkgdb manifest lock --ga-registry' rejects global manifest registry" {
+  run $PKGDB manifest lock --ga-registry                                     \
+                           --global-manifest "$TDATA/global-manifest0.toml"  \
+                           "$TDATA/ga0.toml";
+  assert_failure;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=manifest:ga-registry, lock:ga-registry
+
+@test "'pkgdb manifest lock --ga-registry' rejects env manifest registry" {
+  run $PKGDB manifest lock --ga-registry                               \
+                           --global-manifest "$TDATA/global-ga0.toml"  \
+                           "$TDATA/post-ga0.toml";
+  assert_failure;
+}
+
+
+# ---------------------------------------------------------------------------- #
 #
 #
 #

--- a/tests/ga-registry.bats
+++ b/tests/ga-registry.bats
@@ -56,7 +56,7 @@ setup_file() {
 # Ensure that the search command succeeds with the `--ga-registry' option and
 # no other registry.
 @test "'pkgdb search --ga-registry' provides 'global-manifest'" {
-  run sh -c "$PKGDB search --ga-registry --pname hello|wc -l";
+  run --separate-stderr sh -c "$PKGDB search --ga-registry --pname hello|wc -l";
   assert_success;
   assert_output 1;
 }

--- a/tests/ga-registry.bats
+++ b/tests/ga-registry.bats
@@ -1,0 +1,72 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# `pkgdb search' tests.
+#
+# ---------------------------------------------------------------------------- #
+
+load setup_suite.bash;
+
+# bats file_tags=search
+
+setup_file() {
+  export TDATA="$TESTS_DIR/data/search";
+
+  # We don't parallelize these to avoid DB sync headaches and to recycle the
+  # cache between tests.
+  # Nonetheless this file makes an effort to avoid depending on past state in
+  # such a way that would make it difficult to eventually parallelize in
+  # the future.
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true;
+
+  # Change the rev used for the `--ga-registry' flag to align with our cached
+  # revision used by other tests.
+  # This is both an optimization and a way to ensure consistency of test output.
+  export _PKGDB_GA_REGISTRY_REF_OR_REV="$NIXPKGS_REV";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=search:ga-registry
+
+# Assert that the search command accepts the `--ga-registry' options.
+@test "'pkgdb search --help' has '--ga-registry'" {
+  run $PKGDB search --help;
+  assert_success;
+  assert_output --partial "--ga-registry";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=search:ga-registry
+
+# Ensure that the search command succeeds with the `--ga-registry' option and
+# no other registry.
+@test "'pkgdb search --ga-registry' provides 'global-manifest'" {
+  run sh -c "$PKGDB search --ga-registry --pname hello|wc -l";
+  assert_success;
+  assert_output 1;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=search:ga-registry
+
+# Ensure that the search command with `--ga-registry' option uses
+# `_PKGDB_GA_REGISTRY_REF_OR_REV' as the `nixpkgs' revision.
+@test "'pkgdb search --ga-registry' uses '_PKGDB_GA_REGISTRY_REF_OR_REV'" {
+  run sh -c "$PKGDB search --ga-registry --pname hello -vv 2>&1 >/dev/null";
+  assert_success;
+  assert_output --partial "$NIXPKGS_REF";
+}
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/tests/ga-registry.bats
+++ b/tests/ga-registry.bats
@@ -31,9 +31,19 @@ setup_file() {
 
 # bats test_tags=search:ga-registry
 
-# Assert that the search command accepts the `--ga-registry' options.
 @test "'pkgdb search --help' has '--ga-registry'" {
   run $PKGDB search --help;
+  assert_success;
+  assert_output --partial "--ga-registry";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=manifest:ga-registry, lock:ga-registry
+
+@test "'pkgdb manifest lock --help' has '--ga-registry'" {
+  run $PKGDB manifest lock --help;
   assert_success;
   assert_output --partial "--ga-registry";
 }
@@ -113,6 +123,16 @@ setup_file() {
     \"global-manifest\": { \"options\": { \"allow\": { \"unfree\": true } } },
     \"query\": { \"pname\": \"hello\" }
   }";
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=manifest:ga-registry, lock:ga-registry
+
+@test "'pkgdb manifest lock --ga-registry' provides registry" {
+  run $PKGDB manifest lock --ga-registry "$TDATA/ga0.toml";
   assert_success;
 }
 

--- a/tests/ga-registry.bats
+++ b/tests/ga-registry.bats
@@ -11,7 +11,7 @@ load setup_suite.bash;
 # bats file_tags=search
 
 setup_file() {
-  export TDATA="$TESTS_DIR/data/search";
+  export TDATA="$TESTS_DIR/data/manifest";
 
   # We don't parallelize these to avoid DB sync headaches and to recycle the
   # cache between tests.
@@ -62,6 +62,58 @@ setup_file() {
   run sh -c "$PKGDB search --ga-registry --pname hello -vv 2>&1 >/dev/null";
   assert_success;
   assert_output --partial "$NIXPKGS_REF";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=search:ga-registry, manifest:ga-registry
+
+@test "'pkgdb search --ga-registry' disallows 'registry' in manifests" {
+  run $PKGDB search --ga-registry "{
+    \"manifest\": { \"registry\": {} },
+    \"query\": { \"pname\": \"hello\" }
+  }";
+  assert_failure;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=search:ga-registry, manifest:ga-registry
+
+@test "'pkgdb search --ga-registry' disallows 'registry' in global manifests" {
+  run $PKGDB search --ga-registry "{
+    \"global-manifest\": { \"registry\": {} },
+    \"query\": { \"pname\": \"hello\" }
+  }";
+  assert_failure;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=search:ga-registry, manifest:ga-registry
+
+@test "'pkgdb search --ga-registry' allows 'options' in manifests" {
+  run $PKGDB search --ga-registry "{
+    \"manifest\": { \"options\": { \"allow\": { \"unfree\": true } } },
+    \"query\": { \"pname\": \"hello\" }
+  }";
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=search:ga-registry, manifest:ga-registry
+
+@test "'pkgdb search --ga-registry' allows 'options' in global manifests" {
+  run $PKGDB search --ga-registry "{
+    \"global-manifest\": { \"options\": { \"allow\": { \"unfree\": true } } },
+    \"query\": { \"pname\": \"hello\" }
+  }";
+  assert_success;
 }
 
 

--- a/tests/registry.cc
+++ b/tests/registry.cc
@@ -13,9 +13,9 @@
 
 #include <nlohmann/json.hpp>
 
+#include "flox/core/util.hh"
 #include "flox/registry.hh"
 #include "flox/resolver/manifest.hh"
-#include "flox/core/util.hh"
 #include "test.hh"
 
 
@@ -63,10 +63,10 @@ bool
 test_merge_vecs()
 {
   std::vector<std::string> highPriority = { "a", "b", "c" };
-  std::vector<std::string> lowPriority = { "a", "d", "e" };
-  std::vector<std::string> expected = { "a", "b", "c", "d", "e" };
-  auto merged = flox::merge_vectors(lowPriority, highPriority);
-  EXPECT(merged == expected);
+  std::vector<std::string> lowPriority  = { "a", "d", "e" };
+  std::vector<std::string> expected     = { "a", "b", "c", "d", "e" };
+  auto merged = flox::merge_vectors( lowPriority, highPriority );
+  EXPECT( merged == expected );
   return true;
 }
 

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -114,12 +114,13 @@ misc_vars_setup() {
 
   export _PKGDB_TEST_SUITE_MODE=:;
 
-  NIXPKGS_REF="github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1";
+  NIXPKGS_REV="e8039594435c68eb4f780f3e9bf3972a7399c4b1";
+  NIXPKGS_REF="github:NixOS/nixpkgs/$NIXPKGS_REV";
 
   NIXPKGS_FINGERPRINT="5fde12e3424840cc2752dae09751b09b03f5a33"
   NIXPKGS_FINGERPRINT="${NIXPKGS_FINGERPRINT}c3ec4de672fc89d236720bdc7";
 
-  export NIXPKGS_REF NIXPKGS_FINGERPRINT;
+  export NIXPKGS_REV NIXPKGS_REF NIXPKGS_FINGERPRINT;
 
   export __PD_RAN_MISC_VARS_SETUP=:;
 }
@@ -133,6 +134,7 @@ env_setup() {
   misc_vars_setup;
   {
     print_var NIX_SYSTEM;
+    print_var NIXPKGS_REV;
     print_var NIXPKGS_REF;
   } >&3;
 }


### PR DESCRIPTION
- Adds equality ops for Registry and conversions for manifest <--> GA types
- Adds `installFromJSON` helper
- Adds `_PKGDB_GA_REGISTRY_REF_OR_REV`
- Documents `--ga-registry`
- Adds `--ga-registry` support to `pkgdb manifest lock`
- Add `EnvionmentMixin::init[Global]Manifest` form paths
- Test cases for `--ga-registry`