### PR TITLE
fix: enable flakes

### DIFF
--- a/src/nix-state.cc
+++ b/src/nix-state.cc
@@ -46,6 +46,8 @@ initNix()
   nix::evalSettings.enableImportFromDerivation.setDefault( false );
   nix::evalSettings.pureEval.setDefault( true );
   nix::evalSettings.useEvalCache.setDefault( true );
+  nix::experimentalFeatureSettings.experimentalFeatures.setDefault(
+    std::set( { nix::Xp::Flakes } ) );
 
   /* Use custom logger */
   bool printBuildLogs = nix::logger->isVerbose();


### PR DESCRIPTION
Before this change, on a host with flakes disabled:
> ./bin/pkgdb manifest lock --ga-registry ~/debug/.flox/env/manifest.toml
error locking flake: failed to lock flake "github:NixOS/nixpkgs/release-23.05": error: experimental Nix feature 'flakes' is disabled; use '--extra-experimental-features flakes' to override

After:
> ./bin/pkgdb manifest lock --ga-registry ~/debug/.flox/env/manifest.toml
{...lockfile JSON...}