### PR TITLE
feat: parse descriptors from strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ bin_SRCS       =  src/main.cc src/repl.cc
 bin_SRCS       += $(addprefix src/pkgdb/,scrape.cc get.cc command.cc)
 bin_SRCS       += $(addprefix src/search/,command.cc)
 bin_SRCS       += $(addprefix src/resolver/,command.cc)
+bin_SRCS       += $(addprefix src/parse/,command.cc)
 lib_SRCS       =  $(filter-out $(bin_SRCS),$(SRCS))
 test_SRCS      =  $(sort $(wildcard tests/*.cc))
 ALL_SRCS       = $(SRCS) $(test_SRCS)

--- a/Makefile
+++ b/Makefile
@@ -437,7 +437,7 @@ install: install-dirs install-bin install-lib install-include
 install-dirs: FORCE
 	$(MKDIR_P) $(BINDIR) $(LIBDIR) $(LIBDIR)/pkgconfig;
 	$(MKDIR_P) $(INCLUDEDIR)/flox $(INCLUDEDIR)/flox/core;
-	$(MKDIR_P) $(INCLUDEDIR)/flox/pkgdb $(INCLUDEDIR)/flox/search;
+	$(MKDIR_P) $(INCLUDEDIR)/flox/pkgdb $(INCLUDEDIR)/flox/search $(INCLUDEDIR)/flox/parse;
 	$(MKDIR_P) $(INCLUDEDIR)/flox/resolver $(INCLUDEDIR)/compat;
 
 $(INCLUDEDIR)/%: include/% | install-dirs

--- a/include/flox/core/types.hh
+++ b/include/flox/core/types.hh
@@ -126,13 +126,18 @@ struct Subtree
   }
 
   /** @brief Implicitly convert a @a flox::Subtree to a string. */
-  constexpr explicit operator std::string_view() const
+  constexpr explicit
+  operator std::string_view() const
   {
     return to_string( *this );
   }
 
   // NOLINTNEXTLINE
-  constexpr operator subtree_type() const { return this->subtree; }
+  constexpr
+  operator subtree_type() const
+  {
+    return this->subtree;
+  }
 
   /** @brief Compare two @a flox::Subtree for equality. */
   [[nodiscard]] constexpr bool

--- a/include/flox/core/util.hh
+++ b/include/flox/core/util.hh
@@ -403,6 +403,24 @@ merge_vectors( const std::vector<T> & lower, const std::vector<T> & higher )
 
 /* -------------------------------------------------------------------------- */
 
+/**
+ * @brief Constructs a @a std::vector<std::optional<T>> from a
+ * @a std::vector<T>.
+ */
+template<typename T>
+[[nodiscard]] std::vector<std::optional<T>>
+vectorMapOptional( const std::vector<T> & orig )
+{
+  std::vector<std::optional<T>> rsl;
+  for ( const T & val : orig )
+    {
+      rsl.emplace_back( std::make_optional<T>( val ) );
+    }
+  return rsl;
+}
+
+/* -------------------------------------------------------------------------- */
+
 }  // namespace flox
 
 

--- a/include/flox/core/util.hh
+++ b/include/flox/core/util.hh
@@ -22,6 +22,7 @@
 #include <nlohmann/json.hpp>
 
 #include "flox/core/exceptions.hh"
+#include "flox/core/types.hh"
 
 
 /* -------------------------------------------------------------------------- */
@@ -418,6 +419,14 @@ vectorMapOptional( const std::vector<T> & orig )
     }
   return rsl;
 }
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Convert a @a AttrPathGlob to a string for display.
+ */
+std::string
+displayableGlobbedPath( const AttrPathGlob & attrs );
 
 /* -------------------------------------------------------------------------- */
 

--- a/include/flox/parse/command.hh
+++ b/include/flox/parse/command.hh
@@ -30,7 +30,7 @@ private:
 
   resolver::ManifestDescriptor descriptor;
 
-  std::string format; /** Allowed values are "json" and "query" */
+  std::string format = "json"; /** Allowed values are "json" and "query" */
 
 public:
 

--- a/include/flox/parse/command.hh
+++ b/include/flox/parse/command.hh
@@ -1,0 +1,98 @@
+/* ========================================================================== *
+ *
+ * @file flox/parse/command.hh
+ *
+ * @brief Executable command helpers, argument parsers, etc.
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#pragma once
+
+#include "flox/pkgdb/command.hh"
+#include "flox/resolver/descriptor.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Interfaces used to parse various `pkgdb` constructs. */
+namespace flox::parse {
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Parse a descriptor into a set of @a flox::pkgdb::PkgQueryArgs. */
+class DescriptorCommand
+{
+
+private:
+
+  command::VerboseParser parser; /**< Query arguments and inputs parser */
+
+  resolver::ManifestDescriptor descriptor;
+
+
+public:
+
+  DescriptorCommand();
+
+  [[nodiscard]] command::VerboseParser &
+  getParser()
+  {
+    return this->parser;
+  }
+
+  /**
+   * @brief Execute the `descriptor` routine.
+   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+   */
+  int
+  run();
+
+
+}; /* End class `DescriptorCommand' */
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Parse various constructs. */
+class ParseCommand
+{
+
+private:
+
+  command::VerboseParser parser; /**< Query arguments and inputs parser */
+
+  DescriptorCommand cmdDescriptor;
+
+
+public:
+
+  ParseCommand();
+
+  [[nodiscard]] command::VerboseParser &
+  getParser()
+  {
+    return this->parser;
+  }
+
+  /**
+   * @brief Execute the `parse` routine.
+   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+   */
+  int
+  run();
+
+
+}; /* End class `ParseCommand' */
+
+
+/* -------------------------------------------------------------------------- */
+
+}  // namespace flox::parse
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/include/flox/parse/command.hh
+++ b/include/flox/parse/command.hh
@@ -30,7 +30,8 @@ private:
 
   resolver::ManifestDescriptor descriptor;
 
-  std::string format = "json"; /** Allowed values are "json" and "query" */
+  std::string format
+    = "manifest"; /** Allowed values are "manifest" and "query" */
 
 public:
 

--- a/include/flox/parse/command.hh
+++ b/include/flox/parse/command.hh
@@ -30,6 +30,7 @@ private:
 
   resolver::ManifestDescriptor descriptor;
 
+  std::string format; /** Allowed values are "json" and "query" */
 
 public:
 

--- a/include/flox/pkgdb/pkg-query.hh
+++ b/include/flox/pkgdb/pkg-query.hh
@@ -144,6 +144,15 @@ struct PkgQueryArgs
 
 }; /* End struct `PkgQueryArgs' */
 
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Convert an @a flox::pkgdb::PkgQueryArgs to a
+ *              JSON object.
+ */
+void
+to_json( nlohmann::json & jto, const PkgQueryArgs & descriptor );
+
 
 /* -------------------------------------------------------------------------- */
 

--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -44,6 +44,17 @@ struct ManifestDescriptorRaw
 
 public:
 
+  /** The delimiter for providing an input when the descriptor is a string */
+  static const auto inputSigil = ':';
+
+  /** The delimiter for specifying a version when the descriptor is a string */
+  static const auto versionSigil = '@';
+
+  /** The signifier that the version should be treated exactly
+   *  i.e. not a semver range
+   */
+  static const auto exactVersionSigil = '=';
+
   /**
    * Match `name`, `pname`, or `attrName`.
    * Maps to `flox::pkgdb::PkgQueryArgs::pnameOrAttrName`.
@@ -117,6 +128,9 @@ public:
   void
   clear();
 
+  ManifestDescriptorRaw() = default;
+
+  explicit ManifestDescriptorRaw( const std::string_view & descriptor );
 
 }; /* End struct `ManifestDescriptorRaw' */
 
@@ -155,6 +169,10 @@ FLOX_DEFINE_EXCEPTION( ParseManifestDescriptorRawException,
 
 /**
  * @brief A set of user defined requirements describing a package/dependency.
+ *
+ * May either be defined as a set of attributes or with a string matching
+ * this syntax:
+ * `[<input>:]((<attr>.)*<attrName>|<pname>)[@(<semver>|=<version>)]`
  */
 struct ManifestDescriptor
 {
@@ -199,6 +217,9 @@ public:
 
 
   ManifestDescriptor() = default;
+
+  explicit ManifestDescriptor( const std::string_view & descriptor )
+    : ManifestDescriptor( ManifestDescriptorRaw( descriptor ) ) {};
 
   explicit ManifestDescriptor( const ManifestDescriptorRaw & raw );
 

--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -168,6 +168,49 @@ FLOX_DEFINE_EXCEPTION( ParseManifestDescriptorRawException,
 /* -------------------------------------------------------------------------- */
 
 /**
+ * @brief Validates a single attribute name, `pname`, etc from a globbed
+ * @a flox::AttrPathGlob, returning the attribute name if it is suitable for
+ * appearing as a single attribute in a descriptor.
+ */
+std::optional<std::string>
+validatedSingleAttr( const AttrPathGlob & attrs );
+
+/**
+ * @brief Returns true if any component in the attribute path contains a glob
+ * but is not itself entirely a glob. For example, this would return `true` for
+ * `foo.b*ar.baz`, but not for `foo.*.baz` since `b*ar` contains a glob, but is
+ * not itself entirely a glob.
+ */
+bool
+globInAttrName( const AttrPathGlob & attrs );
+
+/**
+ * @brief Validates a relative attribute path from a globbed
+ * @a flox::AttrPathGlob, returning the string form of the relative path for
+ * use in the @a flox::resolver::ManifestDescriptorRaw.
+ */
+std::vector<std::string>
+validatedRelativePath( const AttrPathGlob &             attrs,
+                       const std::vector<std::string> & strings );
+
+/**
+ * @brief Validates an absolute path from a globbed
+ * @a flox::AttrPathGlob, returning the attribute path if it is suitable for
+ * an absolute path appearing in a descriptor.
+ */
+AttrPathGlob
+validatedAbsolutePath( const AttrPathGlob & attrs );
+
+/**
+ * @brief Returns `true` if the attribute path has enough path components and
+ * begins with one of the allowed prefixes (`legacyPackages` or `packages`).
+ */
+bool
+isAbsolutePath( const AttrPathGlob & attrs );
+
+/* -------------------------------------------------------------------------- */
+
+/**
  * @brief A set of user defined requirements describing a package/dependency.
  *
  * May either be defined as a set of attributes or with a string matching

--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -261,6 +261,15 @@ public:
 /* -------------------------------------------------------------------------- */
 
 /**
+ * @brief Convert an @a flox::resolver::ManifestDescriptor to a
+ *              JSON object.
+ */
+void
+to_json( nlohmann::json & jto, const ManifestDescriptor & descriptor );
+
+/* -------------------------------------------------------------------------- */
+
+/**
  * @class flox::resolver::InvalidManifestDescriptorException
  * @brief An exception thrown when a package descriptor in a manifest
  *        is invalid.

--- a/include/flox/resolver/descriptor.hh
+++ b/include/flox/resolver/descriptor.hh
@@ -172,7 +172,7 @@ FLOX_DEFINE_EXCEPTION( ParseManifestDescriptorRawException,
  *
  * May either be defined as a set of attributes or with a string matching
  * this syntax:
- * `[<input>:]((<attr>.)*<attrName>|<pname>)[@(<semver>|=<version>)]`
+ * `[<input>:]((<attr>.)+<attrName>)|(<pname>|<attrName>|<name>)[@(<semver>|=<version>)]`
  */
 struct ManifestDescriptor
 {

--- a/include/flox/search/command.hh
+++ b/include/flox/search/command.hh
@@ -74,7 +74,7 @@ public:
   run();
 
 
-}; /* End class `ScrapeCommand' */
+}; /* End class `SearchCommand' */
 
 
 /* -------------------------------------------------------------------------- */

--- a/src/main.cc
+++ b/src/main.cc
@@ -23,6 +23,7 @@
 #include "flox/core/command.hh"
 #include "flox/core/exceptions.hh"
 #include "flox/eval.hh"
+#include "flox/parse/command.hh"
 #include "flox/pkgdb/command.hh"
 #include "flox/repl.hh"
 #include "flox/resolver/command.hh"
@@ -54,6 +55,9 @@ run( int argc, char * argv[] )
   flox::resolver::ManifestCommand cmdManifest;
   prog.add_subparser( cmdManifest.getParser() );
 
+  flox::parse::ParseCommand cmdParse;
+  prog.add_subparser( cmdParse.getParser() );
+
   flox::ReplCommand cmdRepl;
   prog.add_subparser( cmdRepl.getParser() );
 
@@ -79,6 +83,7 @@ run( int argc, char * argv[] )
   if ( prog.is_subcommand_used( "list" ) ) { return cmdList.run(); }
   if ( prog.is_subcommand_used( "search" ) ) { return cmdSearch.run(); }
   if ( prog.is_subcommand_used( "manifest" ) ) { return cmdManifest.run(); }
+  if ( prog.is_subcommand_used( "parse" ) ) { return cmdParse.run(); }
   if ( prog.is_subcommand_used( "repl" ) ) { return cmdRepl.run(); }
   if ( prog.is_subcommand_used( "eval" ) ) { return cmdEval.run(); }
 

--- a/src/parse/command.cc
+++ b/src/parse/command.cc
@@ -25,10 +25,9 @@ DescriptorCommand::DescriptorCommand() : parser( "descriptor" )
     .action( [&]( const std::string & desc )
              { this->descriptor = resolver::ManifestDescriptor( desc ); } );
   this->parser.add_argument( "-t", "--to" )
-    .help( "output format of parsed descriptor" )
+    .help( "output format of parsed descriptor ['json' (default), 'query']" )
     .metavar( "FORMAT" )
     .nargs( 1 )
-    .default_value( std::string( "json" ) )
     .action( [&]( const std::string & format ) { this->format = format; } );
 }
 

--- a/src/parse/command.cc
+++ b/src/parse/command.cc
@@ -1,0 +1,80 @@
+/* ========================================================================== *
+ *
+ * @file parse/command.cc
+ *
+ * @brief Executable command helpers, argument parsers, etc.
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#include "flox/parse/command.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+namespace flox::parse {
+
+/* -------------------------------------------------------------------------- */
+
+DescriptorCommand::DescriptorCommand() :parser( "descriptor" )
+{
+  this->parser.add_description( "Parse a package descriptor" );
+  this->parser.add_argument( "descriptor" )
+    .help( "a package descriptor to parse" )
+    .metavar( "DESCRIPTOR" )
+    .action( [&]( const std::string & desc )
+             {
+               // TODO: ManifestDescriptor from string
+               this->descriptor = resolver::ManifestDescriptor(
+                 nlohmann::json( desc ).get<resolver::ManifestDescriptorRaw>()
+               );
+             } );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+int
+DescriptorCommand::run()
+{
+  pkgdb::PkgQueryArgs args;
+  this->descriptor.fillPkgQueryArgs( args );
+  std::cout << nlohmann::json( args ).dump( 2 ) << std::endl;
+  return EXIT_SUCCESS;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+ParseCommand::ParseCommand() : parser( "parse" )
+{
+  this->parser.add_description( "Parse various constructs" );
+  this->parser.add_subparser( this->cmdDescriptor.getParser() );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+int
+ParseCommand::run()
+{
+  if ( this->parser.is_subcommand_used( "descriptor" ) )
+    {
+      return this->cmdDescriptor.run();
+    }
+  std::cerr << this->parser << std::endl;
+  throw flox::FloxException( "You must provide a valid `parse' subcommand" );
+  return EXIT_FAILURE;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+}  // namespace flox::parse
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/src/parse/command.cc
+++ b/src/parse/command.cc
@@ -25,7 +25,8 @@ DescriptorCommand::DescriptorCommand() : parser( "descriptor" )
     .action( [&]( const std::string & desc )
              { this->descriptor = resolver::ManifestDescriptor( desc ); } );
   this->parser.add_argument( "-t", "--to" )
-    .help( "output format of parsed descriptor ['json' (default), 'query']" )
+    .help(
+      "output format of parsed descriptor ['manifest' (default), 'query']" )
     .metavar( "FORMAT" )
     .nargs( 1 )
     .action( [&]( const std::string & format ) { this->format = format; } );
@@ -38,7 +39,7 @@ int
 DescriptorCommand::run()
 {
   nlohmann::json output;
-  if ( this->format == "json" )
+  if ( this->format == "manifest" )
     {
       resolver::to_json( output, this->descriptor );
     }

--- a/src/pkgdb/pkg-query.cc
+++ b/src/pkgdb/pkg-query.cc
@@ -91,6 +91,28 @@ PkgQueryArgs::check() const
     }
 }
 
+/* -------------------------------------------------------------------------- */
+
+void
+to_json( nlohmann::json & jto, const PkgQueryArgs & args )
+{
+  jto = {
+    { "name", args.name },
+    { "pname", args.pname },
+    { "version", args.version },
+    { "semver", args.semver },
+    { "partialMatch", args.partialMatch },
+    { "partialNameMatch", args.partialNameMatch },
+    { "pnameOrAttrName", args.pnameOrAttrName },
+    { "licenses", args.licenses },
+    { "allowBroken", args.allowBroken },
+    { "allowUnfree", args.allowUnfree },
+    { "preferPreReleases", args.preferPreReleases },
+    { "subtrees", args.subtrees },
+    { "systems", args.systems },
+    { "relPath", args.relPath },
+  };
+}
 
 /* -------------------------------------------------------------------------- */
 

--- a/src/resolver/descriptor.cc
+++ b/src/resolver/descriptor.cc
@@ -476,7 +476,7 @@ ManifestDescriptorRaw::ManifestDescriptorRaw(
   size_t attrsEndIdx;
   bool   hasVersion = false;
   if ( auto versionSepIdx
-       = descriptor.find_first_of( ManifestDescriptorRaw::versionSigil );
+       = descriptor.find( ManifestDescriptorRaw::versionSigil );
        versionSepIdx != std::string_view::npos )
     {
       attrsEndIdx = versionSepIdx;
@@ -513,7 +513,7 @@ ManifestDescriptorRaw::ManifestDescriptorRaw(
         break;
       default:
         // Could be a relative or absolute path depending on the prefix
-        if ( attrs[0] == "legacyPackages" )
+        if ( ( attrs[0] == "legacyPackages" ) || ( attrs[0] == "packages" ) )
           {
             this->absPath = vectorMapOptional( attrs );
           }
@@ -521,6 +521,7 @@ ManifestDescriptorRaw::ManifestDescriptorRaw(
         else
           {
             // Someone gave us a path that's malformed e.g. it has zero length
+            // Note that this _should_ be unreachable
             throw InvalidManifestDescriptorException(
               "invalid attribute path: `" + std::string( attrsSubstr ) + "'" );
           }

--- a/src/resolver/descriptor.cc
+++ b/src/resolver/descriptor.cc
@@ -503,6 +503,10 @@ ManifestDescriptorRaw::ManifestDescriptorRaw(
         // We were given an absolute path
         this->absPath = maybeAttrs;
         break;
+      case 3:
+        // We were given an abosolute path inside nixpkgs
+        this->absPath = maybeAttrs;
+        break;
       default:
         // Someone gave us an absolute path for an input type we don't
         // yet support i.e. there are too many path components.

--- a/src/resolver/descriptor.cc
+++ b/src/resolver/descriptor.cc
@@ -637,8 +637,19 @@ ManifestDescriptor::fillPkgQueryArgs( pkgdb::PkgQueryArgs & pqa ) const
 }
 
 
-/* --------------------------------------------------------------------------
- */
+/* -------------------------------------------------------------------------- */
+
+void
+to_json( nlohmann::json & jto, const ManifestDescriptor & descriptor )
+{
+  jto = {
+    { "name", descriptor.name },       { "optional", descriptor.optional },
+    { "group", descriptor.group },     { "version", descriptor.version },
+    { "semver", descriptor.semver },   { "subtree", descriptor.subtree },
+    { "systems", descriptor.systems }, { "path", descriptor.path },
+    { "input", descriptor.input },     { "priority", descriptor.priority }
+  };
+}
 
 }  // namespace flox::resolver
 

--- a/src/resolver/descriptor.cc
+++ b/src/resolver/descriptor.cc
@@ -462,18 +462,17 @@ to_json( nlohmann::json & jto, const ManifestDescriptorRaw & descriptor )
 ManifestDescriptorRaw::ManifestDescriptorRaw(
   const std::string_view & descriptor )
 {
-  ManifestDescriptorRaw parsed;
-  size_t                cursor = 0;
+  size_t cursor = 0;
   // Grab the input if it exists
   if ( auto inputSepIdx
        = descriptor.find_first_of( ManifestDescriptorRaw::inputSigil );
        inputSepIdx != std::string_view::npos )
     {
-      parsed.packageRepository
-        = std::string( descriptor.substr( cursor, inputSepIdx ) );
+      this->packageRepository
+        = std::string( descriptor.substr( cursor, inputSepIdx - cursor ) );
       cursor = inputSepIdx + 1;
     }
-  // Grab the
+  // Grab the attribute path or package name
   size_t attrsEndIdx;
   bool   hasVersion = false;
   if ( auto versionSepIdx
@@ -484,7 +483,8 @@ ManifestDescriptorRaw::ManifestDescriptorRaw(
       hasVersion  = true;
     }
   else { attrsEndIdx = descriptor.size(); }
-  auto maybeAttrs = std::string( descriptor.substr( cursor, attrsEndIdx ) );
+  auto maybeAttrs
+    = std::string( descriptor.substr( cursor, attrsEndIdx - cursor ) );
   auto numAttrSeparators
     = std::count_if( maybeAttrs.begin(),
                      maybeAttrs.end(),
@@ -493,15 +493,15 @@ ManifestDescriptorRaw::ManifestDescriptorRaw(
     {
       case 0:
         // We were given a `pname`
-        parsed.name = maybeAttrs;
+        this->name = maybeAttrs;
         break;
       case 1:
         // We were given a relative path
-        parsed.path = maybeAttrs;
+        this->path = maybeAttrs;
         break;
       case 2:
         // We were given an absolute path
-        parsed.absPath = maybeAttrs;
+        this->absPath = maybeAttrs;
         break;
       default:
         // Someone gave us an absolute path for an input type we don't
@@ -512,8 +512,8 @@ ManifestDescriptorRaw::ManifestDescriptorRaw(
     }
   if ( hasVersion )
     {
-      cursor         = attrsEndIdx + 1;
-      parsed.version = std::string( descriptor.substr( cursor ) );
+      cursor        = attrsEndIdx + 1;
+      this->version = std::string( descriptor.substr( cursor ) );
     }
 }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -21,6 +21,7 @@
 #include <nlohmann/json.hpp>
 
 #include "flox/core/exceptions.hh"
+#include "flox/core/types.hh"
 #include "flox/core/util.hh"
 
 
@@ -302,6 +303,26 @@ extract_json_errmsg( nlohmann::json::exception & err )
   return userFriendly;
 }
 
+/* -------------------------------------------------------------------------- */
+
+std::string
+displayableGlobbedPath( const flox::AttrPathGlob & attrs )
+{
+  std::vector<std::string> globbed;
+  for ( const std::optional<std::string> & attr : attrs )
+    {
+      if ( attr.has_value() ) { globbed.emplace_back( *attr ); }
+      else { globbed.emplace_back( "*" ); }
+    }
+  auto fold
+    = []( std::string a, std::string b ) { return std::move( a ) + '.' + b; };
+
+  std::string s = std::accumulate( std::next( globbed.begin() ),
+                                   globbed.end(),
+                                   globbed[0],
+                                   fold );
+  return s;
+}
 
 /* -------------------------------------------------------------------------- */
 

--- a/tests/descriptor.bats
+++ b/tests/descriptor.bats
@@ -23,7 +23,7 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "parse descriptor 'hello'" {
-  run "$PKGDB" parse descriptor --to json "hello";
+  run "$PKGDB" parse descriptor --to manifest "hello";
   assert_success;
   assert_equal $(echo "$output" | jq -r '.name') "hello";
   unset output;
@@ -34,7 +34,7 @@ setup_file() {
 
 @test "parse descriptor 'hello@1.2.3'" {
   query="hello@1.2.3";
-  run "$PKGDB" parse descriptor --to json "$query";
+  run "$PKGDB" parse descriptor --to manifest "$query";
   assert_success;
   assert_equal $(echo "$output" | jq -r '.name') "hello";
   assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
@@ -47,7 +47,7 @@ setup_file() {
 
 @test "parse descriptor 'hello@1.2'" {
   query="hello@1.2";
-  run "$PKGDB" parse descriptor --to json "$query";
+  run "$PKGDB" parse descriptor --to manifest "$query";
   assert_success;
   assert_equal $(echo "$output" | jq -r '.name') "hello";
   assert_equal $(echo "$output" | jq -r '.semver') "1.2";
@@ -60,7 +60,7 @@ setup_file() {
 
 @test "parse descriptor 'packageset.hello@1.2'" {
   query="packageset.hello@1.2";
-  run "$PKGDB" parse descriptor --to json "$query";
+  run "$PKGDB" parse descriptor --to manifest "$query";
   assert_success;
   assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]';
   assert_equal $(echo "$output" | jq -r '.semver') "1.2";
@@ -73,7 +73,7 @@ setup_file() {
 
 @test "parse descriptor 'legacyPackages.aarch64-darwin.hello@1.2'" {
   query="legacyPackages.aarch64-darwin.hello@1.2";
-  run "$PKGDB" parse descriptor --to json "$query";
+  run "$PKGDB" parse descriptor --to manifest "$query";
   assert_success;
   assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]';
   assert_equal $(echo "$output" | jq -r '.subtree') "legacyPackages";
@@ -88,7 +88,7 @@ setup_file() {
 
 @test "parse descriptor 'legacyPackages.*.hello@1.2'" {
   query="legacyPackages.*.hello@1.2";
-  run "$PKGDB" parse descriptor --to json "$query";
+  run "$PKGDB" parse descriptor --to manifest "$query";
   assert_success;
   assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]';
   assert_equal $(echo "$output" | jq -r '.subtree') "legacyPackages";
@@ -102,7 +102,7 @@ setup_file() {
 }
 
 @test "parse descriptor 'nixpkgs:hello'" {
-  run "$PKGDB" parse descriptor --to json "nixpkgs:hello";
+  run "$PKGDB" parse descriptor --to manifest "nixpkgs:hello";
   assert_success;
   assert_equal $(echo "$output" | jq -r '.name') "hello";
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
@@ -113,7 +113,7 @@ setup_file() {
 }
 
 @test "parse descriptor 'nixpkgs:hello@1.2.3'" {
-  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@1.2.3";
+  run "$PKGDB" parse descriptor --to manifest "nixpkgs:hello@1.2.3";
   assert_success;
   assert_equal $(echo "$output" | jq -r '.name') "hello";
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
@@ -126,7 +126,7 @@ setup_file() {
 }
 
 @test "parse descriptor 'nixpkgs:hello@=1.2.3'" {
-  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@=1.2.3";
+  run "$PKGDB" parse descriptor --to manifest "nixpkgs:hello@=1.2.3";
   assert_success;
   assert_equal $(echo "$output" | jq -r '.name') "hello";
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
@@ -139,7 +139,7 @@ setup_file() {
 }
 
 @test "parse descriptor 'nixpkgs:hello@=1.2'" {
-  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@=1.2";
+  run "$PKGDB" parse descriptor --to manifest "nixpkgs:hello@=1.2";
   assert_success;
   assert_equal $(echo "$output" | jq -r '.name') "hello";
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
@@ -152,7 +152,7 @@ setup_file() {
 }
 
 @test "parse descriptor 'nixpkgs:hello@1.2'" {
-  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@1.2";
+  run "$PKGDB" parse descriptor --to manifest "nixpkgs:hello@1.2";
   assert_success;
   assert_equal $(echo "$output" | jq -r '.name') "hello";
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
@@ -165,7 +165,7 @@ setup_file() {
 }
 
 @test "parse descriptor 'nixpkgs:hello@^1.2.3'" {
-  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@^1.2.3";
+  run "$PKGDB" parse descriptor --to manifest "nixpkgs:hello@^1.2.3";
   assert_success;
   assert_equal $(echo "$output" | jq -r '.name') "hello";
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
@@ -178,7 +178,7 @@ setup_file() {
 }
 
 @test "parse descriptor 'nixpkgs:hello@>1.2.3'" {
-  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@>1.2.3";
+  run "$PKGDB" parse descriptor --to manifest "nixpkgs:hello@>1.2.3";
   assert_success;
   assert_equal $(echo "$output" | jq -r '.name') "hello";
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
@@ -191,7 +191,7 @@ setup_file() {
 }
 
 @test "parse descriptor 'nixpkgs:packageset.hello@1.2.3'" {
-  run "$PKGDB" parse descriptor --to json "nixpkgs:packageset.hello@1.2.3";
+  run "$PKGDB" parse descriptor --to manifest "nixpkgs:packageset.hello@1.2.3";
   assert_success;
   assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]';
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
@@ -204,7 +204,7 @@ setup_file() {
 }
 
 @test "parse descriptor 'nixpkgs:packageset.hello@=1.2.3'" {
-  run "$PKGDB" parse descriptor --to json "nixpkgs:packageset.hello@=1.2.3";
+  run "$PKGDB" parse descriptor --to manifest "nixpkgs:packageset.hello@=1.2.3";
   assert_success;
   assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]';
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
@@ -218,7 +218,7 @@ setup_file() {
 
 @test "parse descriptor 'nixpkgs:legacyPackages.*.hello@1.2.3'" {
   query="nixpkgs:legacyPackages.*.hello@1.2.3"
-  run "$PKGDB" parse descriptor --to json "$query";
+  run "$PKGDB" parse descriptor --to manifest "$query";
   assert_success;
   assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]';
   assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages";
@@ -234,7 +234,7 @@ setup_file() {
 
 @test "parse descriptor 'nixpkgs:legacyPackages.aarch64-darwin.hello@1.2'" {
   query="nixpkgs:legacyPackages.aarch64-darwin.hello@1.2"
-  run "$PKGDB" parse descriptor --to json "$query";
+  run "$PKGDB" parse descriptor --to manifest "$query";
   assert_success;
   assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]';
   assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages";
@@ -250,7 +250,7 @@ setup_file() {
 
 @test "parse descriptor 'nixpkgs:legacyPackages.*.hello@1.2'" {
   query="nixpkgs:legacyPackages.*.hello@1.2"
-  run "$PKGDB" parse descriptor --to json "$query";
+  run "$PKGDB" parse descriptor --to manifest "$query";
   assert_success;
   assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]';
   assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages";
@@ -266,7 +266,7 @@ setup_file() {
 
 @test "parse descriptor 'nixpkgs:legacyPackages.*.packageset.hello@1.2'" {
   query="nixpkgs:legacyPackages.*.packageset.hello@1.2"
-  run "$PKGDB" parse descriptor --to json "$query";
+  run "$PKGDB" parse descriptor --to manifest "$query";
   assert_success;
   assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]';
   assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages";

--- a/tests/descriptor.bats
+++ b/tests/descriptor.bats
@@ -346,3 +346,47 @@ setup_file() {
   assert_failure;
   assert_output --partial "descriptor attribute name was malformed";
 }
+
+@test "parse descriptor 'nixpkgs:*.foo'" {
+  query="nixpkgs:*.foo";
+  run "$PKGDB" parse descriptor --to manifest "$query";
+  assert_failure;
+  assert_output --partial "globs are only allowed to replace entire system names";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_failure;
+  assert_output --partial "globs are only allowed to replace entire system names";
+}
+
+@test "parse descriptor 'nixpkgs:*.foo.bar'" {
+  query="nixpkgs:*.foo.bar";
+  run "$PKGDB" parse descriptor --to manifest "$query";
+  assert_failure;
+  assert_output --partial "globs are only allowed to replace entire system names";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_failure;
+  assert_output --partial "globs are only allowed to replace entire system names";
+}
+
+@test "parse descriptor 'nixpkgs:packages.foo.*'" {
+  query="nixpkgs:packages.foo.*";
+  run "$PKGDB" parse descriptor --to manifest "$query";
+  assert_failure;
+  assert_output --partial "globs are only allowed to replace entire system names";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_failure;
+  assert_output --partial "globs are only allowed to replace entire system names";
+}
+
+@test "parse descriptor 'nixpkgs:packages.foo.b*ar'" {
+  query='nixpkgs:packages.foo.b*ar';
+  run "$PKGDB" parse descriptor --to manifest "$query";
+  assert_failure;
+  assert_output --partial "globs are only allowed to replace entire system names";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_failure;
+  assert_output --partial "globs are only allowed to replace entire system names";
+}

--- a/tests/descriptor.bats
+++ b/tests/descriptor.bats
@@ -264,6 +264,22 @@ setup_file() {
   assert_equal $(echo "$output" | jq -r '.semver') "1.2";
 }
 
+@test "parse descriptor 'myflake:packages.*.hello@1.2'" {
+  query="myflake:packages.*.hello@1.2"
+  run "$PKGDB" parse descriptor --to manifest "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtree') "packages";
+  assert_equal $(echo "$output" | jq -r '.input.id') "myflake";
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.relPath') '["hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtrees') '["packages"]';
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+}
+
 @test "parse descriptor 'nixpkgs:legacyPackages.*.packageset.hello@1.2'" {
   query="nixpkgs:legacyPackages.*.packageset.hello@1.2"
   run "$PKGDB" parse descriptor --to manifest "$query";

--- a/tests/descriptor.bats
+++ b/tests/descriptor.bats
@@ -1,0 +1,281 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# `pkgdb parse descriptor' tests.
+#
+# ---------------------------------------------------------------------------- #
+
+load setup_suite.bash;
+
+# bats file_tags=parse:descriptor
+
+setup_file() {
+  export TDATA="$TESTS_DIR/data/search";
+
+  # Path to `search-params' utility.
+  export SEARCH_PARAMS="$TESTS_DIR/search-params";
+
+  export PKGDB_CACHEDIR="$BATS_FILE_TMPDIR/pkgdbs";
+  echo "PKGDB_CACHEDIR: $PKGDB_CACHEDIR" >&3;
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "parse descriptor 'hello'" {
+  run "$PKGDB" parse descriptor --to json "hello";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.name') "hello";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "hello";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.pnameOrAttrName') "hello";
+}
+
+@test "parse descriptor 'hello@1.2.3'" {
+  query="hello@1.2.3";
+  run "$PKGDB" parse descriptor --to json "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.name') "hello";
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.pnameOrAttrName') "hello";
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+}
+
+@test "parse descriptor 'hello@1.2'" {
+  query="hello@1.2";
+  run "$PKGDB" parse descriptor --to json "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.name') "hello";
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.pnameOrAttrName') "hello";
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+}
+
+@test "parse descriptor 'packageset.hello@1.2'" {
+  query="packageset.hello@1.2";
+  run "$PKGDB" parse descriptor --to json "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]';
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.relPath') '["packageset","hello"]';
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+}
+
+@test "parse descriptor 'legacyPackages.aarch64-darwin.hello@1.2'" {
+  query="legacyPackages.aarch64-darwin.hello@1.2";
+  run "$PKGDB" parse descriptor --to json "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]';
+  assert_equal $(echo "$output" | jq -r '.subtree') "legacyPackages";
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.relPath') '["hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtrees') '["legacyPackages"]';
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+}
+
+@test "parse descriptor 'legacyPackages.*.hello@1.2'" {
+  query="legacyPackages.*.hello@1.2";
+  run "$PKGDB" parse descriptor --to json "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]';
+  assert_equal $(echo "$output" | jq -r '.subtree') "legacyPackages";
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.relPath') '["hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtrees') '["legacyPackages"]';
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+}
+
+@test "parse descriptor 'nixpkgs:hello'" {
+  run "$PKGDB" parse descriptor --to json "nixpkgs:hello";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.name') "hello";
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "nixpkgs:hello";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.pnameOrAttrName') "hello";
+}
+
+@test "parse descriptor 'nixpkgs:hello@1.2.3'" {
+  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.name') "hello";
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "nixpkgs:hello@1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.pnameOrAttrName') "hello";
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+}
+
+@test "parse descriptor 'nixpkgs:hello@=1.2.3'" {
+  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@=1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.name') "hello";
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "nixpkgs:hello@=1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.pnameOrAttrName') "hello";
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+}
+
+@test "parse descriptor 'nixpkgs:hello@=1.2'" {
+  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@=1.2";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.name') "hello";
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.version') "1.2";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "nixpkgs:hello@=1.2";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.pnameOrAttrName') "hello";
+  assert_equal $(echo "$output" | jq -r '.version') "1.2";
+}
+
+@test "parse descriptor 'nixpkgs:hello@1.2'" {
+  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@1.2";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.name') "hello";
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "nixpkgs:hello@1.2";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.pnameOrAttrName') "hello";
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+}
+
+@test "parse descriptor 'nixpkgs:hello@^1.2.3'" {
+  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@^1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.name') "hello";
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.semver') "^1.2.3";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "nixpkgs:hello@^1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.pnameOrAttrName') "hello";
+  assert_equal $(echo "$output" | jq -r '.semver') "^1.2.3";
+}
+
+@test "parse descriptor 'nixpkgs:hello@>1.2.3'" {
+  run "$PKGDB" parse descriptor --to json "nixpkgs:hello@>1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.name') "hello";
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.semver') ">1.2.3";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "nixpkgs:hello@>1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r '.pnameOrAttrName') "hello";
+  assert_equal $(echo "$output" | jq -r '.semver') ">1.2.3";
+}
+
+@test "parse descriptor 'nixpkgs:packageset.hello@1.2.3'" {
+  run "$PKGDB" parse descriptor --to json "nixpkgs:packageset.hello@1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]';
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "nixpkgs:packageset.hello@1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.relPath') '["packageset","hello"]';
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+}
+
+@test "parse descriptor 'nixpkgs:packageset.hello@=1.2.3'" {
+  run "$PKGDB" parse descriptor --to json "nixpkgs:packageset.hello@=1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]';
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "nixpkgs:packageset.hello@=1.2.3";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.relPath') '["packageset","hello"]';
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+}
+
+@test "parse descriptor 'nixpkgs:legacyPackages.*.hello@1.2.3'" {
+  query="nixpkgs:legacyPackages.*.hello@1.2.3"
+  run "$PKGDB" parse descriptor --to json "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages";
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.relPath') '["hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtrees') '["legacyPackages"]';
+  assert_equal $(echo "$output" | jq -r '.version') "1.2.3";
+}
+
+@test "parse descriptor 'nixpkgs:legacyPackages.aarch64-darwin.hello@1.2'" {
+  query="nixpkgs:legacyPackages.aarch64-darwin.hello@1.2"
+  run "$PKGDB" parse descriptor --to json "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages";
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.relPath') '["hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtrees') '["legacyPackages"]';
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+}
+
+@test "parse descriptor 'nixpkgs:legacyPackages.*.hello@1.2'" {
+  query="nixpkgs:legacyPackages.*.hello@1.2"
+  run "$PKGDB" parse descriptor --to json "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages";
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.relPath') '["hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtrees') '["legacyPackages"]';
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+}
+
+@test "parse descriptor 'nixpkgs:legacyPackages.*.packageset.hello@1.2'" {
+  query="nixpkgs:legacyPackages.*.packageset.hello@1.2"
+  run "$PKGDB" parse descriptor --to json "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages";
+  assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs";
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+  unset output;
+  run "$PKGDB" parse descriptor --to query "$query";
+  assert_success;
+  assert_equal $(echo "$output" | jq -r -c '.relPath') '["packageset","hello"]';
+  assert_equal $(echo "$output" | jq -r -c '.subtrees') '["legacyPackages"]';
+  assert_equal $(echo "$output" | jq -r '.semver') "1.2";
+}


### PR DESCRIPTION
This adds a `pkgdb parse descriptor` subcommand that parses descriptors provided as strings in the format:
```
[<input>:]((<attr>.)*<attrName>|<pname>)[@(<semver>|=<version>)]
```

The output format is always JSON, but there is an optional `--to` flag which determines which representation of the descriptor is dumped as JSON. Available options are `manifest` (the default) and `query`.

The `manifest` option dumps the JSON representation of the descriptor as if it had been specified in the manifest. The `query` option dumps the JSON representation of the descriptor after it has been transformed into a query. This second option is useful for verifying that a descriptor has been converted to the intended query (e.g. that the version requirement has populated `semver` or `version` as intended).