### PR TITLE
doc: inline doc for Environment

### DIFF
--- a/include/flox/resolver/environment.hh
+++ b/include/flox/resolver/environment.hh
@@ -203,13 +203,15 @@ private:
 protected:
 
   /**
-   * @brief Get locked input from a lockfile to try to use to resolve a group of
-   *        packages.
+   * @brief Get locked input from a lockfile to try to use to resolve a group
+   *        of packages.
    *
-   * Helper function for @a flox::resolver::Environment::lockSystem. Choosing
-   * the locked input for a group is full of edge cases, because the new group
-   * may be different than whatever was in the group in the old lockfile. We
-   * still want to reuse old locked inputs when we can. For example:
+   * Helper function for @a flox::resolver::Environment::lockSystem.
+   * Choosing the locked input for a group is full of edge cases, because the
+   * new group may be different than whatever was in the group in the
+   * old lockfile.
+   * We still want to reuse old locked inputs when we can.
+   * For example:
    * - If the group name has changed, but nothing else has, we want to use the
    *   locked input.
    * - If packages have been added to a group, we want to use the locked input

--- a/include/flox/resolver/environment.hh
+++ b/include/flox/resolver/environment.hh
@@ -81,6 +81,9 @@ using ResolutionFailure = std::vector<std::pair<InstallID, std::string>>;
  */
 using ResolutionResult = std::variant<ResolutionFailure, SystemPackages>;
 
+
+/* -------------------------------------------------------------------------- */
+
 /**
  * @brief A collection of data associated with an environment and its state.
  *
@@ -206,7 +209,6 @@ private:
                      const pkgdb::PkgDbInput &  input,
                      const System &             system );
 
-  // TODO: Only update changed descriptors.
   /**
    * @brief Lock all descriptors for a given system.
    *        This is a helper function of
@@ -218,6 +220,7 @@ private:
    */
   void
   lockSystem( const System & system );
+
 
 protected:
 
@@ -255,8 +258,8 @@ protected:
    *
    * Checks if:
    * - All descriptors are present in the old manifest.
-   * - No descriptors have changed in the old manifest such that the lock is
-   *   invalidated.
+   * - No descriptors have changed in the old manifest such that the lock
+   *   is invalidated.
    * - All descriptors are present in the old lock
    */
   [[nodiscard]] bool

--- a/include/flox/resolver/environment.hh
+++ b/include/flox/resolver/environment.hh
@@ -136,14 +136,12 @@ private:
 
   /**
    * @brief Get groups that need to be locked as opposed to reusing locks from
-   * @a oldLockfile.
+   *        @a oldLockfile.
    */
   [[nodiscard]] std::vector<InstallDescriptors>
   getUnlockedGroups( const System & system );
 
-  /**
-   * @brief Get groups with locks that can be reused from @a oldLockfile.
-   */
+  /** @brief Get groups with locks that can be reused from @a oldLockfile. */
   [[nodiscard]] std::vector<InstallDescriptors>
   getLockedGroups( const System & system );
 
@@ -169,8 +167,8 @@ private:
    * @brief Try to resolve a group of descriptors
    *
    * Attempts to resolve using a locked input from the old lockfile if it exists
-   * for the group. If not, inputs from the combined environment registry are
-   * used.
+   * for the group. If not, inputs from the combined environment registry
+   * are used.
    *
    * @return `std::nullopt` if resolution fails, otherwise a set of
    *          resolved packages.
@@ -182,7 +180,7 @@ private:
    * @brief Try to resolve a group of descriptors in a given package database.
    *
    * @return InstallID of the package that can't be resolved if resolution
-   * fails, otherwise a set of resolved packages for the system.
+   *         fails, otherwise a set of resolved packages for the system.
    */
   [[nodiscard]] std::variant<InstallID, SystemPackages>
   tryResolveGroupIn( const InstallDescriptors & group,
@@ -213,18 +211,18 @@ protected:
    * may be different than whatever was in the group in the old lockfile. We
    * still want to reuse old locked inputs when we can. For example:
    * - If the group name has changed, but nothing else has, we want to use the
-   * locked input.
+   *   locked input.
    * - If packages have been added to a group, we want to use the locked input
-   * from a package that was already in the group.
+   *   from a package that was already in the group.
    * - If groups are combined into a new group with a new name, we want to try
-   * to use one of the old locked inputs (for now we just use the first one we
-   * find).
+   *   to use one of the old locked inputs ( for now we just use the first one
+   *   we find ).
    *
    * If, on the other hand, a package has changed, we don't want to use its
    * locked input.
    *
-   * @return a locked input related to the group if we can find one, or else
-   *         `std::nullopt`
+   * @return a locked input related to the group if we can find one,
+   *         otherwise `std::nullopt`.
    */
   [[nodiscard]] std::optional<LockedInputRaw>
   getGroupInput( const InstallDescriptors & group,

--- a/include/flox/resolver/environment.hh
+++ b/include/flox/resolver/environment.hh
@@ -59,8 +59,27 @@ FLOX_DEFINE_EXCEPTION( ResolutionFailureException,
 
 /* -------------------------------------------------------------------------- */
 
+/**
+ * @brief A pair of _install ID_ and locked flake URLs used to memoize failed
+ *        resolution attempts for a given descriptor.
+ *
+ * This allows us to skip attempting to resolve the same descriptor again in
+ * the same inputs later.
+ */
 using ResolutionFailure = std::vector<std::pair<InstallID, std::string>>;
-using ResolutionResult  = std::variant<ResolutionFailure, SystemPackages>;
+
+/**
+ * @brief Either a set of resolved packages ( for a given system ) or a memo
+ *        indicating that resolution failed for certain descriptors against
+ *        certain inputs.
+ *
+ * When attempting to resolve a group of packages for a given system,
+ * we either succeed and return @a flox::resolver::SystemPackages or
+ * fail and return @a flox::resolver::ResolutionFailure.
+ * This allows us to skip attempting to resolve the same descriptor again in
+ * the same inputs later.
+ */
+using ResolutionResult = std::variant<ResolutionFailure, SystemPackages>;
 
 /**
  * @brief A collection of data associated with an environment and its state.

--- a/src/pkgdb/write.cc
+++ b/src/pkgdb/write.cc
@@ -445,12 +445,11 @@ PkgDb::scrape( nix::SymbolTable & syms, const Target & target, Todos & todo )
           if ( ! tryRecur ) { continue; }
           if ( auto maybe = child->maybeGetAttr( "recurseForDerivations" );
                ( ( maybe != nullptr ) && maybe->getBool() )
-               /* We explicitly recurse into legacyPackages.*.darwin
-                * due to a bug in nixpkgs which doesn't set
-                * recurseForDerivations attribute correctly.
-                */
-               || ( prefix.front() == "legacyPackages" && syms[aname] == "darwin" )
-             )
+               /* XXX: We explicitly recurse into `legacyPackages.*.darwin'
+                *      due to a bug in `nixpkgs' which doesn't set
+                *      `recurseForDerivations' attribute correctly. */
+               || ( ( prefix.front() == "legacyPackages" )
+                    && ( syms[aname] == "darwin" ) ) )
             {
               flox::AttrPath path = prefix;
               path.emplace_back( syms[aname] );

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -160,8 +160,8 @@ Environment::groupIsLocked( const InstallDescriptors & group,
       {
         bool stale = false;
         std::visit(
-          overloaded { /* If we are upgrading everything, we treat all groups as
-                          "unlocked". */
+          overloaded { /* If we are upgrading everything, we treat all groups
+                        * as "unlocked". */
                        [&]( bool upgradeEverything )
                        {
                          if ( upgradeEverything ) { stale = true; }
@@ -271,7 +271,7 @@ Environment::getLockedGroups( const System & system )
 
   auto groupedDescriptors = this->getManifest().getGroupedDescriptors();
 
-  /* Remove all groups that are ~not~ already locked. */
+  /* Remove all groups that are *not* already locked. */
   for ( auto group = groupedDescriptors.begin();
         group != groupedDescriptors.end(); )
     {
@@ -387,27 +387,6 @@ Environment::lockPackage( const LockedInputRaw & input,
 
 /* -------------------------------------------------------------------------- */
 
-/**
- * @brief Get locked input from a lockfile to try to use to resolve a group of
- *        packages.
- *
- * Helper function for @a flox::resolver::Environment::lockSystem. Choosing the
- * locked input for a group is full of edge cases, because the new group may be
- * different than whatever was in the group in the old lockfile. We still want
- * to reuse old locked inputs when we can. For example:
- * - If the group name has changed, but nothing else has, we want to use the
- * locked input.
- * - If packages have been added to a group, we want to use the locked input
- * from a package that was already in the group.
- * - If groups are combined into a new group with a new name, we want to try to
- * use one of the old locked inputs (for now we just use the first one we find).
- *
- * If, on the other hand, a package has changed, we don't want to use its
- * locked input.
- *
- * @return a locked input related to the group if we can find one, or else
- *         `std::nullopt`
- */
 std::optional<LockedInputRaw>
 Environment::getGroupInput( const InstallDescriptors & group,
                             const Lockfile &           oldLockfile,

--- a/src/resolver/environment.cc
+++ b/src/resolver/environment.cc
@@ -467,7 +467,10 @@ ResolutionResult
 Environment::tryResolveGroup( const InstallDescriptors & group,
                               const System &             system )
 {
-  ResolutionFailure                failure;
+  /* Memoized list of resolution failures to avoid re-checking descriptors
+   * in inputs which are known to fail. */
+  ResolutionFailure failure;
+
   std::optional<pkgdb::PkgDbInput> oldGroupInput;
   if ( auto oldLockfile = this->getOldLockfile(); oldLockfile.has_value() )
     {
@@ -499,11 +502,12 @@ Environment::tryResolveGroup( const InstallDescriptors & group,
             }
         }
     }
+
   // TODO: Use `getCombinedRegistryRaw()'
   for ( const auto & [_, input] : *this->getPkgDbRegistry() )
     {
       /* If we already tried to resolve in this input - skip it. */
-      if ( ! oldGroupInput.has_value() || *input == *oldGroupInput )
+      if ( ! oldGroupInput.has_value() || ( ( *input ) == ( *oldGroupInput ) ) )
         {
           {
             auto maybeResolved


### PR DESCRIPTION
- doc: `ResolutionFailure` and `ResolutionResult`.
- doc: Inline comments for `Environment::tryResolveGroup()`.
- style: use `std::visit( overloaded ... )` when possible.
- style: minor refactor of some conditionals to put simple bodies before
  complex bodies.
  + for ease of reading.
