### PR TITLE
fix: assign nix settings

### DIFF
--- a/src/nix-state.cc
+++ b/src/nix-state.cc
@@ -45,8 +45,8 @@ initNix()
 
   nix::evalSettings.enableImportFromDerivation.setDefault( false );
   nix::evalSettings.pureEval.setDefault( true );
-  nix::evalSettings.useEvalCache.setDefault( true );
-  nix::experimentalFeatureSettings.experimentalFeatures.setDefault(
+  nix::evalSettings.useEvalCache.assign( true );
+  nix::experimentalFeatureSettings.experimentalFeatures.assign(
     std::set( { nix::Xp::Flakes } ) );
 
   /* Use custom logger */


### PR DESCRIPTION
Forces the use of `experimental-features` and `use-eval-cache`.
Previously we only set fallbacks for these settings.

This should fix test case failures in `github:flox/flox`.
