### PR TITLE
feat: 'pkgdb manifest {update,registry}' subcommands

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -156,6 +156,15 @@
           alias gl='git pull';
           alias gp='git push';
 
+          # For running `pkgdb' interactively with inputs from the test suite.
+          NIXPKGS_TEST_REV="e8039594435c68eb4f780f3e9bf3972a7399c4b1";
+          NIXPKGS_TEST_REF="github:NixOS/nixpkgs/$NIXPKGS_TEST_REV";
+
+          # Find the project root and add the `bin' directory to `PATH'.
+          if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            PATH="$PATH:$( git rev-parse --show-toplevel; )/bin";
+          fi
+
           if [ -z "''${NO_WELCOME:-}" ]; then
             {
               echo "";

--- a/include/flox/resolver/command.hh
+++ b/include/flox/resolver/command.hh
@@ -100,14 +100,47 @@ public:
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief Show information about an environment's registries. */
+class RegistryCommand : public GAEnvironmentMixin
+{
+
+private:
+
+  command::VerboseParser parser;
+
+
+public:
+
+  RegistryCommand();
+
+  [[nodiscard]] command::VerboseParser &
+  getParser()
+  {
+    return this->parser;
+  }
+
+  /**
+   * @brief Execute the `registry` routine.
+   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+   */
+  int
+  run();
+
+
+}; /* End class `DiffCommand' */
+
+
+/* -------------------------------------------------------------------------- */
+
 class ManifestCommand
 {
 
 private:
 
-  command::VerboseParser parser;  /**< `manifest`      parser */
-  LockCommand            cmdLock; /**< `manifest lock` command */
-  DiffCommand            cmdDiff; /**< `manifest diff` command */
+  command::VerboseParser parser;      /**< `manifest`          parser */
+  LockCommand            cmdLock;     /**< `manifest lock`     command */
+  DiffCommand            cmdDiff;     /**< `manifest diff`     command */
+  RegistryCommand        cmdRegistry; /**< `manifest registry` command */
 
 
 public:

--- a/include/flox/resolver/command.hh
+++ b/include/flox/resolver/command.hh
@@ -100,6 +100,40 @@ public:
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief Update lockfile inputs. */
+class UpdateCommand : public GAEnvironmentMixin
+{
+
+private:
+
+  std::optional<std::string> inputName;
+
+  command::VerboseParser parser;
+
+
+public:
+
+  UpdateCommand();
+
+  [[nodiscard]] command::VerboseParser &
+  getParser()
+  {
+    return this->parser;
+  }
+
+  /**
+   * @brief Execute the `update` routine.
+   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+   */
+  int
+  run();
+
+
+}; /* End class `UpdateCommand' */
+
+
+/* -------------------------------------------------------------------------- */
+
 /** @brief Show information about an environment's registries. */
 class RegistryCommand : public GAEnvironmentMixin
 {
@@ -140,6 +174,7 @@ private:
   command::VerboseParser parser;      /**< `manifest`          parser */
   LockCommand            cmdLock;     /**< `manifest lock`     command */
   DiffCommand            cmdDiff;     /**< `manifest diff`     command */
+  UpdateCommand          cmdUpdate;   /**< `manifest update`   command */
   RegistryCommand        cmdRegistry; /**< `manifest registry` command */
 
 

--- a/include/flox/resolver/environment.hh
+++ b/include/flox/resolver/environment.hh
@@ -298,7 +298,6 @@ public:
     return this->oldLockfile;
   }
 
-  // TODO: Implement
   /**
    * @brief Get a merged form of @a oldLockfile ( if available ),
    *        @a globalManifest ( if available ) and @a manifest registries.

--- a/include/flox/resolver/lockfile.hh
+++ b/include/flox/resolver/lockfile.hh
@@ -83,8 +83,21 @@ struct LockedInputRaw
     return RegistryInput( static_cast<nix::FlakeRef>( *this ) );
   }
 
+  [[nodiscard]] bool
+  operator==( const LockedInputRaw & other ) const
+  {
+    return ( this->fingerprint == other.fingerprint )
+           && ( this->url == other.url ) && ( this->attrs == other.attrs );
+  }
 
-}; /* End struct `LockedInputRaw::Input' */
+  [[nodiscard]] bool
+  operator!=( const LockedInputRaw & other ) const
+  {
+    return ! ( ( *this ) == other );
+  }
+
+
+}; /* End struct `LockedInputRaw' */
 
 
 /* -------------------------------------------------------------------------- */
@@ -100,14 +113,39 @@ to_json( nlohmann::json & jto, const LockedInputRaw & raw );
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief Print a locked input's to an output stream as a JSON object. */
+std::ostream &
+operator<<( std::ostream & oss, const LockedInputRaw & raw );
+
+
+/* -------------------------------------------------------------------------- */
+
 /** @brief A locked package's _installable URI_. */
 struct LockedPackageRaw
 {
+
   LockedInputRaw input;
   AttrPath       attrPath;
   unsigned       priority;
   nlohmann::json info; /* pname, version, license */
-};                     /* End struct `LockedPackageRaw' */
+
+  [[nodiscard]] bool
+  operator==( const LockedPackageRaw & other ) const
+  {
+    return ( this->input == other.input )
+           && ( this->attrPath == other.attrPath )
+           && ( this->priority == other.priority )
+           && ( this->info == other.info );
+  }
+
+  [[nodiscard]] bool
+  operator!=( const LockedPackageRaw & other ) const
+  {
+    return ! ( ( *this ) == other );
+  }
+
+
+}; /* End struct `LockedPackageRaw' */
 
 
 /* -------------------------------------------------------------------------- */
@@ -119,6 +157,13 @@ from_json( const nlohmann::json & jfrom, LockedPackageRaw & raw );
 /** @brief Convert a @a flox::resolver::LockedPackageRaw to a JSON object. */
 void
 to_json( nlohmann::json & jto, const LockedPackageRaw & raw );
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Print a locked package to an output stream as a JSON object. */
+std::ostream &
+operator<<( std::ostream & oss, const LockedPackageRaw & raw );
 
 
 /* -------------------------------------------------------------------------- */

--- a/include/flox/resolver/lockfile.hh
+++ b/include/flox/resolver/lockfile.hh
@@ -352,6 +352,16 @@ public:
     return this->packagesRegistryRaw;
   }
 
+  /**
+   * @brief Drop any `registry.inputs` and `registry.priority` members that are
+   *        not explicitly declared in the manifest `registry` or used by
+   *        resolved packages.
+   *
+   * @return The number of removed inputs.
+   */
+  std::size_t
+  removeUnusedInputs();
+
 
 }; /* End class `Lockfile' */
 

--- a/include/flox/resolver/manifest-raw.hh
+++ b/include/flox/resolver/manifest-raw.hh
@@ -530,6 +530,7 @@ struct ManifestRawGA : public GlobalManifestRawGA
   {
     ManifestRaw raw;
     raw.registry = getGARegistry();
+    raw.options  = this->options;
     raw.install  = this->install;
     raw.vars     = this->vars;
     raw.hook     = this->hook;

--- a/include/flox/resolver/mixins.hh
+++ b/include/flox/resolver/mixins.hh
@@ -94,7 +94,8 @@ private:
 protected:
 
   /**
-   * @brief Initialize the @a globalManifestPath member variable.
+   * @brief Initialize the @a globalManifestPath and @a globalManifest member
+   *        variables by reading from a file.
    *
    * This may only be called once and must be called before
    * `getEnvironment()` is ever used - otherwise an exception will be thrown.
@@ -103,8 +104,22 @@ protected:
    * @a flox::resolver::EnvirontMixin base at runtime without accessing
    * private member variables.
    */
-  void
+  virtual void
   initGlobalManifestPath( std::filesystem::path path );
+
+  /**
+   * @brief Manually set @a globalManifestPath without checking to see if it was
+   *        previously set, and do not initialize @manifest.
+   *
+   * This function exists so that child classes can override their
+   * @a flox::resolver::EnvirontMixin base @a globalManifestPath at runtime
+   * without accessing private member variables.
+   */
+  void
+  setGlobalManifestPath( std::optional<std::filesystem::path> maybePath )
+  {
+    this->globalManifestPath = std::move( maybePath );
+  }
 
   /**
    * @brief Initialize the @a globalManifest member variable.
@@ -120,8 +135,8 @@ protected:
   initGlobalManifest( GlobalManifestRaw manifestRaw );
 
   /**
-   * @brief Initialize the @a globalManifest member variable by reading from
-   *        a path.
+   * @brief Initialize the @a manifestPath and @a manifest member variables by
+   *        reading from a file.
    *
    * This may only be called once and must be called before
    * `getEnvironment()` is ever used - otherwise an exception will be thrown.
@@ -131,20 +146,21 @@ protected:
    * private member variables.
    */
   virtual void
-  initGlobalManifest( std::filesystem::path path );
+  initManifestPath( std::filesystem::path path );
 
   /**
-   * @brief Initialize the @a manifestPath member variable.
+   * @brief Manually set `manifestPath' without checking to see if it was
+   *        previously set, and do not initialize @manifest.
    *
-   * This may only be called once and must be called before
-   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
-   *
-   * This function exists so that child classes can initialize their
-   * @a flox::resolver::EnvirontMixin base at runtime without accessing
-   * private member variables.
+   * This function exists so that child classes can override their
+   * @a flox::resolver::EnvirontMixin base @a manifestPath at runtime without
+   * accessing private member variables.
    */
   void
-  initManifestPath( std::filesystem::path path );
+  setManifestPath( std::optional<std::filesystem::path> maybePath )
+  {
+    this->manifestPath = std::move( maybePath );
+  }
 
   /**
    * @brief Initialize the @a manifest member variable.
@@ -160,19 +176,6 @@ protected:
   initManifest( ManifestRaw manifestRaw );
 
   /**
-   * @brief Initialize the @a manifest member variable by reading from a path.
-   *
-   * This may only be called once and must be called before
-   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
-   *
-   * This function exists so that child classes can initialize their
-   * @a flox::resolver::EnvirontMixin base at runtime without accessing
-   * private member variables.
-   */
-  virtual void
-  initManifest( std::filesystem::path path );
-
-  /**
    * @brief Initialize the @a lockfilePath member variable.
    *
    * This may only be called once and must be called before
@@ -182,7 +185,7 @@ protected:
    * @a flox::resolver::EnvirontMixin base at runtime without accessing
    * private member variables.
    */
-  void
+  virtual void
   initLockfilePath( std::filesystem::path path );
 
   /**
@@ -195,28 +198,18 @@ protected:
    * @a flox::resolver::EnvirontMixin base at runtime without accessing
    * private member variables.
    */
-  void
+  virtual void
   initLockfile( LockfileRaw lockfileRaw );
-
-  /**
-   * @brief Initialize the @a lockfile member variable.
-   *
-   * This may only be called once and must be called before
-   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
-   *
-   * This function exists so that child classes can initialize their
-   * @a flox::resolver::EnvirontMixin base at runtime without accessing
-   * private member variables.
-   */
-  void
-  initLockfile( Lockfile lockfile );
 
 
 public:
 
   /** @brief Get the filesystem path to the global manifest ( if any ). */
   [[nodiscard]] const std::optional<std::filesystem::path> &
-  getGlobalManifestPath() const;
+  getGlobalManifestPath() const
+  {
+    return this->globalManifestPath;
+  }
 
   /**
    * @brief Lazily initialize and return the @a globalManifest.
@@ -226,11 +219,17 @@ public:
    * load from the file.
    */
   [[nodiscard]] virtual const std::optional<GlobalManifest> &
-  getGlobalManifest();
+  getGlobalManifest()
+  {
+    return this->globalManifest;
+  }
 
   /** @brief Get the filesystem path to the manifest ( if any ). */
   [[nodiscard]] const std::optional<std::filesystem::path> &
-  getManifestPath() const;
+  getManifestPath() const
+  {
+    return this->manifestPath;
+  }
 
   /**
    * @brief Lazily initialize and return the @a manifest.
@@ -244,7 +243,10 @@ public:
 
   /** @brief Get the filesystem path to the lockfile ( if any ). */
   [[nodiscard]] const std::optional<std::filesystem::path> &
-  getLockfilePath() const;
+  getLockfilePath() const
+  {
+    return this->lockfilePath;
+  }
 
   /**
    * @brief Lazily initialize and return the @a lockfile.
@@ -254,7 +256,10 @@ public:
    * load from the file.
    */
   [[nodiscard]] const std::optional<Lockfile> &
-  getLockfile();
+  getLockfile()
+  {
+    return this->lockfile;
+  }
 
   /**
    * @brief Laziliy initialize and return the @a environment.
@@ -332,6 +337,22 @@ private:
 protected:
 
   /**
+   * @brief Initialize the @a globalManifestPath and @a globalManifest member
+   *        variables by reading from a file.
+   *        This form enforces `--ga-registry` by disallowing `registry` in its
+   *        input, and injecting a hard coded `registry`.
+   *
+   * This may only be called once and must be called before
+   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
+   *
+   * This function exists so that child classes can initialize their
+   * @a flox::resolver::EnvirontMixin base at runtime without accessing
+   * private member variables.
+   */
+  void
+  initGlobalManifestPath( std::filesystem::path path ) override;
+
+  /**
    * @brief Initialize the @a globalManifest member variable.
    *        This form enforces `--ga-registry` by disallowing `registry` in its
    *        input, and injecting a hard coded `registry`.
@@ -347,8 +368,8 @@ protected:
   initGlobalManifest( GlobalManifestRaw manifestRaw ) override;
 
   /**
-   * @brief Initialize the @a globalManifest member variable by reading from
-   *        a path.
+   * @brief Initialize the @a manifestPath and @a manifest member variables by
+   *        reading from a file.
    *        This form enforces `--ga-registry` by disallowing `registry` in its
    *        input, and injecting a hard coded `registry`.
    *
@@ -360,7 +381,7 @@ protected:
    * private member variables.
    */
   void
-  initGlobalManifest( std::filesystem::path path ) override;
+  initManifestPath( std::filesystem::path path ) override;
 
   /**
    * @brief Initialize the @a manifest member variable.
@@ -376,21 +397,6 @@ protected:
    */
   void
   initManifest( ManifestRaw manifestRaw ) override;
-
-  /**
-   * @brief Initialize the @a manifest member variable by reading from a path.
-   *        This form enforces `--ga-registry` by disallowing `registry` in its
-   *        input, and injecting a hard coded `registry`.
-   *
-   * This may only be called once and must be called before
-   * `getEnvironment()` is ever used - otherwise an exception will be thrown.
-   *
-   * This function exists so that child classes can initialize their
-   * @a flox::resolver::EnvirontMixin base at runtime without accessing
-   * private member variables.
-   */
-  void
-  initManifest( std::filesystem::path path ) override;
 
 
 public:

--- a/include/flox/resolver/mixins.hh
+++ b/include/flox/resolver/mixins.hh
@@ -272,7 +272,7 @@ public:
    * After @a getEnvironment() has been called once, it is no longer possible
    * to use any `init*( MEMBER )` functions.
    */
-  [[nodiscard]] virtual Environment &
+  [[nodiscard]] Environment &
   getEnvironment();
 
   /**

--- a/src/resolver/command.cc
+++ b/src/resolver/command.cc
@@ -142,31 +142,32 @@ RegistryCommand::run()
 {
   nlohmann::json registries = {
     { "manifest", this->getEnvironment().getManifest().getRegistryRaw() },
-    { "manifest-locked", this->getEnvironment().getManifest().getLockedRegistry() },
+    { "manifest-locked",
+      this->getEnvironment().getManifest().getLockedRegistry() },
     { "combined", this->getEnvironment().getCombinedRegistryRaw() },
   };
 
   if ( auto maybeGlobal = this->getEnvironment().getGlobalManifest();
        maybeGlobal.has_value() )
     {
-      registries["global"] = maybeGlobal->getRegistryRaw();
+      registries["global"]        = maybeGlobal->getRegistryRaw();
       registries["global-locked"] = maybeGlobal->getLockedRegistry();
     }
   else
     {
-      registries["global"] = nullptr;
+      registries["global"]        = nullptr;
       registries["global-locked"] = nullptr;
     }
 
   if ( auto maybeLock = this->getEnvironment().getOldLockfile();
        maybeLock.has_value() )
     {
-      registries["lockfile"] = maybeLock->getRegistryRaw();
+      registries["lockfile"]          = maybeLock->getRegistryRaw();
       registries["lockfile-packages"] = maybeLock->getPackagesRegistryRaw();
     }
   else
     {
-      registries["lockfile"] = nullptr;
+      registries["lockfile"]          = nullptr;
       registries["lockfile-packages"] = nullptr;
     }
 

--- a/src/resolver/command.cc
+++ b/src/resolver/command.cc
@@ -24,9 +24,9 @@ LockCommand::LockCommand() : parser( "lock" )
 {
   this->parser.add_description( "Lock a manifest" );
   this->addGlobalManifestFileOption( this->parser );
-  this->addManifestFileArg( this->parser );
   this->addLockfileOption( this->parser );
   this->addGARegistryOption( this->parser );
+  this->addManifestFileArg( this->parser );
 }
 
 
@@ -125,13 +125,74 @@ DiffCommand::run()
 
 /* -------------------------------------------------------------------------- */
 
+UpdateCommand::UpdateCommand() : parser( "update" )
+{
+  this->parser.add_description( "Update environment inputs" );
+  this->addGlobalManifestFileOption( this->parser );
+  this->addLockfileOption( this->parser );
+  this->addGARegistryOption( this->parser );
+
+  this->parser.add_argument( "-i", "--input" )
+    .help( "name of input to update" )
+    .nargs( 1 )
+    .metavar( "NAME" )
+    .action( [&]( const std::string & inputName )
+             { this->inputName = inputName; } );
+
+  this->addManifestFileArg( this->parser );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+int
+UpdateCommand::run()
+{
+  if ( auto maybeLockfile = this->getLockfile(); maybeLockfile.has_value() )
+    {
+      auto lockedRaw = maybeLockfile->getLockfileRaw();
+      auto manifestRegistry
+        = this->getEnvironment().getManifest().getLockedRegistry();
+      if ( this->inputName.has_value() )
+        {
+          if ( const auto & maybeInput
+               = manifestRegistry.inputs.find( *this->inputName );
+               maybeInput != manifestRegistry.inputs.end() )
+            {
+              lockedRaw.registry.inputs[*this->inputName] = maybeInput->second;
+              lockedRaw.registry.defaults = manifestRegistry.defaults;
+              lockedRaw.registry.priority = manifestRegistry.priority;
+            }
+          else
+            {
+              throw FloxException( "input `" + *this->inputName
+                                   + "' does not exist in manifest." );
+            }
+        }
+      else { lockedRaw.registry = std::move( manifestRegistry ); }
+      std::cout << nlohmann::json( lockedRaw ).dump() << std::endl;
+    }
+  else
+    {
+      // TODO: `RegistryRaw' should drop empty fields.
+      nlohmann::json lockfile
+        = this->getEnvironment().createLockfile().getLockfileRaw();
+      /* Print that bad boii */
+      std::cout << lockfile.dump() << std::endl;
+    }
+  return EXIT_SUCCESS;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 RegistryCommand::RegistryCommand() : parser( "registry" )
 {
   this->parser.add_description( "Show environment registry information" );
   this->addGlobalManifestFileOption( this->parser );
-  this->addManifestFileArg( this->parser );
   this->addLockfileOption( this->parser );
   this->addGARegistryOption( this->parser );
+  this->addManifestFileArg( this->parser );
 }
 
 
@@ -184,6 +245,7 @@ ManifestCommand::ManifestCommand() : parser( "manifest" ), cmdLock(), cmdDiff()
   this->parser.add_subparser( this->cmdLock.getParser() );
   this->parser.add_subparser( this->cmdDiff.getParser() );
   this->parser.add_subparser( this->cmdRegistry.getParser() );
+  this->parser.add_subparser( this->cmdUpdate.getParser() );
 }
 
 
@@ -199,6 +261,10 @@ ManifestCommand::run()
   if ( this->parser.is_subcommand_used( "diff" ) )
     {
       return this->cmdDiff.run();
+    }
+  if ( this->parser.is_subcommand_used( "update" ) )
+    {
+      return this->cmdUpdate.run();
     }
   if ( this->parser.is_subcommand_used( "registry" ) )
     {

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -414,13 +414,13 @@ Environment::getGroupInput( const InstallDescriptors & group,
                 {
                   auto & [_, oldDescriptor] = *oldDescriptorPair;
                   /* At this point we know the same iid is both locked in the
-                   * old lockfile and present in the new manifest */
-
-                  /* Don't use a locked input if the package has changed.
+                   * old lockfile and present in the new manifest.
+                   *
+                   * Don't use a locked input if the package has changed.
                    * The * following fields control what the package actually
                    * *is*, * while:
                    * - `optional' and `systems' control how we behave if
-                   * resolution fails, but they don't change the package.
+                   *   resolution fails, but they don't change the package.
                    * - `priority' is a setting for mkEnv
                    * - `group' is handled below
                    */
@@ -440,10 +440,11 @@ Environment::getGroupInput( const InstallDescriptors & group,
                        * return this input below if we don't ever find a package
                        * with the correct group.
                        * If packages have come from multiple different wrong
-                       * groups, just return the first one we encounter. We
-                       * could come up with a better heuristic like most
-                       * packages or newest, or we could try resolving in all of
-                       * them. For now, don't get too fancy.
+                       * groups, just return the first one we encounter.
+                       * We could come up with a better heuristic like most
+                       * packages or newest, or we could try resolving in all
+                       * of them.
+                       * For now, don't get too fancy.
                        */
                       if ( ! wrongGroupInput.has_value() )
                         {

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -416,9 +416,9 @@ Environment::getGroupInput( const InstallDescriptors & group,
                   /* At this point we know the same iid is both locked in the
                    * old lockfile and present in the new manifest */
 
-                  /* Don't use a locked input if the package has changed. The
-                   * following fields control what the package actually *is*,
-                   * while:
+                  /* Don't use a locked input if the package has changed.
+                   * The * following fields control what the package actually
+                   * *is*, * while:
                    * - `optional' and `systems' control how we behave if
                    * resolution fails, but they don't change the package.
                    * - `priority' is a setting for mkEnv

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -633,15 +633,15 @@ Environment::createLockfile()
     {
       this->lockfileRaw           = LockfileRaw {};
       this->lockfileRaw->manifest = this->getManifestRaw();
-      // TODO: Once you figure out `getCombinedRegistryRaw' you might need to
-      //       remove some unused registry members.
       this->lockfileRaw->registry = this->getCombinedRegistryRaw();
       for ( const auto & system : this->getSystems() )
         {
           this->lockSystem( system );
         }
     }
-  return Lockfile( *this->lockfileRaw );
+  Lockfile lockfile( *this->lockfileRaw );
+  lockfile.removeUnusedInputs();
+  return lockfile;
 }
 
 

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -634,8 +634,7 @@ Environment::createLockfile()
       this->lockfileRaw->manifest = this->getManifestRaw();
       // TODO: Once you figure out `getCombinedRegistryRaw' you might need to
       //       remove some unused registry members.
-      this->lockfileRaw->registry
-        = this->getManifest().getLockedRegistry( this->getStore() );
+      this->lockfileRaw->registry = this->getCombinedRegistryRaw();
       for ( const auto & system : this->getSystems() )
         {
           this->lockSystem( system );

--- a/src/resolver/lockfile.cc
+++ b/src/resolver/lockfile.cc
@@ -9,6 +9,8 @@
  *
  * -------------------------------------------------------------------------- */
 
+#include <algorithm>
+
 #include <nix/hash.hh>
 
 #include "flox/core/util.hh"
@@ -424,6 +426,55 @@ to_json( nlohmann::json & jto, const LockfileRaw & raw )
           { "registry", raw.registry },
           { "packages", raw.packages },
           { "lockfile-version", raw.lockfileVersion } };
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::size_t
+Lockfile::removeUnusedInputs()
+{
+  /* Check to see if an input was declared in the manifest registry. */
+  auto inManifestRegistry = [&]( const std::string & name ) -> bool
+  {
+    const auto & maybeRegistry = this->getManifestRaw().registry;
+    return maybeRegistry.has_value() &&
+           ( maybeRegistry->inputs.find( name ) != maybeRegistry->inputs.end() );
+  };
+
+  /* Check to see if an input is used by a package. */
+  auto inPackagesRegistry = [&]( const std::string & url ) -> bool
+  {
+    for ( const auto & [name, input] : this->getPackagesRegistryRaw().inputs )
+      {
+        if ( input.from->to_string() == url ) { return true; }
+      }
+    return false;
+  };
+
+  /* Counts the number of removed inputs. */
+  std::size_t count = 0;
+
+  /* Remove. */
+  for ( auto elem = this->getRegistryRaw().inputs.begin(); elem
+        != this->getRegistryRaw().inputs.end(); )
+    {
+      if ( ( ! inManifestRegistry( elem->first ) ) &&
+           ( ! inPackagesRegistry( elem->second.from->to_string() ) ) )
+        {
+          std::remove( this->lockfileRaw.registry.priority.begin(),
+                       this->lockfileRaw.registry.priority.end(),
+                       elem->first );
+          this->lockfileRaw.registry.inputs.erase( elem->first );
+          ++count;
+        }
+      else
+        {
+          ++elem;
+        }
+    }
+
+  return count;
 }
 
 

--- a/src/resolver/lockfile.cc
+++ b/src/resolver/lockfile.cc
@@ -236,6 +236,15 @@ to_json( nlohmann::json & jto, const LockedInputRaw & raw )
 
 /* -------------------------------------------------------------------------- */
 
+std::ostream &
+operator<<( std::ostream & oss, const LockedInputRaw & raw )
+{
+  return oss << nlohmann::json( raw ).dump();
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 void
 from_json( const nlohmann::json & jfrom, LockedPackageRaw & raw )
 {
@@ -299,6 +308,15 @@ to_json( nlohmann::json & jto, const LockedPackageRaw & raw )
           { "attr-path", raw.attrPath },
           { "priority", raw.priority },
           { "info", raw.info } };
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::ostream &
+operator<<( std::ostream & oss, const LockedPackageRaw & raw )
+{
+  return oss << nlohmann::json( raw ).dump();
 }
 
 

--- a/src/resolver/lockfile.cc
+++ b/src/resolver/lockfile.cc
@@ -438,8 +438,9 @@ Lockfile::removeUnusedInputs()
   auto inManifestRegistry = [&]( const std::string & name ) -> bool
   {
     const auto & maybeRegistry = this->getManifestRaw().registry;
-    return maybeRegistry.has_value() &&
-           ( maybeRegistry->inputs.find( name ) != maybeRegistry->inputs.end() );
+    return maybeRegistry.has_value()
+           && ( maybeRegistry->inputs.find( name )
+                != maybeRegistry->inputs.end() );
   };
 
   /* Check to see if an input is used by a package. */
@@ -456,11 +457,11 @@ Lockfile::removeUnusedInputs()
   std::size_t count = 0;
 
   /* Remove. */
-  for ( auto elem = this->getRegistryRaw().inputs.begin(); elem
-        != this->getRegistryRaw().inputs.end(); )
+  for ( auto elem = this->getRegistryRaw().inputs.begin();
+        elem != this->getRegistryRaw().inputs.end(); )
     {
-      if ( ( ! inManifestRegistry( elem->first ) ) &&
-           ( ! inPackagesRegistry( elem->second.from->to_string() ) ) )
+      if ( ( ! inManifestRegistry( elem->first ) )
+           && ( ! inPackagesRegistry( elem->second.from->to_string() ) ) )
         {
           std::remove( this->lockfileRaw.registry.priority.begin(),
                        this->lockfileRaw.registry.priority.end(),
@@ -468,10 +469,7 @@ Lockfile::removeUnusedInputs()
           this->lockfileRaw.registry.inputs.erase( elem->first );
           ++count;
         }
-      else
-        {
-          ++elem;
-        }
+      else { ++elem; }
     }
 
   return count;

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -61,8 +61,7 @@ EnvironmentMixin::initGlobalManifestPath( std::filesystem::path path )
 {
   ENV_MIXIN_THROW_IF_SET( globalManifestPath )
   this->globalManifestPath = std::move( path );
-  this->initGlobalManifest( readManifestFromPath<GlobalManifestRaw>(
-    path ) );
+  this->initGlobalManifest( readManifestFromPath<GlobalManifestRaw>( path ) );
 }
 
 
@@ -267,7 +266,7 @@ GAEnvironmentMixin::initGlobalManifestPath( std::filesystem::path path )
   if ( this->gaRegistry )
     {
       auto manifestRawGA = readManifestFromPath<GlobalManifestRawGA>( path );
-      auto manifestRaw = static_cast<GlobalManifestRaw>( manifestRawGA );
+      auto manifestRaw   = static_cast<GlobalManifestRaw>( manifestRawGA );
       this->setGlobalManifestPath( std::move( path ) );
       this->EnvironmentMixin::initGlobalManifest( std::move( manifestRaw ) );
     }
@@ -300,7 +299,7 @@ GAEnvironmentMixin::initManifestPath( std::filesystem::path path )
   if ( this->gaRegistry )
     {
       auto manifestRawGA = readManifestFromPath<ManifestRawGA>( path );
-      auto manifestRaw = static_cast<ManifestRaw>( manifestRawGA );
+      auto manifestRaw   = static_cast<ManifestRaw>( manifestRawGA );
       this->setManifestPath( std::move( path ) );
       this->EnvironmentMixin::initManifest( std::move( manifestRaw ) );
     }

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -50,47 +50,23 @@ namespace flox::resolver {
 /* -------------------------------------------------------------------------- */
 
 void
-EnvironmentMixin::initGlobalManifestPath( std::filesystem::path path )
-{
-  ENV_MIXIN_THROW_IF_SET( globalManifestPath )
-  this->globalManifestPath = std::move( path );
-}
-
-void
-EnvironmentMixin::initGlobalManifest( std::filesystem::path path )
-{
-  ENV_MIXIN_THROW_IF_SET( globalManifest )
-  if ( ! this->globalManifestPath.has_value() )
-    {
-      this->globalManifestPath = path;
-    }
-  this->globalManifest = GlobalManifest( std::move( path ) );
-}
-
-void
 EnvironmentMixin::initGlobalManifest( GlobalManifestRaw manifestRaw )
 {
   ENV_MIXIN_THROW_IF_SET( globalManifest )
   this->globalManifest = GlobalManifest( std::move( manifestRaw ) );
 }
 
+void
+EnvironmentMixin::initGlobalManifestPath( std::filesystem::path path )
+{
+  ENV_MIXIN_THROW_IF_SET( globalManifestPath )
+  this->globalManifestPath = std::move( path );
+  this->initGlobalManifest( readManifestFromPath<GlobalManifestRaw>(
+    path ) );
+}
+
 
 /* -------------------------------------------------------------------------- */
-
-void
-EnvironmentMixin::initManifestPath( std::filesystem::path path )
-{
-  ENV_MIXIN_THROW_IF_SET( manifestPath )
-  this->manifestPath = std::move( path );
-}
-
-void
-EnvironmentMixin::initManifest( std::filesystem::path path )
-{
-  ENV_MIXIN_THROW_IF_SET( manifest )
-  if ( ! this->manifestPath.has_value() ) { this->globalManifestPath = path; }
-  this->manifest = EnvironmentManifest( std::move( path ) );
-}
 
 void
 EnvironmentMixin::initManifest( ManifestRaw manifestRaw )
@@ -99,15 +75,16 @@ EnvironmentMixin::initManifest( ManifestRaw manifestRaw )
   this->manifest = EnvironmentManifest( std::move( manifestRaw ) );
 }
 
+void
+EnvironmentMixin::initManifestPath( std::filesystem::path path )
+{
+  ENV_MIXIN_THROW_IF_SET( manifestPath )
+  this->manifestPath = std::move( path );
+  this->initManifest( readManifestFromPath<ManifestRaw>( path ) );
+}
+
 
 /* -------------------------------------------------------------------------- */
-
-void
-EnvironmentMixin::initLockfilePath( std::filesystem::path path )
-{
-  ENV_MIXIN_THROW_IF_SET( lockfilePath )
-  this->lockfilePath = std::move( path );
-}
 
 void
 EnvironmentMixin::initLockfile( LockfileRaw lockfileRaw )
@@ -117,42 +94,15 @@ EnvironmentMixin::initLockfile( LockfileRaw lockfileRaw )
 }
 
 void
-EnvironmentMixin::initLockfile( Lockfile lockfile )
+EnvironmentMixin::initLockfilePath( std::filesystem::path path )
 {
-  ENV_MIXIN_THROW_IF_SET( lockfile )
-  this->lockfile = std::move( lockfile );
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-const std::optional<std::filesystem::path> &
-EnvironmentMixin::getGlobalManifestPath() const
-{
-  return this->globalManifestPath;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-const std::optional<GlobalManifest> &
-EnvironmentMixin::getGlobalManifest()
-{
-  if ( ( ! this->globalManifest.has_value() )
-       && this->globalManifestPath.has_value() )
+  if ( ! std::filesystem::exists( path ) )
     {
-      this->initGlobalManifest( *this->globalManifestPath );
+      throw InvalidLockfileException( "no such path: " + path.string() );
     }
-  return this->globalManifest;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-const std::optional<std::filesystem::path> &
-EnvironmentMixin::getManifestPath() const
-{
-  return this->manifestPath;
+  ENV_MIXIN_THROW_IF_SET( lockfilePath )
+  this->lockfilePath = std::move( path );
+  this->initLockfile( readAndCoerceJSON( *this->lockfilePath ) );
 }
 
 
@@ -163,37 +113,11 @@ EnvironmentMixin::getManifest()
 {
   if ( ! this->manifest.has_value() )
     {
-      if ( ! this->manifestPath.has_value() )
-        {
-          throw EnvironmentMixinException(
-            "you must provide an inline manifest or the path to a manifest "
-            "file" );
-        }
-      this->initManifest( *this->manifestPath );
+      throw EnvironmentMixinException(
+        "you must provide an inline manifest or the path to a "
+        "manifest file" );
     }
   return *this->manifest;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-const std::optional<std::filesystem::path> &
-EnvironmentMixin::getLockfilePath() const
-{
-  return this->manifestPath;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-const std::optional<Lockfile> &
-EnvironmentMixin::getLockfile()
-{
-  if ( ( ! this->lockfile.has_value() ) && this->lockfilePath.has_value() )
-    {
-      this->lockfile = Lockfile( *this->lockfilePath );
-    }
-  return this->lockfile;
 }
 
 
@@ -325,12 +249,11 @@ GAEnvironmentMixin::initGlobalManifest( GlobalManifestRaw manifestRaw )
 {
   if ( this->gaRegistry )
     {
-      if ( manifestRaw.registry.has_value() )
+      (void) static_cast<GlobalManifestRawGA>( manifestRaw );
+      if ( ! manifestRaw.registry.has_value() )
         {
-          throw InvalidManifestFileException(
-            "user defined `registries` are not yet supported" );
+          manifestRaw.registry = getGARegistry();
         }
-      manifestRaw.registry = getGARegistry();
     }
   this->EnvironmentMixin::initGlobalManifest( std::move( manifestRaw ) );
 }
@@ -339,16 +262,16 @@ GAEnvironmentMixin::initGlobalManifest( GlobalManifestRaw manifestRaw )
 /* -------------------------------------------------------------------------- */
 
 void
-GAEnvironmentMixin::initGlobalManifest( std::filesystem::path path )
+GAEnvironmentMixin::initGlobalManifestPath( std::filesystem::path path )
 {
   if ( this->gaRegistry )
     {
-      GlobalManifestGA  manifest( std::move( path ) );
-      GlobalManifestRaw manifestRaw( manifest.getManifestRaw() );
-      manifestRaw.registry = manifest.getRegistryRaw();
+      auto manifestRawGA = readManifestFromPath<GlobalManifestRawGA>( path );
+      auto manifestRaw = static_cast<GlobalManifestRaw>( manifestRawGA );
+      this->setGlobalManifestPath( std::move( path ) );
       this->EnvironmentMixin::initGlobalManifest( std::move( manifestRaw ) );
     }
-  else { this->EnvironmentMixin::initGlobalManifest( std::move( path ) ); }
+  else { this->EnvironmentMixin::initGlobalManifestPath( std::move( path ) ); }
 }
 
 
@@ -359,12 +282,11 @@ GAEnvironmentMixin::initManifest( ManifestRaw manifestRaw )
 {
   if ( this->gaRegistry )
     {
-      if ( manifestRaw.registry.has_value() )
+      (void) static_cast<ManifestRawGA>( manifestRaw );
+      if ( ! manifestRaw.registry.has_value() )
         {
-          throw InvalidManifestFileException(
-            "user defined `registries` are not yet supported" );
+          manifestRaw.registry = getGARegistry();
         }
-      manifestRaw.registry = getGARegistry();
     }
   this->EnvironmentMixin::initManifest( std::move( manifestRaw ) );
 }
@@ -373,16 +295,16 @@ GAEnvironmentMixin::initManifest( ManifestRaw manifestRaw )
 /* -------------------------------------------------------------------------- */
 
 void
-GAEnvironmentMixin::initManifest( std::filesystem::path path )
+GAEnvironmentMixin::initManifestPath( std::filesystem::path path )
 {
   if ( this->gaRegistry )
     {
-      EnvironmentManifestGA manifest( std::move( path ) );
-      ManifestRaw           manifestRaw( manifest.getManifestRaw() );
-      manifestRaw.registry = manifest.getRegistryRaw();
+      auto manifestRawGA = readManifestFromPath<ManifestRawGA>( path );
+      auto manifestRaw = static_cast<ManifestRaw>( manifestRawGA );
+      this->setManifestPath( std::move( path ) );
       this->EnvironmentMixin::initManifest( std::move( manifestRaw ) );
     }
-  else { this->EnvironmentMixin::initManifest( std::move( path ) ); }
+  else { this->EnvironmentMixin::initManifestPath( std::move( path ) ); }
 }
 
 

--- a/src/resolver/mixins.cc
+++ b/src/resolver/mixins.cc
@@ -61,7 +61,8 @@ EnvironmentMixin::initGlobalManifestPath( std::filesystem::path path )
 {
   ENV_MIXIN_THROW_IF_SET( globalManifestPath )
   this->globalManifestPath = std::move( path );
-  this->initGlobalManifest( readManifestFromPath<GlobalManifestRaw>( path ) );
+  this->initGlobalManifest(
+    readManifestFromPath<GlobalManifestRaw>( *this->globalManifestPath ) );
 }
 
 
@@ -79,7 +80,8 @@ EnvironmentMixin::initManifestPath( std::filesystem::path path )
 {
   ENV_MIXIN_THROW_IF_SET( manifestPath )
   this->manifestPath = std::move( path );
-  this->initManifest( readManifestFromPath<ManifestRaw>( path ) );
+  this->initManifest(
+    readManifestFromPath<ManifestRaw>( *this->manifestPath ) );
 }
 
 

--- a/src/search/command.cc
+++ b/src/search/command.cc
@@ -126,7 +126,7 @@ SearchCommand::initEnvironment()
   /* Init global manifest. */
   auto maybePath = this->params.getGlobalManifestPath();
   if ( maybePath.has_value() ) { this->initGlobalManifestPath( *maybePath ); }
-  if ( auto raw = this->params.getGlobalManifestRaw(); raw.has_value() )
+  else if ( auto raw = this->params.getGlobalManifestRaw(); raw.has_value() )
     {
       this->initGlobalManifest( *raw );
     }
@@ -134,12 +134,12 @@ SearchCommand::initEnvironment()
   /* Init manifest. */
   maybePath = this->params.getManifestPath();
   if ( maybePath.has_value() ) { this->initManifestPath( *maybePath ); }
-  this->initManifest( this->params.getManifestRaw() );
+  else { this->initManifest( this->params.getManifestRaw() ); }
 
   /* Init lockfile . */
   maybePath = this->params.getLockfilePath();
   if ( maybePath.has_value() ) { this->initLockfilePath( *maybePath ); }
-  if ( auto raw = this->params.getLockfileRaw(); raw.has_value() )
+  else if ( auto raw = this->params.getLockfileRaw(); raw.has_value() )
     {
       this->initLockfile( *raw );
     }

--- a/src/util.cc
+++ b/src/util.cc
@@ -108,7 +108,10 @@ readAndCoerceJSON( const std::filesystem::path & path )
 
   std::ifstream ifs( path );
   auto          ext = path.extension();
-  if ( ext == ".json" ) { return nlohmann::json::parse( ifs ); }
+  if ( ( ext == ".json" ) || ( ext == ".lock" ) )
+    {
+      return nlohmann::json::parse( ifs );
+    }
 
   /* Read file to buffer */
   std::ostringstream oss;

--- a/tests/environment.cc
+++ b/tests/environment.cc
@@ -165,48 +165,6 @@ RegistryRaw registryWithNixpkgs( registryWithNixpkgsJSON );
 /* -------------------------------------------------------------------------- */
 
 bool
-equalLockedInputRaw( const LockedInputRaw & first,
-                     const LockedInputRaw & second )
-{
-  // TODO check:
-  // pkgdb::Fingerprint fingerprint;
-  EXPECT_EQ( first.url, second.url );
-  EXPECT_EQ( first.attrs, second.attrs );
-  return true;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-bool
-equalAttrPath( const AttrPath & first, const AttrPath & second )
-{
-  EXPECT_EQ( first.size(), second.size() );
-  for ( size_t i = 0; i < first.size(); ++i )
-    {
-      EXPECT_EQ( first[i], second[i] );
-    }
-  return true;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-bool
-equalLockedPackageRaw( const LockedPackageRaw & first,
-                       const LockedPackageRaw & second )
-{
-  EXPECT( equalLockedInputRaw( first.input, second.input ) );
-  EXPECT( equalAttrPath( first.attrPath, second.attrPath ) );
-  EXPECT_EQ( first.priority, second.priority );
-  EXPECT_EQ( first.info, second.info );
-  return true;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-bool
 equalLockfileRaw( const LockfileRaw & first, const LockfileRaw & second )
 {
   for ( const auto & [system, firstSystemPackages] : first.packages )
@@ -224,8 +182,7 @@ equalLockfileRaw( const LockfileRaw & first, const LockfileRaw & second )
           if ( lockedPackageRaw.has_value()
                && secondLockedPackageRaw.has_value() )
             {
-              if ( ! equalLockedPackageRaw( *lockedPackageRaw,
-                                            *secondLockedPackageRaw ) )
+              if ( ( *lockedPackageRaw ) != ( *secondLockedPackageRaw ) )
                 {
                   return false;
                 };
@@ -611,7 +568,7 @@ test_getGroupInput0()
     {
       auto input = environment.getGroupInput( group, lockfile, _system );
       EXPECT( input.has_value() );
-      EXPECT( equalLockedInputRaw( *input, mockHelloLocked.input ) );
+      EXPECT_EQ( *input, mockHelloLocked.input );
     }
   return true;
 }
@@ -661,8 +618,8 @@ test_getGroupInput1()
       auto input = environment.getGroupInput( group, lockfile, _system );
       EXPECT( input.has_value() );
       // TODO this prints "Expectation failed" which should probably be silenced
-      EXPECT( ! equalLockedInputRaw( *input, mockHelloLocked.input ) );
-      EXPECT( equalLockedInputRaw( *input, mockCurlLockedModified.input ) );
+      EXPECT( ( *input ) != mockHelloLocked.input );
+      EXPECT_EQ( *input, mockCurlLockedModified.input );
     }
   return true;
 }
@@ -715,8 +672,8 @@ test_getGroupInput2()
     {
       auto input = environment.getGroupInput( group, lockfile, _system );
       EXPECT( input.has_value() );
-      EXPECT( equalLockedInputRaw( *input, mockHelloLocked.input )
-              || equalLockedInputRaw( *input, mockCurlLockedModified.input ) );
+      EXPECT( ( ( *input ) == mockHelloLocked.input )
+              || ( ( *input ) == mockCurlLockedModified.input ) );
     }
   return true;
 }

--- a/tests/ga-registry.bats
+++ b/tests/ga-registry.bats
@@ -193,12 +193,6 @@ setup_file() {
                                    '$PROJ1/manifest.toml'              \
             |jq -r '.combined.inputs.nixpkgs.from.rev';";
   assert_success;
-  if [[ "$output" != "$OTHER_REV" ]]; then
-    $PKGDB manifest registry --ga-registry                      \
-                            --lockfile "$PROJ1/manifest2.lock"  \
-                            "$PROJ1/manifest.toml"              \
-      |jq -r '.combined' >&3;
-  fi
   assert_output "$OTHER_REV";
 }
 

--- a/tests/ga-registry.bats
+++ b/tests/ga-registry.bats
@@ -221,9 +221,10 @@ setup_file() {
 
 @test "'pkgdb search --ga-registry' uses lockfile rev" {
   # `$NIXPKGS_REV'
-  run --separate-stderr                                              \
-    sh -c "$PKGDB search --ga-registry --match-name nodejs|head -n1  \
-               |jq -r '.version';";
+  run --separate-stderr sh -c "$PKGDB search --ga-registry '{
+      \"lockfile\": \"$PROJ1/manifest.lock\",
+      \"query\": { \"match-name\": \"nodejs\" }
+    }'|head -n1|jq -r '.version';";
   assert_success;
   assert_output '18.16.0';
 

--- a/tests/ga-registry.bats
+++ b/tests/ga-registry.bats
@@ -193,6 +193,12 @@ setup_file() {
                                    '$PROJ1/manifest.toml'              \
             |jq -r '.combined.inputs.nixpkgs.from.rev';";
   assert_success;
+  if [[ "$output" != "$OTHER_REV" ]]; then
+    $PKGDB manifest registry --ga-registry                      \
+                            --lockfile "$PROJ1/manifest2.lock"  \
+                            "$PROJ1/manifest.toml"              \
+      |jq -r '.combined' >&3;
+  fi
   assert_output "$OTHER_REV";
 }
 

--- a/tests/ga-registry.bats
+++ b/tests/ga-registry.bats
@@ -187,10 +187,11 @@ setup_file() {
 # pin used by our test suite.
 # This should detect whether the lockfile's `rev` is preserved in `combined`.
 @test "Combined registry prefers lockfile inputs" {
-  run sh -c "$PKGDB manifest registry --ga-registry                       \
-                                      --lockfile '$PROJ1/manifest2.lock'  \
-                                      '$PROJ1/manifest.toml'              \
-               |jq -r '.combined.inputs.nixpkgs.from.rev';";
+  run --separate-stderr                                                \
+    sh -c "$PKGDB manifest registry --ga-registry                      \
+                                   --lockfile '$PROJ1/manifest2.lock'  \
+                                   '$PROJ1/manifest.toml'              \
+            |jq -r '.combined.inputs.nixpkgs.from.rev';";
   assert_success;
   assert_output "$OTHER_REV";
 }
@@ -204,10 +205,11 @@ setup_file() {
 # pin used by our test suite.
 # This should cause the `rev` to be updated.
 @test "'pkgdb manifest update --ga-registry' updates lockfile rev" {
-  run sh -c "$PKGDB manifest update --ga-registry                       \
-                                    --lockfile '$PROJ1/manifest2.lock'  \
-                                    '$PROJ1/manifest.toml'              \
-               |jq -r '.registry.inputs.nixpkgs.from.rev';";
+  run --separate-stderr                                               \
+    sh -c "$PKGDB manifest update --ga-registry                       \
+                                  --lockfile '$PROJ1/manifest2.lock'  \
+                                  '$PROJ1/manifest.toml'              \
+            |jq -r '.registry.inputs.nixpkgs.from.rev';";
   assert_success;
   assert_output "$NIXPKGS_REV";
 }
@@ -219,13 +221,14 @@ setup_file() {
 
 @test "'pkgdb search --ga-registry' uses lockfile rev" {
   # `$NIXPKGS_REV'
-  run sh -c "$PKGDB search --ga-registry --match-name nodejs|head -n1  \
+  run --separate-stderr                                              \
+    sh -c "$PKGDB search --ga-registry --match-name nodejs|head -n1  \
                |jq -r '.version';";
   assert_success;
   assert_output '18.16.0';
 
   # `$OTHER_REV'
-  run sh -c "$PKGDB search --ga-registry '{
+  run --separate-stderr sh -c "$PKGDB search --ga-registry '{
     \"lockfile\": \"$PROJ1/manifest2.lock\",
     \"query\": { \"match-name\": \"nodejs\" }
   }'|head -n1|jq -r '.version';";
@@ -239,7 +242,8 @@ setup_file() {
 # bats test_tags=manifest:ga-registry, lock:ga-registry, manifest:update
 
 @test "'pkgdb manifest update --ga-registry' creates missing lockfile" {
-  run $PKGDB manifest update --ga-registry "$PROJ1/manifest.toml";
+  run --separate-stderr                                             \
+    "$PKGDB" manifest update --ga-registry "$PROJ1/manifest.toml";
   assert_success;
   assert_output < "$PROJ1/manifest.lock";
 }

--- a/tests/ga-registry.bats
+++ b/tests/ga-registry.bats
@@ -12,6 +12,12 @@ load setup_suite.bash;
 
 setup_file() {
   export TDATA="$TESTS_DIR/data/manifest";
+  export PROJ1="$TESTS_DIR/harnesses/proj1";
+
+  OTHER_REV="$(
+    jq -r '.registry.inputs.nixpkgs.from.rev' "$PROJ1/manifest2.lock";
+  )";
+  export OTHER_REV;
 
   # We don't parallelize these to avoid DB sync headaches and to recycle the
   # cache between tests.
@@ -170,6 +176,72 @@ setup_file() {
                            --global-manifest "$TDATA/global-ga0.toml"  \
                            "$TDATA/post-ga0.toml";
   assert_failure;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=manifest:ga-registry, lock:ga-registry, manifest:registry-cmd
+
+# The lockfile provided contains a `rev` which differs from the `--ga-registry`
+# pin used by our test suite.
+# This should detect whether the lockfile's `rev` is preserved in `combined`.
+@test "Combined registry prefers lockfile inputs" {
+  run sh -c "$PKGDB manifest registry --ga-registry                       \
+                                      --lockfile '$PROJ1/manifest2.lock'  \
+                                      '$PROJ1/manifest.toml'              \
+               |jq -r '.combined.inputs.nixpkgs.from.rev';";
+  assert_success;
+  assert_output "$OTHER_REV";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=manifest:ga-registry, lock:ga-registry, manifest:update
+
+# The lockfile provided contains a `rev` which differs from the `--ga-registry`
+# pin used by our test suite.
+# This should cause the `rev` to be updated.
+@test "'pkgdb manifest update --ga-registry' updates lockfile rev" {
+  run sh -c "$PKGDB manifest update --ga-registry                       \
+                                    --lockfile '$PROJ1/manifest2.lock'  \
+                                    '$PROJ1/manifest.toml'              \
+               |jq -r '.registry.inputs.nixpkgs.from.rev';";
+  assert_success;
+  assert_output "$NIXPKGS_REV";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=search:ga-registry, search:lockfile
+
+@test "'pkgdb search --ga-registry' uses lockfile rev" {
+  # `$NIXPKGS_REV'
+  run sh -c "$PKGDB search --ga-registry --match-name nodejs|head -n1  \
+               |jq -r '.version';";
+  assert_success;
+  assert_output '18.16.0';
+
+  # `$OTHER_REV'
+  run sh -c "$PKGDB search --ga-registry '{
+    \"lockfile\": \"$PROJ1/manifest2.lock\",
+    \"query\": { \"match-name\": \"nodejs\" }
+  }'|head -n1|jq -r '.version';";
+  assert_success;
+  assert_output '18.17.1';
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=manifest:ga-registry, lock:ga-registry, manifest:update
+
+@test "'pkgdb manifest update --ga-registry' creates missing lockfile" {
+  run $PKGDB manifest update --ga-registry "$PROJ1/manifest.toml";
+  assert_success;
+  assert_output < "$PROJ1/manifest.lock";
 }
 
 

--- a/tests/ga-registry.bats
+++ b/tests/ga-registry.bats
@@ -222,6 +222,7 @@ setup_file() {
 @test "'pkgdb search --ga-registry' uses lockfile rev" {
   # `$NIXPKGS_REV'
   run --separate-stderr sh -c "$PKGDB search --ga-registry '{
+      \"manifest\": \"$PROJ1/manifest.toml\",
       \"lockfile\": \"$PROJ1/manifest.lock\",
       \"query\": { \"match-name\": \"nodejs\" }
     }'|head -n1|jq -r '.version';";
@@ -230,9 +231,10 @@ setup_file() {
 
   # `$OTHER_REV'
   run --separate-stderr sh -c "$PKGDB search --ga-registry '{
-    \"lockfile\": \"$PROJ1/manifest2.lock\",
-    \"query\": { \"match-name\": \"nodejs\" }
-  }'|head -n1|jq -r '.version';";
+      \"manifest\": \"$PROJ1/manifest.toml\",
+      \"lockfile\": \"$PROJ1/manifest2.lock\",
+      \"query\": { \"match-name\": \"nodejs\" }
+    }'|head -n1|jq -r '.version';";
   assert_success;
   assert_output '18.17.1';
 }

--- a/tests/harnesses/proj1/manifest.lock
+++ b/tests/harnesses/proj1/manifest.lock
@@ -4,6 +4,11 @@
     "install": {
       "nodejs": null
     },
+    "options": {
+      "systems": [
+        "x86_64-linux"
+      ]
+    },
     "registry": {
       "defaults": {
         "subtrees": null

--- a/tests/harnesses/proj1/manifest.lock
+++ b/tests/harnesses/proj1/manifest.lock
@@ -1,0 +1,83 @@
+{
+  "lockfile-version": 0,
+  "manifest": {
+    "install": {
+      "nodejs": null
+    },
+    "registry": {
+      "defaults": {
+        "subtrees": null
+      },
+      "inputs": {
+        "nixpkgs": {
+          "from": {
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+            "type": "github"
+          },
+          "subtrees": [
+            "legacyPackages"
+          ]
+        }
+      },
+      "priority": [
+        "nixpkgs"
+      ]
+    }
+  },
+  "packages": {
+    "x86_64-linux": {
+      "nodejs": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "nodejs"
+        ],
+        "info": {
+          "broken": false,
+          "license": "MIT",
+          "pname": "nodejs",
+          "unfree": false,
+          "version": "18.16.0"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1685979279,
+            "narHash": "sha256-1UGacsv5coICyvAzwuq89v9NsS00Lo8sz22cDHwhnn8=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+            "type": "github"
+          },
+          "fingerprint": "5fde12e3424840cc2752dae09751b09b03f5a33c3ec4de672fc89d236720bdc7",
+          "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+        },
+        "priority": 5
+      }
+    }
+  },
+  "registry": {
+    "defaults": {
+      "subtrees": null
+    },
+    "inputs": {
+      "nixpkgs": {
+        "from": {
+          "lastModified": 1685979279,
+          "narHash": "sha256-1UGacsv5coICyvAzwuq89v9NsS00Lo8sz22cDHwhnn8=",
+          "owner": "NixOS",
+          "repo": "nixpkgs",
+          "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+          "type": "github"
+        },
+        "subtrees": [
+          "legacyPackages"
+        ]
+      }
+    },
+    "priority": [
+      "nixpkgs"
+    ]
+  }
+}

--- a/tests/harnesses/proj1/manifest.toml
+++ b/tests/harnesses/proj1/manifest.toml
@@ -1,0 +1,1 @@
+install.nodejs = {}

--- a/tests/harnesses/proj1/manifest.toml
+++ b/tests/harnesses/proj1/manifest.toml
@@ -1,1 +1,2 @@
+options.systems = ["x86_64-linux"]
 install.nodejs = {}

--- a/tests/harnesses/proj1/manifest2.lock
+++ b/tests/harnesses/proj1/manifest2.lock
@@ -1,0 +1,83 @@
+{
+  "lockfile-version": 0,
+  "manifest": {
+    "install": {
+      "nodejs": null
+    },
+    "registry": {
+      "defaults": {
+        "subtrees": null
+      },
+      "inputs": {
+        "nixpkgs": {
+          "from": {
+            "owner": "NixOS",
+            "ref": "release-23.05",
+            "repo": "nixpkgs",
+            "type": "github"
+          },
+          "subtrees": [
+            "legacyPackages"
+          ]
+        }
+      },
+      "priority": [
+        "nixpkgs"
+      ]
+    }
+  },
+  "packages": {
+    "x86_64-linux": {
+      "nodejs": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "nodejs"
+        ],
+        "info": {
+          "broken": false,
+          "license": "MIT",
+          "pname": "nodejs",
+          "unfree": false,
+          "version": "18.17.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1700478853,
+            "narHash": "sha256-5uA6jKckTf+DCbVBNKsmT5pUT/7Apt5tNdpcbLnPzFI=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "9faf91e6d0b7743d41cce3b63a8e5c733dc696a3",
+            "type": "github"
+          },
+          "fingerprint": "9ea15e83111e20cb13cf98e8592e09d1356df773b6e87492710d006b9d031486",
+          "url": "github:NixOS/nixpkgs/9faf91e6d0b7743d41cce3b63a8e5c733dc696a3"
+        },
+        "priority": 5
+      }
+    }
+  },
+  "registry": {
+    "defaults": {
+      "subtrees": null
+    },
+    "inputs": {
+      "nixpkgs": {
+        "from": {
+          "lastModified": 1700478853,
+          "narHash": "sha256-5uA6jKckTf+DCbVBNKsmT5pUT/7Apt5tNdpcbLnPzFI=",
+          "owner": "NixOS",
+          "repo": "nixpkgs",
+          "rev": "9faf91e6d0b7743d41cce3b63a8e5c733dc696a3",
+          "type": "github"
+        },
+        "subtrees": [
+          "legacyPackages"
+        ]
+      }
+    },
+    "priority": [
+      "nixpkgs"
+    ]
+  }
+}

--- a/tests/harnesses/proj1/manifest2.lock
+++ b/tests/harnesses/proj1/manifest2.lock
@@ -4,6 +4,11 @@
     "install": {
       "nodejs": null
     },
+    "options": {
+      "systems": [
+        "x86_64-linux"
+      ]
+    },
     "registry": {
       "defaults": {
         "subtrees": null


### PR DESCRIPTION
- fixes: fix EnvironmentMixin::getLockfilePath and simplify EnvironmentMixinGA inits
- fixes: `Environment::getCombinedRegistry()` to include lockfile inputs.
- fixes: A bug which ignored the `options.systems` field in _manifest_ files in combination with `--ga-registry`.
- adds: `pkgdb manifest registry` sub-command
- adds: equality and ostream ops for lockfile inputs and packages
- adds: `pkgdb manifest update` sub-command

## TODO ( post-GA ):
- `pkgdb manifest lock` should have special handling for inputs pulled from `global-manifest` which are not in `manifest.toml` if they are used to resolve packages ( warn the user ).