### PR TITLE
fix: no duplicate resolution error msgs

### DIFF
--- a/include/flox/resolver/environment.hh
+++ b/include/flox/resolver/environment.hh
@@ -182,7 +182,7 @@ private:
    * @brief Try to resolve a group of descriptors in a given package database.
    *
    * @return InstallID of the package that can't be resolved if resolution fails,
-   *          otherwise a set of resolved packages for the system.
+   *         otherwise a set of resolved packages for the system.
    */
   [[nodiscard]] std::variant<InstallID, SystemPackages>
   tryResolveGroupIn( const InstallDescriptors & group,

--- a/include/flox/resolver/environment.hh
+++ b/include/flox/resolver/environment.hh
@@ -181,8 +181,8 @@ private:
   /**
    * @brief Try to resolve a group of descriptors in a given package database.
    *
-   * @return `std::nullopt` if resolution fails, otherwise a set of
-   *          resolved packages for.
+   * @return InstallID of the package that can't be resolved if resolution fails,
+   *          otherwise a set of resolved packages for the system.
    */
   [[nodiscard]] std::variant<InstallID, SystemPackages>
   tryResolveGroupIn( const InstallDescriptors & group,

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -521,22 +521,9 @@ Environment::tryResolveGroup( const InstallDescriptors & group,
             "we thought this was an unreachable error" );
         }
     }
-  if ( failureForNewInput.empty() )
-    {
-      if ( failureForOldInput.empty() )
-        {
-          throw ResolutionFailureException(
-            "failed to resolve but there were no errors" );
-        }
-      else
-        {
-          return failureForOldInput;
-        }
-    }
-  else
-    {
-      return failureForNewInput;
-    }
+  if ( ! failureForNewInput.empty() ) { return failureForNewInput; }  
+  if ( ! failureForOldInput.empty() ) { return failureForOldInput; }
+  throw ResolutionFailureException("failed to resolve but there were no errors" );
 }
 
 

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -468,7 +468,8 @@ ResolutionResult
 Environment::tryResolveGroup( const InstallDescriptors & group,
                               const System &             system )
 {
-  ResolutionFailure failure;
+  ResolutionFailure failureForOldInput;
+  ResolutionFailure failureForNewInput;
   if ( auto oldLockfile = this->getOldLockfile(); oldLockfile.has_value() )
     {
       auto lockedInput
@@ -487,7 +488,7 @@ Environment::tryResolveGroup( const InstallDescriptors & group,
           else if ( const InstallID * iid
                     = std::get_if<InstallID>( &maybeResolved ) )
             {
-              failure.push_back( std::pair<InstallID, std::string> {
+              failureForOldInput.push_back( std::pair<InstallID, std::string> {
                 *iid,
                 input.getDbReadOnly()->lockedRef.string } );
             }
@@ -510,7 +511,7 @@ Environment::tryResolveGroup( const InstallDescriptors & group,
       else if ( const InstallID * iid
                 = std::get_if<InstallID>( &maybeResolved ) )
         {
-          failure.push_back( std::pair<InstallID, std::string> {
+          failureForNewInput.push_back( std::pair<InstallID, std::string> {
             *iid,
             input->getDbReadOnly()->lockedRef.string } );
         }
@@ -520,7 +521,22 @@ Environment::tryResolveGroup( const InstallDescriptors & group,
             "we thought this was an unreachable error" );
         }
     }
-  return failure;
+  if ( failureForNewInput.empty() )
+    {
+      if ( failureForOldInput.empty() )
+        {
+          throw ResolutionFailureException(
+            "failed to resolve but there were no errors" );
+        }
+      else
+        {
+          return failureForOldInput;
+        }
+    }
+  else
+    {
+      return failureForNewInput;
+    }
 }
 
 


### PR DESCRIPTION
This deduplicates error messages encountered while trying to resolve a group of descriptors.