### PR TITLE
opt: remove PkgDescriptorBase

### DIFF
--- a/docs/params-to-sql.md
+++ b/docs/params-to-sql.md
@@ -54,45 +54,6 @@ harder for readers to trace; the aim of this section is to aggregate all of
 classes related to this transformation in one place, and describe their
 relationships to one another.
 
-
-### flox::pkgdb::PkgDescriptorBase
-
-Declared in
-[<pkgdb>/include/flox/pkgdb/pkg-query.hh](../include/flox/pkgdb/pkg-query.hh).
-
-This is the most common set of query filters related to a single package,
-and is used as a base for several more complex descriptors.
-
-It has the following members:
-```c++
-// NOTE: This document may be out of sync with `pkg-query.hh'.
-//       The header itself is the _source of truth_.
-
-struct PkgDescriptorBase
-{
-
-  std::optional<std::string> name;    /**< Filter results by exact `name`. */
-  std::optional<std::string> pname;   /**< Filter results by exact `pname`. */
-  std::optional<std::string> version; /**< Filter results by exact version. */
-  std::optional<std::string> semver;  /**< Filter results by version range. */
-
-  // ...<SNIP>...
-
-};
-
-/**
- * @brief A concept that checks if a typename is derived
- *        from @a flox::pkgdb::PkgDescriptorBase.
- */
-template<typename T>
-concept pkg_descriptor_typename = std::derived_from<T, PkgDescriptorBase>;
-```
-
-Child Classes:
-- `flox::pkgdb::PkgQueryArgs`
-- `flox::search::SearchQuery`
-    
-    
 ### flox::RegistryRaw
 
 Declared in [<pkgdb>/include/flox/registry.hh](../include/flox/registry.hh).
@@ -120,26 +81,21 @@ will be performed.
 // NOTE: This document may be out of sync with `pkg-query.hh'.
 //       The header itself is the _source of truth_.
 
-struct PkgQueryArgs : public PkgDescriptorBase
+struct PkgQueryArgs
 {
 
-  /* From `PkgDescriptorBase':
-   *   std::optional<std::string> name;    //< Filter results by exact `name`.
-   *   std::optional<std::string> pname;   //< Filter results by exact `pname`.
-   *   std::optional<std::string> version; //< Filter results by exact version.
-   *   std::optional<std::string> semver;  //< Filter results by version range.
-   */
-
+   std::optional<std::string> name;    //< Filter results by exact `name`.
+   std::optional<std::string> pname;   //< Filter results by exact `pname`.
+   std::optional<std::string> version; //< Filter results by exact version.
+   std::optional<std::string> semver;  //< Filter results by version range.
+   
   /** Filter results by partial match on pname, attrName, or description. */
   std::optional<std::string> partialMatch;
 
   /** Filter results by partial match on pname or attrName. */
   std::optional<std::string> partialNameMatch;
 
-  /**
-   * Filter results by an exact match on either `pname` or `attrName`.
-   * To match just `pname` see @a flox::pkgdb::PkgDescriptorBase.
-   */
+  /** Filter results by an exact match on either `pname` or `attrName`. */
   std::optional<std::string> pnameOrAttrName;
 
   /** 
@@ -190,11 +146,6 @@ Declared in
 
 This set of parameters is used by `pkgdb search` in order to support
 `flox search` and `flox show` sub-commands.
-
-This is an incredibly lightweight extension of `flox::pkgdb::PkgDescriptorBase`
-which simply adds the ability to filter by a partial match on
-`pname`, `attrName`, or `description` fields ( using `partialMatch` field
-in `flox::pkgdb::PkgQueryArgs` ).
 It has the following declaration:
 
 ```c++
@@ -206,18 +157,19 @@ It has the following declaration:
  * This is essentially a reorganized form of @a flox::pkgdb::PkgQueryArgs
  * that is suited for JSON input.
  */
-struct SearchQuery : public pkgdb::PkgDescriptorBase
+struct SearchQuery
 {
 
-  /* From `pkgdb::PkgDescriptorBase`:
-   *   std::optional<std::string> name;
-   *   std::optional<std::string> pname;
-   *   std::optional<std::string> version;
-   *   std::optional<std::string> semver;
-   */
+  std::optional<std::string> name;
+  std::optional<std::string> pname;
+  std::optional<std::string> version;
+  std::optional<std::string> semver;
 
   /** Filter results by partial match on pname, attrName, or description */
   std::optional<std::string> partialMatch;
+
+  /** Filter results by partial match on pname or attrName. */
+  std::optional<std::string> partialNameMatch;
   
   // ...<SNIP>...
 
@@ -236,8 +188,7 @@ For a detailed look at `SearchParams` see
 Declared in
 [<pkgdb>/include/flox/resolver/descriptor.hh](../include/flox/resolver/descriptor.hh).
 
-This form of descriptor is found in `manifest.{toml,yaml,json}` files, and
-is the only descriptor that does not extend `flox::pkgdb::PkgDescriptorBase`.
+This form of descriptor is found in `manifest.{toml,yaml,json}` files.
 
 It currently uses an intermediate struct `ManifestDescriptor` as an intermediate
 step in its conversion to `flox::pkgdb::PkgQueryArgs`; but these two structures

--- a/include/flox/core/exceptions.hh
+++ b/include/flox/core/exceptions.hh
@@ -55,8 +55,6 @@ enum error_category {
   EC_PACKAGE_INIT,
   /** Exception parsing `flox::resolver::ManifestDescriptorRaw` from JSON. */
   EC_PARSE_MANIFEST_DESCRIPTOR_RAW,
-  /** Exception parsing `PkgDescriptorBase` from JSON. */
-  EC_PARSE_PKG_DESCRIPTOR_BASE,
   /** Exception parsing `flox::resolver::Resolved` from JSON. */
   EC_PARSE_RESOLVED,
   /** Exception parsing @a flox::search::SearchQuery from JSON. */

--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -50,74 +50,6 @@ using row_id = uint64_t; /**< A _row_ index in a SQLite3 table. */
 
 /* -------------------------------------------------------------------------- */
 
-/** @brief Minimal set of query parameters related to a single package. */
-struct PkgDescriptorBase
-{
-
-  std::optional<std::string> name;    /**< Filter results by exact `name`. */
-  std::optional<std::string> pname;   /**< Filter results by exact `pname`. */
-  std::optional<std::string> version; /**< Filter results by exact version. */
-  std::optional<std::string> semver;  /**< Filter results by version range. */
-
-
-  /* Base struct boilerplate */
-  PkgDescriptorBase()                            = default;
-  PkgDescriptorBase( const PkgDescriptorBase & ) = default;
-  PkgDescriptorBase( PkgDescriptorBase && )      = default;
-
-  virtual ~PkgDescriptorBase() = default;
-
-  PkgDescriptorBase &
-  operator=( const PkgDescriptorBase & )
-    = default;
-  PkgDescriptorBase &
-  operator=( PkgDescriptorBase && )
-    = default;
-
-  /** @brief Reset to default state. */
-  virtual void
-  clear();
-
-
-}; /* End struct `PkgDescriptorBase' */
-
-
-/**
- * @brief Convert a JSON object to a @a flox::pkgdb::PkgDescriptorBase.
- */
-void
-from_json( const nlohmann::json & jfrom,
-           PkgDescriptorBase &    pkgDescriptorBase );
-/**
- *
- * @brief Convert a @a flox::pkgdb::PkgDescriptorBase to a JSON object.
- */
-void
-to_json( nlohmann::json & jto, const PkgDescriptorBase & pkgDescriptorBase );
-
-/**
- * @class flox::pkgdb::ParsePkgDescriptorBaseException
- * @brief An exception thrown when parsing @a flox::pkgdb::PkgDescriptorBase
- * from JSON.
- *
- * @{
- */
-FLOX_DEFINE_EXCEPTION( ParsePkgDescriptorBaseException,
-                       EC_PARSE_PKG_DESCRIPTOR_BASE,
-                       "error parsing package descriptor base" )
-/** @} */
-
-
-/**
- * @brief A concept that checks if a typename is derived
- *        from @a flox::pkgdb::PkgDescriptorBase.
- */
-template<typename T>
-concept pkg_descriptor_typename = std::derived_from<T, PkgDescriptorBase>;
-
-
-/* -------------------------------------------------------------------------- */
-
 /**
  * @class flox::pkgdb::InvalidPkgQueryArg
  * @brief Indicates invalid arguments were set in a
@@ -139,15 +71,13 @@ FLOX_DEFINE_EXCEPTION( InvalidPkgQueryArg,
  * These use a combination of SQL statements and post processing with
  * `node-semver` to produce a list of satisfactory packages.
  */
-struct PkgQueryArgs : public PkgDescriptorBase
+struct PkgQueryArgs
 {
 
-  /* From `PkgDescriptorBase':
-   *   std::optional<std::string> name;    //< Filter results by exact `name`.
-   *   std::optional<std::string> pname;   //< Filter results by exact `pname`.
-   *   std::optional<std::string> version; //< Filter results by exact version.
-   *   std::optional<std::string> semver;  //< Filter results by version range.
-   */
+  std::optional<std::string> name;    /**< Filter results by exact `name`. */
+  std::optional<std::string> pname;   /**< Filter results by exact `pname`. */
+  std::optional<std::string> version; /**< Filter results by exact version. */
+  std::optional<std::string> semver;  /**< Filter results by version range. */
 
   /** Filter results by partial match on pname, attrName, or description. */
   std::optional<std::string> partialMatch;
@@ -155,10 +85,7 @@ struct PkgQueryArgs : public PkgDescriptorBase
   /** Filter results by partial match on pname or attrName. */
   std::optional<std::string> partialNameMatch;
 
-  /**
-   * Filter results by an exact match on either `pname` or `attrName`.
-   * To match just `pname` see @a flox::pkgdb::PkgDescriptorBase.
-   */
+  /** Filter results by an exact match on either `pname` or `attrName`. */
   std::optional<std::string> pnameOrAttrName;
 
   /**
@@ -196,9 +123,10 @@ struct PkgQueryArgs : public PkgDescriptorBase
    */
   std::optional<flox::AttrPath> relPath;
 
+
   /** @brief Reset argset to its _default_ state. */
   void
-  clear() override;
+  clear();
 
   /**
    * @brief Sanity check parameters throwing a

--- a/include/flox/search/params.hh
+++ b/include/flox/search/params.hh
@@ -39,15 +39,13 @@ namespace flox::search {
  * This is essentially a reorganized form of @a flox::pkgdb::PkgQueryArgs
  * that is suited for JSON input.
  */
-struct SearchQuery : public pkgdb::PkgDescriptorBase
+struct SearchQuery
 {
 
-  /* From `pkgdb::PkgDescriptorBase`:
-   *   std::optional<std::string> name;
-   *   std::optional<std::string> pname;
-   *   std::optional<std::string> version;
-   *   std::optional<std::string> semver;
-   */
+  std::optional<std::string> name;    /**< Filter results by exact `name`. */
+  std::optional<std::string> pname;   /**< Filter results by exact `pname`. */
+  std::optional<std::string> version; /**< Filter results by exact version. */
+  std::optional<std::string> semver;  /**< Filter results by version range. */
 
   /** Filter results by partial match on pname, attrName, or description */
   std::optional<std::string> partialMatch;
@@ -57,7 +55,7 @@ struct SearchQuery : public pkgdb::PkgDescriptorBase
 
   /** @brief Reset to default state. */
   void
-  clear() override;
+  clear();
 
   /** @brief Check validity of fields, throwing an exception if invalid. */
   void

--- a/src/pkgdb/pkg-query.cc
+++ b/src/pkgdb/pkg-query.cc
@@ -38,112 +38,6 @@ namespace flox::pkgdb {
 /* -------------------------------------------------------------------------- */
 
 void
-PkgDescriptorBase::clear()
-{
-  this->name    = std::nullopt;
-  this->pname   = std::nullopt;
-  this->version = std::nullopt;
-  this->semver  = std::nullopt;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-void
-from_json( const nlohmann::json & jfrom, PkgDescriptorBase & pkgDescriptorBase )
-{
-  assertIsJSONObject<ParsePkgDescriptorBaseException>( jfrom,
-                                                       "package descriptor" );
-  /* Clear fields. */
-  pkgDescriptorBase.clear();
-  for ( const auto & [key, value] : jfrom.items() )
-    {
-      if ( key == "name" )
-        {
-          try
-            {
-              value.get_to( pkgDescriptorBase.name );
-            }
-          catch ( nlohmann::json::exception & e )
-            {
-              throw ParsePkgDescriptorBaseException(
-                "couldn't interpret field `name'",
-                flox::extract_json_errmsg( e ) );
-            }
-        }
-      else if ( key == "pname" )
-        {
-          try
-            {
-              value.get_to( pkgDescriptorBase.pname );
-            }
-          catch ( nlohmann::json::exception & e )
-            {
-              throw ParsePkgDescriptorBaseException(
-                "couldn't interpret field `pname'",
-                flox::extract_json_errmsg( e ) );
-            }
-        }
-      else if ( key == "version" )
-        {
-          try
-            {
-              value.get_to( pkgDescriptorBase.version );
-            }
-          catch ( nlohmann::json::exception & e )
-            {
-              throw ParsePkgDescriptorBaseException(
-                "couldn't interpret field `version'",
-                flox::extract_json_errmsg( e ) );
-            }
-        }
-      else if ( key == "semver" )
-        {
-          try
-            {
-              value.get_to( pkgDescriptorBase.semver );
-            }
-          catch ( nlohmann::json::exception & e )
-            {
-              throw ParsePkgDescriptorBaseException(
-                "couldn't interpret field `semver'",
-                flox::extract_json_errmsg( e ) );
-            }
-        }
-      else
-        {
-          throw ParsePkgDescriptorBaseException(
-            "encountered unrecognized field `" + key
-            + "' while parsing package descriptor" );
-        }
-    }
-}
-
-void
-to_json( nlohmann::json & jto, const PkgDescriptorBase & pkgDescriptorBase )
-{
-  if ( pkgDescriptorBase.name.has_value() )
-    {
-      jto["name"] = *pkgDescriptorBase.name;
-    };
-  if ( pkgDescriptorBase.pname.has_value() )
-    {
-      jto["pname"] = *pkgDescriptorBase.pname;
-    };
-  if ( pkgDescriptorBase.version.has_value() )
-    {
-      jto["version"] = *pkgDescriptorBase.version;
-    };
-  if ( pkgDescriptorBase.semver.has_value() )
-    {
-      jto["semver"] = *pkgDescriptorBase.semver;
-    };
-}
-
-
-/* -------------------------------------------------------------------------- */
-
-void
 PkgQueryArgs::check() const
 {
 
@@ -203,7 +97,10 @@ PkgQueryArgs::check() const
 void
 PkgQueryArgs::clear()
 {
-  this->PkgDescriptorBase::clear();
+  this->name              = std::nullopt;
+  this->pname             = std::nullopt;
+  this->version           = std::nullopt;
+  this->semver            = std::nullopt;
   this->partialMatch      = std::nullopt;
   this->partialNameMatch  = std::nullopt;
   this->pnameOrAttrName   = std::nullopt;

--- a/src/search/params.cc
+++ b/src/search/params.cc
@@ -20,7 +20,10 @@ namespace flox::search {
 void
 SearchQuery::clear()
 {
-  this->pkgdb::PkgDescriptorBase::clear();
+  this->name             = std::nullopt;
+  this->pname            = std::nullopt;
+  this->version          = std::nullopt;
+  this->semver           = std::nullopt;
   this->partialMatch     = std::nullopt;
   this->partialNameMatch = std::nullopt;
 }
@@ -31,6 +34,25 @@ SearchQuery::clear()
 void
 SearchQuery::check() const
 {
+  /* `name' and `pname' or `version' cannot be used together. */
+  if ( this->name.has_value() && this->pname.has_value() )
+    {
+      throw ParseSearchQueryException(
+        "`name' and `pname' filters may not be used together." );
+    }
+  if ( this->name.has_value() && this->version.has_value() )
+    {
+      throw ParseSearchQueryException(
+        "`name' and `version' filters may not be used together." );
+    }
+
+  /* `version' and `semver' cannot be used together. */
+  if ( this->version.has_value() && this->semver.has_value() )
+    {
+      throw ParseSearchQueryException(
+        "`version' and `semver' filters may not be used together." );
+    }
+
   /* `partialMatch' and `partialNameMatch' cannot be used together. */
   if ( this->partialMatch.has_value() && this->partialNameMatch.has_value() )
     {

--- a/tests/pkgdb.cc
+++ b/tests/pkgdb.cc
@@ -276,40 +276,6 @@ test_descriptions0( flox::pkgdb::PkgDb & db )
 
 /* -------------------------------------------------------------------------- */
 
-/** @brief Test `flox::pkgdb::PkgDescriptorBase` gets deserialized correctly. */
-bool
-test_deserialize_PkgDescriptorBase()
-{
-  flox::pkgdb::PkgDescriptorBase pkgDescriptorBase
-    = pkgDescriptorBaseRaw.template get<flox::pkgdb::PkgDescriptorBase>();
-
-  // Do a non-exhaustive sanity check for now
-  EXPECT_EQ( pkgDescriptorBase.name.value(), "name" );
-  EXPECT_EQ( pkgDescriptorBase.pname.value(), "pname" );
-  EXPECT_EQ( pkgDescriptorBase.version.value(), "version" );
-  EXPECT_EQ( pkgDescriptorBase.semver.value(), "semver" );
-
-  return true;
-}
-
-/* -------------------------------------------------------------------------- */
-
-/** @brief Test `flox::pkgdb::PkgDescriptorBase` gets serialized correctly. */
-bool
-test_serialize_PkgDescriptorBase()
-{
-  flox::pkgdb::PkgDescriptorBase pkgDescriptorBase
-    = pkgDescriptorBaseRaw.template get<flox::pkgdb::PkgDescriptorBase>();
-
-  EXPECT_EQ( nlohmann::json( pkgDescriptorBase ).dump(),
-             pkgDescriptorBaseRaw.dump() );
-
-  return true;
-}
-
-
-/* -------------------------------------------------------------------------- */
-
 /* Tests `systems', `name', `pname', `version', and `subtree' filtering. */
 bool
 test_PkgQuery0( flox::pkgdb::PkgDb & db )
@@ -1042,9 +1008,6 @@ main( int argc, char * argv[] )
     RUN_TEST( hasPackage0, db );
 
     RUN_TEST( descriptions0, db );
-
-    RUN_TEST( deserialize_PkgDescriptorBase );
-    RUN_TEST( serialize_PkgDescriptorBase );
 
     RUN_TEST( PkgQuery0, db );
     RUN_TEST( PkgQuery1, db );


### PR DESCRIPTION
The `flox::pkgdb::PkgDescriptorBase` struct is no longer useful following
changes to search parameters and manifest descriptors.

This PR removes the struct and related docs.

The fields it provided to `PkgQueryArgs` and `SearchQuery` structs have been inlined there.
Ideally this should make the code-base slightly easier to read.
