### PR TITLE
test: naive grouping strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ else  # Darwin
 ifneq "$(findstring install,$(MAKECMDGOALS))" ""
 flox_pkgdb_LDFLAGS = '-L$(LIBDIR)' -lflox-pkgdb
 else
-flox_pkgdb_LDFLAGS += '-l$(MAKEFILE_DIR)/lib/libflox-pkgdb$(libExt)'
+flox_pkgdb_LDFLAGS += '$(MAKEFILE_DIR)/lib/libflox-pkgdb$(libExt)'
 endif # ifneq $(,$(findstring install,$(MAKECMDGOALS)))
 endif # ifeq (Linux,$(OS))
 endif # ifndef flox_pkgdb_LDFLAGS

--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,7 @@ $(BINDIR)/%: bin/% | install-dirs
 
 # Darwin has to relink
 ifneq (Linux,$(OS))
-LINK_INAME_FLAG = -Wl,-install_name,$(LIBDIR)/$(LIBFLOXPKGDB)
+LINK_INAME_FLAG = -install_name '$(LIBDIR)/$(LIBFLOXPKGDB)'
 $(LIBDIR)/$(LIBFLOXPKGDB): CXXFLAGS += $(lib_CXXFLAGS)
 $(LIBDIR)/$(LIBFLOXPKGDB): $(lib_SRCS:.cc=.o)
 	$(MKDIR_P) $(@D);

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ else  # Darwin
 ifneq "$(findstring install,$(MAKECMDGOALS))" ""
 flox_pkgdb_LDFLAGS = '-L$(LIBDIR)' -lflox-pkgdb
 else
-flox_pkgdb_LDFLAGS += '-l:$(MAKEFILE_DIR)/lib/libflox-pkgdb.$(libExt)'
+flox_pkgdb_LDFLAGS += '-l:$(MAKEFILE_DIR)/lib/libflox-pkgdb$(libExt)'
 endif # ifneq $(,$(findstring install,$(MAKECMDGOALS)))
 endif # ifeq (Linux,$(OS))
 endif # ifndef flox_pkgdb_LDFLAGS

--- a/Makefile
+++ b/Makefile
@@ -306,10 +306,11 @@ flox_pkgdb_LDFLAGS = -Wl,--enable-new-dtags '-Wl,-rpath,$$ORIGIN/../lib'
 flox_pkgdb_LDFLAGS += '-L$(MAKEFILE_DIR)/lib' -lflox-pkgdb
 else  # Darwin
 ifneq "$(findstring install,$(MAKECMDGOALS))" ""
-flox_pkgdb_LDFLAGS = '-L$(LIBDIR)' -lflox-pkgdb
+flox_pkgdb_LDFLAGS = '-L$(LIBDIR)'
 else
-flox_pkgdb_LDFLAGS += '$(MAKEFILE_DIR)/lib/libflox-pkgdb$(libExt)'
+flox_pkgdb_LDFLAGS += '-L$(MAKEFILE_DIR)/lib' -Wl,-rpath,@executable_path/../lib
 endif # ifneq $(,$(findstring install,$(MAKECMDGOALS)))
+flox_pkgdb_LDFLAGS += '-lflox-pkgdb'
 endif # ifeq (Linux,$(OS))
 endif # ifndef flox_pkgdb_LDFLAGS
 
@@ -390,6 +391,10 @@ else
 SONAME_FLAG =
 endif
 
+ifneq (Linux,$(OS))
+LINK_INAME_FLAG = -Wl,-install_name,@rpath/$(LIBFLOXPKGDB)
+lib/$(LIBFLOXPKGDB): CXXFLAGS += $(LINK_INAME_FLAG)
+endif # ifneq (Linux,$(OS))
 lib/$(LIBFLOXPKGDB): CXXFLAGS += $(lib_CXXFLAGS)
 lib/$(LIBFLOXPKGDB): $(lib_SRCS:.cc=.o)
 	$(MKDIR_P) $(@D);

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ else  # Darwin
 ifneq "$(findstring install,$(MAKECMDGOALS))" ""
 flox_pkgdb_LDFLAGS = '-L$(LIBDIR)' -lflox-pkgdb
 else
-flox_pkgdb_LDFLAGS += '-l:$(MAKEFILE_DIR)/lib/libflox-pkgdb$(libExt)'
+flox_pkgdb_LDFLAGS += '-l$(MAKEFILE_DIR)/lib/libflox-pkgdb$(libExt)'
 endif # ifneq $(,$(findstring install,$(MAKECMDGOALS)))
 endif # ifeq (Linux,$(OS))
 endif # ifndef flox_pkgdb_LDFLAGS

--- a/Makefile
+++ b/Makefile
@@ -393,12 +393,13 @@ endif
 
 ifneq (Linux,$(OS))
 LINK_INAME_FLAG = -install_name '@rpath/$(LIBFLOXPKGDB)'
-lib/$(LIBFLOXPKGDB): CXXFLAGS += $(LINK_INAME_FLAG)
+lib/$(LIBFLOXPKGDB): LDFLAGS += $(LINK_INAME_FLAG)
 endif # ifneq (Linux,$(OS))
+lib/$(LIBFLOXPKGDB): LDFLAGS  += $(lib_LDFLAGS)
 lib/$(LIBFLOXPKGDB): CXXFLAGS += $(lib_CXXFLAGS)
 lib/$(LIBFLOXPKGDB): $(lib_SRCS:.cc=.o)
 	$(MKDIR_P) $(@D);
-	$(CXX) $(filter %.o,$^) $(LDFLAGS) $(lib_LDFLAGS) $(SONAME_FLAG) -o $@;
+	$(CXX) $(filter %.o,$^) $(LDFLAGS) $(SONAME_FLAG) -o $@;
 
 
 # ---------------------------------------------------------------------------- #
@@ -449,12 +450,12 @@ $(BINDIR)/%: bin/% | install-dirs
 
 # Darwin has to relink
 ifneq (Linux,$(OS))
-LINK_INAME_FLAG = -install_name '$(LIBDIR)/$(LIBFLOXPKGDB)'
+LINK_INAME_FLAG = -install_name '@rpath/$(LIBFLOXPKGDB)'
 $(LIBDIR)/$(LIBFLOXPKGDB): CXXFLAGS += $(lib_CXXFLAGS)
+$(LIBDIR)/$(LIBFLOXPKGDB): LDFLAGS  += $(lib_LDFLAGS)
 $(LIBDIR)/$(LIBFLOXPKGDB): $(lib_SRCS:.cc=.o)
 	$(MKDIR_P) $(@D);
-	$(CXX) $(filter %.o,$^) $(LDFLAGS) $(lib_LDFLAGS) $(LINK_INAME_FLAG)  \
-	       -o $@;
+	$(CXX) $(filter %.o,$^) $(LDFLAGS) -o $@;
 
 $(BINDIR)/pkgdb: $(bin_SRCS:.cc=.o) $(LIBDIR)/$(LIBFLOXPKGDB)
 	$(MKDIR_P) $(@D);

--- a/Makefile
+++ b/Makefile
@@ -303,13 +303,13 @@ nix_LDFLAGS := $(nix_LDFLAGS)
 ifndef flox_pkgdb_LDFLAGS
 ifeq (Linux,$(OS))
 flox_pkgdb_LDFLAGS = -Wl,--enable-new-dtags '-Wl,-rpath,$$ORIGIN/../lib'
-else  # Darwin
-ifneq "$(findstring install,$(MAKECMDGOALS))" ""
-flox_pkgdb_LDFLAGS = '-L$(LIBDIR)'
-endif # ifneq $(,$(findstring install,$(MAKECMDGOALS)))
 flox_pkgdb_LDFLAGS += '-L$(MAKEFILE_DIR)/lib' -lflox-pkgdb
 else  # Darwin
+ifneq "$(findstring install,$(MAKECMDGOALS))" ""
+flox_pkgdb_LDFLAGS = '-L$(LIBDIR)' -lflox-pkgdb
+else
 flox_pkgdb_LDFLAGS += '-l:$(MAKEFILE_DIR)/lib/libflox-pkgdb.$(libExt)'
+endif # ifneq $(,$(findstring install,$(MAKECMDGOALS)))
 endif # ifeq (Linux,$(OS))
 endif # ifndef flox_pkgdb_LDFLAGS
 

--- a/Makefile
+++ b/Makefile
@@ -308,9 +308,9 @@ else  # Darwin
 ifneq "$(findstring install,$(MAKECMDGOALS))" ""
 flox_pkgdb_LDFLAGS = '-L$(LIBDIR)'
 else
-flox_pkgdb_LDFLAGS += '-L$(MAKEFILE_DIR)/lib' -Wl,-rpath,@executable_path/../lib
+flox_pkgdb_LDFLAGS += '-L$(MAKEFILE_DIR)/lib' -rpath @executable_path/../lib
 endif # ifneq $(,$(findstring install,$(MAKECMDGOALS)))
-flox_pkgdb_LDFLAGS += '-lflox-pkgdb'
+flox_pkgdb_LDFLAGS += -lflox-pkgdb
 endif # ifeq (Linux,$(OS))
 endif # ifndef flox_pkgdb_LDFLAGS
 
@@ -392,7 +392,7 @@ SONAME_FLAG =
 endif
 
 ifneq (Linux,$(OS))
-LINK_INAME_FLAG = -Wl,-install_name,@rpath/$(LIBFLOXPKGDB)
+LINK_INAME_FLAG = -install_name '@rpath/$(LIBFLOXPKGDB)'
 lib/$(LIBFLOXPKGDB): CXXFLAGS += $(LINK_INAME_FLAG)
 endif # ifneq (Linux,$(OS))
 lib/$(LIBFLOXPKGDB): CXXFLAGS += $(lib_CXXFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -382,8 +382,7 @@ fullclean: clean
 # ---------------------------------------------------------------------------- #
 
 %.o: %.cc $(COMMON_HEADERS)
-	@echo '$(CXX) <CXXFLAGS> -c $< -o $@;' >&2;
-	@$(CXX) $(CXXFLAGS) -c $< -o $@;
+	$(CXX) $(CXXFLAGS) -c $< -o $@;
 
 ifeq (Linux,$(OS))
 SONAME_FLAG = -Wl,-soname,$(LIBFLOXPKGDB)
@@ -394,8 +393,7 @@ endif
 lib/$(LIBFLOXPKGDB): CXXFLAGS += $(lib_CXXFLAGS)
 lib/$(LIBFLOXPKGDB): $(lib_SRCS:.cc=.o)
 	$(MKDIR_P) $(@D);
-	@echo '$(CXX) $(filter %.o,$^) <LDFLAGS> -o $@;' >&2;
-	@$(CXX) $(filter %.o,$^) $(LDFLAGS) $(lib_LDFLAGS) $(SONAME_FLAG) -o $@;
+	$(CXX) $(filter %.o,$^) $(LDFLAGS) $(lib_LDFLAGS) $(SONAME_FLAG) -o $@;
 
 
 # ---------------------------------------------------------------------------- #
@@ -403,13 +401,11 @@ lib/$(LIBFLOXPKGDB): $(lib_SRCS:.cc=.o)
 src/pkgdb/write.o: src/pkgdb/schemas.hh
 
 $(bin_SRCS:.cc=.o): %.o: %.cc $(COMMON_HEADERS)
-	@echo '$(CXX) <CXXFLAGS> -c $< -o $@;' >&2;
-	@$(CXX) $(CXXFLAGS) $(bin_CXXFLAGS) -c $< -o $@;
+	$(CXX) $(CXXFLAGS) $(bin_CXXFLAGS) -c $< -o $@;
 
 bin/pkgdb: $(bin_SRCS:.cc=.o) lib/$(LIBFLOXPKGDB)
 	$(MKDIR_P) $(@D);
-	@echo '$(CXX) $(filter %.o,$^) <LDFLAGS> -o $@;' >&2;
-	@$(CXX) $(filter %.o,$^) $(LDFLAGS) $(bin_LDFLAGS) -o $@;
+	$(CXX) $(filter %.o,$^) $(LDFLAGS) $(bin_LDFLAGS) -o $@;
 
 
 # ---------------------------------------------------------------------------- #
@@ -417,8 +413,7 @@ bin/pkgdb: $(bin_SRCS:.cc=.o) lib/$(LIBFLOXPKGDB)
 $(TESTS) $(TEST_UTILS): $(COMMON_HEADERS)
 $(TESTS) $(TEST_UTILS): bin_CXXFLAGS += '-DTEST_DATA_DIR="$(TEST_DATA_DIR)"'
 $(TESTS) $(TEST_UTILS): tests/%: tests/%.cc lib/$(LIBFLOXPKGDB)
-	@echo '$(CXX) <CXXFLAGS> $< <LDFLAGS> -o $@;' >&2;
-	@$(CXX) $(CXXFLAGS) $(bin_CXXFLAGS) $< $(LDFLAGS) $(bin_LDFLAGS) -o $@;
+	$(CXX) $(CXXFLAGS) $(bin_CXXFLAGS) $< $(LDFLAGS) $(bin_LDFLAGS) -o $@;
 
 
 # ---------------------------------------------------------------------------- #
@@ -453,14 +448,12 @@ LINK_INAME_FLAG = -Wl,-install_name,$(LIBDIR)/$(LIBFLOXPKGDB)
 $(LIBDIR)/$(LIBFLOXPKGDB): CXXFLAGS += $(lib_CXXFLAGS)
 $(LIBDIR)/$(LIBFLOXPKGDB): $(lib_SRCS:.cc=.o)
 	$(MKDIR_P) $(@D);
-	@echo '$(CXX) $(filter %.o,$^) <LDFLAGS> -o $@;' >&2;
-	@$(CXX) $(filter %.o,$^) $(LDFLAGS) $(lib_LDFLAGS) $(LINK_INAME_FLAG)  \
+	$(CXX) $(filter %.o,$^) $(LDFLAGS) $(lib_LDFLAGS) $(LINK_INAME_FLAG)  \
 	       -o $@;
 
 $(BINDIR)/pkgdb: $(bin_SRCS:.cc=.o) $(LIBDIR)/$(LIBFLOXPKGDB)
 	$(MKDIR_P) $(@D);
-	@echo '$(CXX) $(filter %.o,$^) <LDFLAGS> -o $@;' >&2;
-	@$(CXX) $(filter %.o,$^) $(LDFLAGS) $(bin_LDFLAGS) -o $@;
+	$(CXX) $(filter %.o,$^) $(LDFLAGS) $(bin_LDFLAGS) -o $@;
 endif # ifneq (Linux,$(OS))
 
 #: Install binaries
@@ -497,8 +490,7 @@ $(PRE_COMPILED_HEADERS): CXXFLAGS += $(lib_CXXFLAGS) $(bin_CXXFLAGS)
 $(PRE_COMPILED_HEADERS): $(COMMON_HEADERS) $(DEPFILES)
 $(PRE_COMPILED_HEADERS): $(lastword $(MAKEFILE_LIST))
 $(PRE_COMPILED_HEADERS): %.gch: %
-	@echo '$(CXX) <CXXFLAGS> -x c++-header -c $< -o $@ 2>/dev/null;' >&2;
-	@$(CXX) $(CXXFLAGS) -x c++-header -c $< -o $@ 2>/dev/null;
+	$(CXX) $(CXXFLAGS) -x c++-header -c $< -o $@ 2>/dev/null;
 
 #: Create pre-compiled-headers
 pre-compiled-headers: $(PRE_COMPILED_HEADERS)
@@ -507,8 +499,7 @@ pre-compiled-headers: $(PRE_COMPILED_HEADERS)
 # This is used when creating our compilation databases to ensure that
 # pre-compiled headers aren't taking priority over _real_ headers.
 clean-pch: FORCE
-	@echo $(RM) '<PRE_COMPILED_HEADERS>;' >&2;
-	@$(RM) $(PRE_COMPILED_HEADERS);
+	$(RM) $(PRE_COMPILED_HEADERS);
 
 
 # ---------------------------------------------------------------------------- #
@@ -565,12 +556,10 @@ compile_commands.json: bear.d/c++ $(DEPFILES)
 compile_commands.json: $(lastword $(MAKEFILE_LIST))
 compile_commands.json: $(COMMON_HEADERS) $(ALL_SRCS)
 	-$(MAKE) -C $(MAKEFILE_DIR) clean;
-	@echo '$(BEAR) -- $(MAKE) -C $(MAKEFILE_DIR) -j bin tests' >&2;
-	@EXTRA_CXXFLAGS='$(EXTRA_CXXFLAGS)'                    \
+	EXTRA_CXXFLAGS='$(EXTRA_CXXFLAGS)'                     \
 	  PATH="$(MAKEFILE_DIR)/bear.d/:$(PATH)"               \
 	  $(BEAR) -- $(MAKE) -C $(MAKEFILE_DIR) -j bin tests;
-	@echo '$(BEAR) -- $(MAKE) -C $(MAKEFILE_DIR) -j pre-compiled-headers' >&2;
-	@EXTRA_CXXFLAGS='$(EXTRA_CXXFLAGS)'                                        \
+	EXTRA_CXXFLAGS='$(EXTRA_CXXFLAGS)'                                         \
 	  PATH="$(MAKEFILE_DIR)/bear.d/:$(PATH)"                                   \
 	  $(BEAR) --append -- $(MAKE) -C $(MAKEFILE_DIR) -j pre-compiled-headers;
 	$(MAKE) -C $(MAKEFILE_DIR) clean-pch;

--- a/Makefile
+++ b/Makefile
@@ -307,8 +307,10 @@ else  # Darwin
 ifneq "$(findstring install,$(MAKECMDGOALS))" ""
 flox_pkgdb_LDFLAGS = '-L$(LIBDIR)'
 endif # ifneq $(,$(findstring install,$(MAKECMDGOALS)))
-endif # ifeq (Linux,$(OS))
 flox_pkgdb_LDFLAGS += '-L$(MAKEFILE_DIR)/lib' -lflox-pkgdb
+else  # Darwin
+flox_pkgdb_LDFLAGS += '-l:$(MAKEFILE_DIR)/lib/libflox-pkgdb.$(libExt)'
+endif # ifeq (Linux,$(OS))
 endif # ifndef flox_pkgdb_LDFLAGS
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
         # For tests
         batsWith
         pkgs.jq
+        pkgs.yj
         # For doc
         pkgs.doxygen
       ];

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -608,8 +608,8 @@ Environment::lockSystem( const System & system )
           [&]( const ResolutionFailure & failure )
           {
             /* We should only hit this on the first iteration.
-             * TODO: throw sooner rather than trying to resolve every
-             * group? */
+             * TODO: throw sooner rather than trying to resolve
+             * every group? */
             if ( failure.empty() )
               {
                 throw ResolutionFailureException(

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -381,8 +381,8 @@ Environment::lockPackage( const LockedInputRaw & input,
  * - If groups are combined into a new group with a new name, we want to try to
  * use one of the old locked inputs (for now we just use the first one we find).
  *
- * If, on the other hand, a package has changed, we don't want to use its locked
- * input.
+ * If, on the other hand, a package has changed, we don't want to use its
+ * locked input.
  *
  * @return a locked input related to the group if we can find one, or else
  *         `std::nullopt`
@@ -417,12 +417,13 @@ Environment::getGroupInput( const InstallDescriptors & group,
                    * old lockfile and present in the new manifest.
                    *
                    * Don't use a locked input if the package has changed.
-                   * The * following fields control what the package actually
-                   * *is*, * while:
+                   * The fields handled below control what the package actually
+                   * *is* while:
                    * - `optional' and `systems' control how we behave if
                    *   resolution fails, but they don't change the package.
-                   * - `priority' is a setting for mkEnv
-                   * - `group' is handled below
+                   * - `priority' is a setting for `mkEnv' and is passed through
+                   *   without effecting resolution.
+                   * - `group' is handled below.
                    */
                   if ( ( descriptor.name == oldDescriptor.name )
                        && ( descriptor.path == oldDescriptor.path )

--- a/tests/groups.bats
+++ b/tests/groups.bats
@@ -1,0 +1,227 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# `pkgdb manifest' tests related to package groups.
+#
+# ---------------------------------------------------------------------------- #
+
+load setup_suite.bash;
+
+# bats file_tags=resolver:manifest, resolver:groups
+
+setup_file() {
+  export PROJ2="$TESTS_DIR/harnesses/proj2";
+
+  # We don't parallelize these to avoid DB sync headaches and to recycle the
+  # cache between tests.
+  # Nonetheless this file makes an effort to avoid depending on past state in
+  # such a way that would make it difficult to eventually parallelize in
+  # the future.
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true;
+
+  # Extract revisions from the manifest.
+  STABLE_REV="$(
+    yj -t <"$PROJ2/manifest.toml"|jq -r '.registry.inputs.stable.from.rev';
+  )";
+  STAGING_REV="$(
+    yj -t <"$PROJ2/manifest.toml"|jq -r '.registry.inputs.staging.from.rev';
+  )";
+  UNSTABLE_REV="$(
+    yj -t <"$PROJ2/manifest.toml"|jq -r '.registry.inputs.unstable.from.rev';
+  )";
+  export STABLE_REV STAGING_REV UNSTABLE_REV;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# Create a directory with a JSON manifest file based on `proj2/manifest.toml'.
+setup_project() {
+  local _dir;
+  _dir="${1:-$BATS_TEST_TMPDIR/project}";
+  mkdir -p "$_dir";
+  pushd "$_dir" >/dev/null||return;
+  yj -t <"$PROJ2/manifest.toml" > manifest.json;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# Edit a JSON file with `jq' in-place.
+jq_edit() {
+  local _file="${1?You must provide a target file}";
+  local _command="${2?You must provide a jq command}";
+  local _tmp;
+  _tmp="${_file}~";
+  jq "$_command" "$_file" >"$_tmp";
+  mv "$_tmp" "$_file";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=resolver:no-lockfile, resolver:singleton-groups
+
+# This has three packages in singleton groups.
+# One of them is in the default group.
+# The other two are in non-default groups.
+# It is not possible for all three to resolve to a single revision.
+#
+# We expect each descriptor to resolve to a different revision when processed
+# in separate groups.
+@test "'pkgdb manifest lock' singleton groups with no previous lock" {
+  setup_project;
+
+  run sh -c 'pkgdb manifest lock manifest.json > manifest.lock;';
+  assert_success;
+
+  run jq -r '.packages["x86_64-linux"].nodejsOld.input.attrs.rev' manifest.lock;
+  assert_success;
+  assert_output "$STABLE_REV";
+
+  run jq -r '.packages["x86_64-linux"].nodejs.input.attrs.rev' manifest.lock;
+  assert_success;
+  assert_output "$STAGING_REV";
+
+  run jq -r '.packages["x86_64-linux"].nodejsNew.input.attrs.rev' manifest.lock;
+  assert_success;
+  assert_output "$UNSTABLE_REV";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=resolver:no-lockfile, resolver:groups
+
+# It is not possible for all three to resolve to a single revision,
+# so we expect failure here.
+@test "'pkgdb manifest lock' impossible group" {
+  setup_project;
+
+  jq_edit manifest.json '.install.nodejsOld|=del( .["package-group"] )
+                         |.install.nodejsNew|=del( .["package-group"] )';
+
+  run sh -c 'pkgdb manifest lock manifest.json > manifest.lock;';
+  assert_failure;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=resolver:no-lockfile, resolver:groups
+
+# We can get two of our descriptors in a single revision, but not all three.
+@test "'pkgdb manifest lock' groups with no previous lock" {
+  setup_project;
+
+  jq_edit manifest.json '.install.nodejsNew|=del( .["package-group"] )';
+
+  run sh -c 'pkgdb manifest lock manifest.json > manifest.lock;';
+  assert_success;
+
+  run jq -r '.packages["x86_64-linux"].nodejsOld.input.attrs.rev' manifest.lock;
+  assert_success;
+  assert_output "$STABLE_REV";
+
+  run jq -r '.packages["x86_64-linux"].nodejs.input.attrs.rev' manifest.lock;
+  assert_success;
+  assert_output "$UNSTABLE_REV";
+
+  run jq -r '.packages["x86_64-linux"].nodejsNew.input.attrs.rev' manifest.lock;
+  assert_success;
+  assert_output "$UNSTABLE_REV";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=resolver:lockfile, resolver:groups, resolver:optional
+
+# Like the test above but adds `nodejsNew' after the lock is created.
+# This changes the resolution of `nodejs' to use _staging_ instead of
+# _unstable_, making it impossible to resolve `nodejsNew' later.
+@test "'pkgdb manifest lock' impossible group with previous lock" {
+  setup_project;
+
+  jq_edit manifest.json '.install|=del( .nodejsNew )';
+
+  run sh -c 'pkgdb manifest lock manifest.json|tee manifest.lock;';
+  assert_success;
+
+  run jq -r '.packages["x86_64-linux"].nodejsOld.input.attrs.rev' manifest.lock;
+  assert_success;
+  assert_output "$STABLE_REV";
+
+  run jq -r '.packages["x86_64-linux"].nodejs.input.attrs.rev' manifest.lock;
+  assert_success;
+  assert_output "$STAGING_REV";
+
+  jq_edit manifest.json '.install.nodejsNew={
+    "name": "nodejs", "version": "^18.17"
+  }';
+
+  # This doesn't have `pipefail' so we will always get a `manifest.lock2'
+  # even if resolution fails.
+  run sh -c 'pkgdb manifest lock --lockfile manifest.lock manifest.json  \
+               |tee manifest.lock2;';
+  assert_success;
+
+  run jq -r '.category_message' manifest.lock2;
+  assert_output "resolution failure";
+
+  # Making the package optional fixes makes it possible to resolve.
+  jq_edit manifest.json '.install.nodejsNew.optional=true';
+  run sh -c 'pkgdb manifest lock --lockfile manifest.lock manifest.json  \
+               |tee manifest.lock3;';
+  assert_success;
+
+  run jq -r '.packages["x86_64-linux"].nodejsNew' manifest.lock3;
+  assert_success;
+  assert_output 'null';
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=resolver:lockfile, resolver:groups
+
+# Like the test above but adds `nodejs' after the lock is created.
+@test "'pkgdb manifest lock' group with previous lock" {
+  setup_project;
+
+  jq_edit manifest.json '.install|=del( .nodejs )
+                         |.install.nodejsNew|=del( .["package-group"] )';
+
+  run sh -c 'pkgdb manifest lock manifest.json|tee manifest.lock;';
+  assert_success;
+
+  run jq -r '.packages["x86_64-linux"].nodejsOld.input.attrs.rev' manifest.lock;
+  assert_success;
+  assert_output "$STABLE_REV";
+
+  run jq -r '.packages["x86_64-linux"].nodejsNew.input.attrs.rev' manifest.lock;
+  assert_success;
+  assert_output "$UNSTABLE_REV";
+
+  jq_edit manifest.json '.install.nodejs={
+    "name": "nodejs", "version": ">=18.15.0 <19.0.0"
+  }';
+
+  # This doesn't have `pipefail' so we will always get a `manifest.lock2'
+  # even if resolution fails.
+  run sh -c 'pkgdb manifest lock --lockfile manifest.lock manifest.json  \
+               |tee manifest.lock2;';
+  assert_success;
+
+  run jq -r '.packages["x86_64-linux"].nodejs.input.attrs.rev' manifest.lock2;
+  assert_success;
+  assert_output "$UNSTABLE_REV";
+}
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/tests/groups.bats
+++ b/tests/groups.bats
@@ -138,6 +138,10 @@ jq_edit() {
 
 # bats test_tags=resolver:lockfile, resolver:groups, resolver:optional
 
+# XXX: This test case shows an undesirable behavior.
+# Use it as a case study for making improvements and later, remove it or modify
+# it to reflect the new behavior.
+
 # Like the test above but adds `nodejsNew' after the lock is created.
 # This changes the resolution of `nodejs' to use _staging_ instead of
 # _unstable_, making it impossible to resolve `nodejsNew' later.

--- a/tests/harnesses/proj2/manifest.toml
+++ b/tests/harnesses/proj2/manifest.toml
@@ -1,0 +1,76 @@
+# ============================================================================ #
+#
+# Tests upgrade behavior for ungrouped packages.
+# Specifically we're interested in how revisions are deduplicated.
+#
+# ---------------------------------------------------------------------------- #
+
+[options]
+systems = ["x86_64-linux"]
+
+
+# ---------------------------------------------------------------------------- #
+
+[registry]
+[registry.defaults]
+subtrees = ["legacyPackages"]
+
+
+# ---------------------------------------------------------------------------- #
+
+[registry.inputs.stable.from]
+type = "github"
+owner = "NixOS"
+repo = "nixpkgs"
+rev = "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b"
+# nodejs@18.14.1
+
+[registry.inputs.staging.from]
+type = "github"
+owner = "NixOS"
+repo = "nixpkgs"
+rev = "e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+# nodejs@18.16.0
+
+[registry.inputs.unstable.from]
+type = "github"
+owner = "NixOS"
+repo = "nixpkgs"
+rev = "9faf91e6d0b7743d41cce3b63a8e5c733dc696a3"
+# nodejs@18.17.1
+
+
+# ---------------------------------------------------------------------------- #
+#
+# Without `package-group' declarations the default resolution strategy tries to
+# put all packages who do not declare a group into a _default group_.
+# This would cause the following requests to fail, since you cannot resolve all
+# three of these descriptors in any single revision.
+#
+# This behavior tends to prevent upgrades in cases where descriptors
+# declare semantic version ranges for the same reason.
+#
+#
+# ---------------------------------------------------------------------------- #
+
+[install]
+# Normally resolves in _stable_ revision
+nodejsOld.name          = "nodejs"
+nodejsOld.version       = "^18 <18.16"
+nodejsOld.package-group = "old"
+
+# Normally resolves in _staging_ revision
+nodejs.name    = "nodejs"
+nodejs.version = ">=18.15.0 <19.0.0"
+
+# Normally resolves in _unstable_ revision
+nodejsNew.name          = "nodejs"
+nodejsNew.version       = "^18.17"
+nodejsNew.package-group = "new"
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/tests/util.cc
+++ b/tests/util.cc
@@ -218,6 +218,42 @@ test_hasPrefix0()
 
 /* -------------------------------------------------------------------------- */
 
+bool
+test_ltrim_copy0()
+{
+  std::string str( "  foo " );
+  EXPECT_EQ( flox::ltrim_copy( str ), "foo " );
+  EXPECT_EQ( flox::ltrim_copy( str ), flox::ltrim_copy( str ) );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+bool
+test_rtrim_copy0()
+{
+  std::string str( "  foo " );
+  EXPECT_EQ( flox::rtrim_copy( str ), "  foo" );
+  EXPECT_EQ( flox::rtrim_copy( str ), flox::rtrim_copy( str ) );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+bool
+test_trim_copy0()
+{
+  std::string str( "  foo " );
+  EXPECT_EQ( flox::trim_copy( str ), "foo" );
+  EXPECT_EQ( flox::trim_copy( str ), flox::trim_copy( str ) );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 int
 main()
 {
@@ -236,6 +272,10 @@ main()
   RUN_TEST( variantJSON1 );
   RUN_TEST( variantJSON2 );
   RUN_TEST( variantJSON3 );
+
+  RUN_TEST( ltrim_copy0 );
+  RUN_TEST( rtrim_copy0 );
+  RUN_TEST( trim_copy0 );
 
   RUN_TEST( hasPrefix0 );
 


### PR DESCRIPTION
- test: add new harness manifest and [lr]trim tests
- test: add tests for groups
- test: add note in about naive group implementation's limitations

There's an `XXX:` block for one test which is worth reviewing in detail.
It shows in practice what _naive implementation_ meant practically, and highlights one limitation that we would like to improve in the near future.
